### PR TITLE
タブ表示位置を下だけではなく上にも変更可能に

### DIFF
--- a/OpenTween/AppendSettingDialog.Designer.cs
+++ b/OpenTween/AppendSettingDialog.Designer.cs
@@ -118,6 +118,7 @@
             this.Label11 = new System.Windows.Forms.Label();
             this.IconSize = new System.Windows.Forms.ComboBox();
             this.TextBox3 = new System.Windows.Forms.TextBox();
+            this.CheckViewTabBottom = new System.Windows.Forms.CheckBox();
             this.CheckSortOrderLock = new System.Windows.Forms.CheckBox();
             this.CheckShowGrid = new System.Windows.Forms.CheckBox();
             this.chkUnreadStyle = new System.Windows.Forms.CheckBox();
@@ -323,10 +324,13 @@
             // 
             // SplitContainer1.Panel1
             // 
+            resources.ApplyResources(this.SplitContainer1.Panel1, "SplitContainer1.Panel1");
             this.SplitContainer1.Panel1.Controls.Add(this.TreeViewSetting);
+            this.ToolTip1.SetToolTip(this.SplitContainer1.Panel1, resources.GetString("SplitContainer1.Panel1.ToolTip"));
             // 
             // SplitContainer1.Panel2
             // 
+            resources.ApplyResources(this.SplitContainer1.Panel2, "SplitContainer1.Panel2");
             this.SplitContainer1.Panel2.BackColor = System.Drawing.SystemColors.Control;
             this.SplitContainer1.Panel2.Controls.Add(this.StartupPanel);
             this.SplitContainer1.Panel2.Controls.Add(this.PreviewPanel);
@@ -343,12 +347,14 @@
             this.SplitContainer1.Panel2.Controls.Add(this.ActionPanel);
             this.SplitContainer1.Panel2.Controls.Add(this.FontPanel);
             this.SplitContainer1.Panel2.Controls.Add(this.FontPanel2);
+            this.ToolTip1.SetToolTip(this.SplitContainer1.Panel2, resources.GetString("SplitContainer1.Panel2.ToolTip"));
             this.SplitContainer1.TabStop = false;
+            this.ToolTip1.SetToolTip(this.SplitContainer1, resources.GetString("SplitContainer1.ToolTip"));
             // 
             // TreeViewSetting
             // 
-            this.TreeViewSetting.Cursor = System.Windows.Forms.Cursors.Hand;
             resources.ApplyResources(this.TreeViewSetting, "TreeViewSetting");
+            this.TreeViewSetting.Cursor = System.Windows.Forms.Cursors.Hand;
             this.TreeViewSetting.HideSelection = false;
             this.TreeViewSetting.Name = "TreeViewSetting";
             this.TreeViewSetting.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
@@ -358,44 +364,51 @@
             ((System.Windows.Forms.TreeNode)(resources.GetObject("TreeViewSetting.Nodes3"))),
             ((System.Windows.Forms.TreeNode)(resources.GetObject("TreeViewSetting.Nodes4")))});
             this.TreeViewSetting.ShowLines = false;
+            this.ToolTip1.SetToolTip(this.TreeViewSetting, resources.GetString("TreeViewSetting.ToolTip"));
             this.TreeViewSetting.BeforeSelect += new System.Windows.Forms.TreeViewCancelEventHandler(this.TreeViewSetting_BeforeSelect);
             this.TreeViewSetting.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.TreeViewSetting_AfterSelect);
             // 
             // StartupPanel
             // 
+            resources.ApplyResources(this.StartupPanel, "StartupPanel");
             this.StartupPanel.Controls.Add(this.StartupReaded);
             this.StartupPanel.Controls.Add(this.CheckStartupFollowers);
             this.StartupPanel.Controls.Add(this.CheckStartupVersion);
             this.StartupPanel.Controls.Add(this.chkGetFav);
-            resources.ApplyResources(this.StartupPanel, "StartupPanel");
             this.StartupPanel.Name = "StartupPanel";
+            this.ToolTip1.SetToolTip(this.StartupPanel, resources.GetString("StartupPanel.ToolTip"));
             // 
             // StartupReaded
             // 
             resources.ApplyResources(this.StartupReaded, "StartupReaded");
             this.StartupReaded.Name = "StartupReaded";
+            this.ToolTip1.SetToolTip(this.StartupReaded, resources.GetString("StartupReaded.ToolTip"));
             this.StartupReaded.UseVisualStyleBackColor = true;
             // 
             // CheckStartupFollowers
             // 
             resources.ApplyResources(this.CheckStartupFollowers, "CheckStartupFollowers");
             this.CheckStartupFollowers.Name = "CheckStartupFollowers";
+            this.ToolTip1.SetToolTip(this.CheckStartupFollowers, resources.GetString("CheckStartupFollowers.ToolTip"));
             this.CheckStartupFollowers.UseVisualStyleBackColor = true;
             // 
             // CheckStartupVersion
             // 
             resources.ApplyResources(this.CheckStartupVersion, "CheckStartupVersion");
             this.CheckStartupVersion.Name = "CheckStartupVersion";
+            this.ToolTip1.SetToolTip(this.CheckStartupVersion, resources.GetString("CheckStartupVersion.ToolTip"));
             this.CheckStartupVersion.UseVisualStyleBackColor = true;
             // 
             // chkGetFav
             // 
             resources.ApplyResources(this.chkGetFav, "chkGetFav");
             this.chkGetFav.Name = "chkGetFav";
+            this.ToolTip1.SetToolTip(this.chkGetFav, resources.GetString("chkGetFav.ToolTip"));
             this.chkGetFav.UseVisualStyleBackColor = true;
             // 
             // PreviewPanel
             // 
+            resources.ApplyResources(this.PreviewPanel, "PreviewPanel");
             this.PreviewPanel.Controls.Add(this.Label2);
             this.PreviewPanel.Controls.Add(this.IsNotifyUseGrowlCheckBox);
             this.PreviewPanel.Controls.Add(this.ReplyIconStateCombo);
@@ -415,8 +428,8 @@
             this.PreviewPanel.Controls.Add(this.cmbNameBalloon);
             this.PreviewPanel.Controls.Add(this.CheckDispUsername);
             this.PreviewPanel.Controls.Add(this.CheckBox3);
-            resources.ApplyResources(this.PreviewPanel, "PreviewPanel");
             this.PreviewPanel.Name = "PreviewPanel";
+            this.ToolTip1.SetToolTip(this.PreviewPanel, resources.GetString("PreviewPanel.ToolTip"));
             // 
             // Label2
             // 
@@ -428,40 +441,46 @@
             // 
             resources.ApplyResources(this.IsNotifyUseGrowlCheckBox, "IsNotifyUseGrowlCheckBox");
             this.IsNotifyUseGrowlCheckBox.Name = "IsNotifyUseGrowlCheckBox";
+            this.ToolTip1.SetToolTip(this.IsNotifyUseGrowlCheckBox, resources.GetString("IsNotifyUseGrowlCheckBox.ToolTip"));
             this.IsNotifyUseGrowlCheckBox.UseVisualStyleBackColor = true;
             // 
             // ReplyIconStateCombo
             // 
+            resources.ApplyResources(this.ReplyIconStateCombo, "ReplyIconStateCombo");
             this.ReplyIconStateCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ReplyIconStateCombo.FormattingEnabled = true;
             this.ReplyIconStateCombo.Items.AddRange(new object[] {
             resources.GetString("ReplyIconStateCombo.Items"),
             resources.GetString("ReplyIconStateCombo.Items1"),
             resources.GetString("ReplyIconStateCombo.Items2")});
-            resources.ApplyResources(this.ReplyIconStateCombo, "ReplyIconStateCombo");
             this.ReplyIconStateCombo.Name = "ReplyIconStateCombo";
+            this.ToolTip1.SetToolTip(this.ReplyIconStateCombo, resources.GetString("ReplyIconStateCombo.ToolTip"));
             // 
             // Label72
             // 
             resources.ApplyResources(this.Label72, "Label72");
             this.Label72.Name = "Label72";
+            this.ToolTip1.SetToolTip(this.Label72, resources.GetString("Label72.ToolTip"));
             // 
             // ChkNewMentionsBlink
             // 
             resources.ApplyResources(this.ChkNewMentionsBlink, "ChkNewMentionsBlink");
             this.ChkNewMentionsBlink.Name = "ChkNewMentionsBlink";
+            this.ToolTip1.SetToolTip(this.ChkNewMentionsBlink, resources.GetString("ChkNewMentionsBlink.ToolTip"));
             this.ChkNewMentionsBlink.UseVisualStyleBackColor = true;
             // 
             // chkTabIconDisp
             // 
             resources.ApplyResources(this.chkTabIconDisp, "chkTabIconDisp");
             this.chkTabIconDisp.Name = "chkTabIconDisp";
+            this.ToolTip1.SetToolTip(this.chkTabIconDisp, resources.GetString("chkTabIconDisp.ToolTip"));
             this.chkTabIconDisp.UseVisualStyleBackColor = true;
             // 
             // CheckPreviewEnable
             // 
             resources.ApplyResources(this.CheckPreviewEnable, "CheckPreviewEnable");
             this.CheckPreviewEnable.Name = "CheckPreviewEnable";
+            this.ToolTip1.SetToolTip(this.CheckPreviewEnable, resources.GetString("CheckPreviewEnable.ToolTip"));
             this.CheckPreviewEnable.UseVisualStyleBackColor = true;
             // 
             // Label81
@@ -470,9 +489,11 @@
             this.Label81.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Label81.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.Label81.Name = "Label81";
+            this.ToolTip1.SetToolTip(this.Label81, resources.GetString("Label81.ToolTip"));
             // 
             // LanguageCombo
             // 
+            resources.ApplyResources(this.LanguageCombo, "LanguageCombo");
             this.LanguageCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.LanguageCombo.FormattingEnabled = true;
             this.LanguageCombo.Items.AddRange(new object[] {
@@ -480,39 +501,45 @@
             resources.GetString("LanguageCombo.Items1"),
             resources.GetString("LanguageCombo.Items2"),
             resources.GetString("LanguageCombo.Items3")});
-            resources.ApplyResources(this.LanguageCombo, "LanguageCombo");
             this.LanguageCombo.Name = "LanguageCombo";
+            this.ToolTip1.SetToolTip(this.LanguageCombo, resources.GetString("LanguageCombo.ToolTip"));
             // 
             // Label13
             // 
             resources.ApplyResources(this.Label13, "Label13");
             this.Label13.Name = "Label13";
+            this.ToolTip1.SetToolTip(this.Label13, resources.GetString("Label13.ToolTip"));
             // 
             // CheckAlwaysTop
             // 
             resources.ApplyResources(this.CheckAlwaysTop, "CheckAlwaysTop");
             this.CheckAlwaysTop.Name = "CheckAlwaysTop";
+            this.ToolTip1.SetToolTip(this.CheckAlwaysTop, resources.GetString("CheckAlwaysTop.ToolTip"));
             this.CheckAlwaysTop.UseVisualStyleBackColor = true;
             // 
             // CheckMonospace
             // 
             resources.ApplyResources(this.CheckMonospace, "CheckMonospace");
             this.CheckMonospace.Name = "CheckMonospace";
+            this.ToolTip1.SetToolTip(this.CheckMonospace, resources.GetString("CheckMonospace.ToolTip"));
             this.CheckMonospace.UseVisualStyleBackColor = true;
             // 
             // CheckBalloonLimit
             // 
             resources.ApplyResources(this.CheckBalloonLimit, "CheckBalloonLimit");
             this.CheckBalloonLimit.Name = "CheckBalloonLimit";
+            this.ToolTip1.SetToolTip(this.CheckBalloonLimit, resources.GetString("CheckBalloonLimit.ToolTip"));
             this.CheckBalloonLimit.UseVisualStyleBackColor = true;
             // 
             // Label10
             // 
             resources.ApplyResources(this.Label10, "Label10");
             this.Label10.Name = "Label10";
+            this.ToolTip1.SetToolTip(this.Label10, resources.GetString("Label10.ToolTip"));
             // 
             // ComboDispTitle
             // 
+            resources.ApplyResources(this.ComboDispTitle, "ComboDispTitle");
             this.ComboDispTitle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ComboDispTitle.FormattingEnabled = true;
             this.ComboDispTitle.Items.AddRange(new object[] {
@@ -524,39 +551,44 @@
             resources.GetString("ComboDispTitle.Items5"),
             resources.GetString("ComboDispTitle.Items6"),
             resources.GetString("ComboDispTitle.Items7")});
-            resources.ApplyResources(this.ComboDispTitle, "ComboDispTitle");
             this.ComboDispTitle.Name = "ComboDispTitle";
+            this.ToolTip1.SetToolTip(this.ComboDispTitle, resources.GetString("ComboDispTitle.ToolTip"));
             // 
             // Label45
             // 
             resources.ApplyResources(this.Label45, "Label45");
             this.Label45.Name = "Label45";
+            this.ToolTip1.SetToolTip(this.Label45, resources.GetString("Label45.ToolTip"));
             // 
             // cmbNameBalloon
             // 
+            resources.ApplyResources(this.cmbNameBalloon, "cmbNameBalloon");
             this.cmbNameBalloon.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbNameBalloon.FormattingEnabled = true;
             this.cmbNameBalloon.Items.AddRange(new object[] {
             resources.GetString("cmbNameBalloon.Items"),
             resources.GetString("cmbNameBalloon.Items1"),
             resources.GetString("cmbNameBalloon.Items2")});
-            resources.ApplyResources(this.cmbNameBalloon, "cmbNameBalloon");
             this.cmbNameBalloon.Name = "cmbNameBalloon";
+            this.ToolTip1.SetToolTip(this.cmbNameBalloon, resources.GetString("cmbNameBalloon.ToolTip"));
             // 
             // CheckDispUsername
             // 
             resources.ApplyResources(this.CheckDispUsername, "CheckDispUsername");
             this.CheckDispUsername.Name = "CheckDispUsername";
+            this.ToolTip1.SetToolTip(this.CheckDispUsername, resources.GetString("CheckDispUsername.ToolTip"));
             this.CheckDispUsername.UseVisualStyleBackColor = true;
             // 
             // CheckBox3
             // 
             resources.ApplyResources(this.CheckBox3, "CheckBox3");
             this.CheckBox3.Name = "CheckBox3";
+            this.ToolTip1.SetToolTip(this.CheckBox3, resources.GetString("CheckBox3.ToolTip"));
             this.CheckBox3.UseVisualStyleBackColor = true;
             // 
             // TweetActPanel
             // 
+            resources.ApplyResources(this.TweetActPanel, "TweetActPanel");
             this.TweetActPanel.Controls.Add(this.CheckHashSupple);
             this.TweetActPanel.Controls.Add(this.CheckAtIdSupple);
             this.TweetActPanel.Controls.Add(this.ComboBoxPostKeySelect);
@@ -565,52 +597,59 @@
             this.TweetActPanel.Controls.Add(this.Label12);
             this.TweetActPanel.Controls.Add(this.CheckUseRecommendStatus);
             this.TweetActPanel.Controls.Add(this.StatusText);
-            resources.ApplyResources(this.TweetActPanel, "TweetActPanel");
             this.TweetActPanel.Name = "TweetActPanel";
+            this.ToolTip1.SetToolTip(this.TweetActPanel, resources.GetString("TweetActPanel.ToolTip"));
             // 
             // CheckHashSupple
             // 
             resources.ApplyResources(this.CheckHashSupple, "CheckHashSupple");
             this.CheckHashSupple.Name = "CheckHashSupple";
+            this.ToolTip1.SetToolTip(this.CheckHashSupple, resources.GetString("CheckHashSupple.ToolTip"));
             this.CheckHashSupple.UseVisualStyleBackColor = true;
             // 
             // CheckAtIdSupple
             // 
             resources.ApplyResources(this.CheckAtIdSupple, "CheckAtIdSupple");
             this.CheckAtIdSupple.Name = "CheckAtIdSupple";
+            this.ToolTip1.SetToolTip(this.CheckAtIdSupple, resources.GetString("CheckAtIdSupple.ToolTip"));
             this.CheckAtIdSupple.UseVisualStyleBackColor = true;
             // 
             // ComboBoxPostKeySelect
             // 
+            resources.ApplyResources(this.ComboBoxPostKeySelect, "ComboBoxPostKeySelect");
             this.ComboBoxPostKeySelect.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ComboBoxPostKeySelect.FormattingEnabled = true;
             this.ComboBoxPostKeySelect.Items.AddRange(new object[] {
             resources.GetString("ComboBoxPostKeySelect.Items"),
             resources.GetString("ComboBoxPostKeySelect.Items1"),
             resources.GetString("ComboBoxPostKeySelect.Items2")});
-            resources.ApplyResources(this.ComboBoxPostKeySelect, "ComboBoxPostKeySelect");
             this.ComboBoxPostKeySelect.Name = "ComboBoxPostKeySelect";
+            this.ToolTip1.SetToolTip(this.ComboBoxPostKeySelect, resources.GetString("ComboBoxPostKeySelect.ToolTip"));
             // 
             // Label27
             // 
             resources.ApplyResources(this.Label27, "Label27");
             this.Label27.Name = "Label27";
+            this.ToolTip1.SetToolTip(this.Label27, resources.GetString("Label27.ToolTip"));
             // 
             // CheckRetweetNoConfirm
             // 
             resources.ApplyResources(this.CheckRetweetNoConfirm, "CheckRetweetNoConfirm");
             this.CheckRetweetNoConfirm.Name = "CheckRetweetNoConfirm";
+            this.ToolTip1.SetToolTip(this.CheckRetweetNoConfirm, resources.GetString("CheckRetweetNoConfirm.ToolTip"));
             this.CheckRetweetNoConfirm.UseVisualStyleBackColor = true;
             // 
             // Label12
             // 
             resources.ApplyResources(this.Label12, "Label12");
             this.Label12.Name = "Label12";
+            this.ToolTip1.SetToolTip(this.Label12, resources.GetString("Label12.ToolTip"));
             // 
             // CheckUseRecommendStatus
             // 
             resources.ApplyResources(this.CheckUseRecommendStatus, "CheckUseRecommendStatus");
             this.CheckUseRecommendStatus.Name = "CheckUseRecommendStatus";
+            this.ToolTip1.SetToolTip(this.CheckUseRecommendStatus, resources.GetString("CheckUseRecommendStatus.ToolTip"));
             this.CheckUseRecommendStatus.UseVisualStyleBackColor = true;
             this.CheckUseRecommendStatus.CheckedChanged += new System.EventHandler(this.CheckUseRecommendStatus_CheckedChanged);
             // 
@@ -618,9 +657,11 @@
             // 
             resources.ApplyResources(this.StatusText, "StatusText");
             this.StatusText.Name = "StatusText";
+            this.ToolTip1.SetToolTip(this.StatusText, resources.GetString("StatusText.ToolTip"));
             // 
             // GetCountPanel
             // 
+            resources.ApplyResources(this.GetCountPanel, "GetCountPanel");
             this.GetCountPanel.Controls.Add(this.ListTextCountApi);
             this.GetCountPanel.Controls.Add(this.Label25);
             this.GetCountPanel.Controls.Add(this.UserTimelineTextCountApi);
@@ -638,84 +679,98 @@
             this.GetCountPanel.Controls.Add(this.TextCountApiReply);
             this.GetCountPanel.Controls.Add(this.Label67);
             this.GetCountPanel.Controls.Add(this.TextCountApi);
-            resources.ApplyResources(this.GetCountPanel, "GetCountPanel");
             this.GetCountPanel.Name = "GetCountPanel";
+            this.ToolTip1.SetToolTip(this.GetCountPanel, resources.GetString("GetCountPanel.ToolTip"));
             // 
             // ListTextCountApi
             // 
             resources.ApplyResources(this.ListTextCountApi, "ListTextCountApi");
             this.ListTextCountApi.Name = "ListTextCountApi";
+            this.ToolTip1.SetToolTip(this.ListTextCountApi, resources.GetString("ListTextCountApi.ToolTip"));
             this.ListTextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.ListTextCountApi_Validating);
             // 
             // Label25
             // 
             resources.ApplyResources(this.Label25, "Label25");
             this.Label25.Name = "Label25";
+            this.ToolTip1.SetToolTip(this.Label25, resources.GetString("Label25.ToolTip"));
             // 
             // UserTimelineTextCountApi
             // 
             resources.ApplyResources(this.UserTimelineTextCountApi, "UserTimelineTextCountApi");
             this.UserTimelineTextCountApi.Name = "UserTimelineTextCountApi";
+            this.ToolTip1.SetToolTip(this.UserTimelineTextCountApi, resources.GetString("UserTimelineTextCountApi.ToolTip"));
             this.UserTimelineTextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.UserTimelineTextCountApi_Validating);
             // 
             // Label17
             // 
             resources.ApplyResources(this.Label17, "Label17");
             this.Label17.Name = "Label17";
+            this.ToolTip1.SetToolTip(this.Label17, resources.GetString("Label17.ToolTip"));
             // 
             // Label30
             // 
             resources.ApplyResources(this.Label30, "Label30");
             this.Label30.Name = "Label30";
+            this.ToolTip1.SetToolTip(this.Label30, resources.GetString("Label30.ToolTip"));
             // 
             // Label28
             // 
             resources.ApplyResources(this.Label28, "Label28");
             this.Label28.Name = "Label28";
+            this.ToolTip1.SetToolTip(this.Label28, resources.GetString("Label28.ToolTip"));
             // 
             // Label19
             // 
             resources.ApplyResources(this.Label19, "Label19");
             this.Label19.Name = "Label19";
+            this.ToolTip1.SetToolTip(this.Label19, resources.GetString("Label19.ToolTip"));
             // 
             // FavoritesTextCountApi
             // 
             resources.ApplyResources(this.FavoritesTextCountApi, "FavoritesTextCountApi");
             this.FavoritesTextCountApi.Name = "FavoritesTextCountApi";
+            this.ToolTip1.SetToolTip(this.FavoritesTextCountApi, resources.GetString("FavoritesTextCountApi.ToolTip"));
             this.FavoritesTextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.FavoritesTextCountApi_Validating);
             // 
             // SearchTextCountApi
             // 
             resources.ApplyResources(this.SearchTextCountApi, "SearchTextCountApi");
             this.SearchTextCountApi.Name = "SearchTextCountApi";
+            this.ToolTip1.SetToolTip(this.SearchTextCountApi, resources.GetString("SearchTextCountApi.ToolTip"));
             this.SearchTextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.SearchTextCountApi_Validating);
             // 
             // Label66
             // 
             resources.ApplyResources(this.Label66, "Label66");
             this.Label66.Name = "Label66";
+            this.ToolTip1.SetToolTip(this.Label66, resources.GetString("Label66.ToolTip"));
             // 
             // FirstTextCountApi
             // 
             resources.ApplyResources(this.FirstTextCountApi, "FirstTextCountApi");
             this.FirstTextCountApi.Name = "FirstTextCountApi";
+            this.ToolTip1.SetToolTip(this.FirstTextCountApi, resources.GetString("FirstTextCountApi.ToolTip"));
             this.FirstTextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.FirstTextCountApi_Validating);
             // 
             // GetMoreTextCountApi
             // 
             resources.ApplyResources(this.GetMoreTextCountApi, "GetMoreTextCountApi");
             this.GetMoreTextCountApi.Name = "GetMoreTextCountApi";
+            this.ToolTip1.SetToolTip(this.GetMoreTextCountApi, resources.GetString("GetMoreTextCountApi.ToolTip"));
             this.GetMoreTextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.GetMoreTextCountApi_Validating);
             // 
             // Label53
             // 
             resources.ApplyResources(this.Label53, "Label53");
             this.Label53.Name = "Label53";
+            this.ToolTip1.SetToolTip(this.Label53, resources.GetString("Label53.ToolTip"));
             // 
             // UseChangeGetCount
             // 
             resources.ApplyResources(this.UseChangeGetCount, "UseChangeGetCount");
             this.UseChangeGetCount.Name = "UseChangeGetCount";
+            this.ToolTip1.SetToolTip(this.UseChangeGetCount, resources.GetString("UseChangeGetCount.ToolTip"));
             this.UseChangeGetCount.UseVisualStyleBackColor = true;
             this.UseChangeGetCount.CheckedChanged += new System.EventHandler(this.UseChangeGetCount_CheckedChanged);
             // 
@@ -723,21 +778,25 @@
             // 
             resources.ApplyResources(this.TextCountApiReply, "TextCountApiReply");
             this.TextCountApiReply.Name = "TextCountApiReply";
+            this.ToolTip1.SetToolTip(this.TextCountApiReply, resources.GetString("TextCountApiReply.ToolTip"));
             this.TextCountApiReply.Validating += new System.ComponentModel.CancelEventHandler(this.TextCountApiReply_Validating);
             // 
             // Label67
             // 
             resources.ApplyResources(this.Label67, "Label67");
             this.Label67.Name = "Label67";
+            this.ToolTip1.SetToolTip(this.Label67, resources.GetString("Label67.ToolTip"));
             // 
             // TextCountApi
             // 
             resources.ApplyResources(this.TextCountApi, "TextCountApi");
             this.TextCountApi.Name = "TextCountApi";
+            this.ToolTip1.SetToolTip(this.TextCountApi, resources.GetString("TextCountApi.ToolTip"));
             this.TextCountApi.Validating += new System.ComponentModel.CancelEventHandler(this.TextCountApi_Validating);
             // 
             // ShortUrlPanel
             // 
+            resources.ApplyResources(this.ShortUrlPanel, "ShortUrlPanel");
             this.ShortUrlPanel.Controls.Add(this.ShortenTcoCheck);
             this.ShortUrlPanel.Controls.Add(this.CheckForceResolve);
             this.ShortUrlPanel.Controls.Add(this.CheckTinyURL);
@@ -748,36 +807,41 @@
             this.ShortUrlPanel.Controls.Add(this.Label76);
             this.ShortUrlPanel.Controls.Add(this.Label77);
             this.ShortUrlPanel.Controls.Add(this.TextBitlyId);
-            resources.ApplyResources(this.ShortUrlPanel, "ShortUrlPanel");
             this.ShortUrlPanel.Name = "ShortUrlPanel";
+            this.ToolTip1.SetToolTip(this.ShortUrlPanel, resources.GetString("ShortUrlPanel.ToolTip"));
             // 
             // ShortenTcoCheck
             // 
             resources.ApplyResources(this.ShortenTcoCheck, "ShortenTcoCheck");
             this.ShortenTcoCheck.Name = "ShortenTcoCheck";
+            this.ToolTip1.SetToolTip(this.ShortenTcoCheck, resources.GetString("ShortenTcoCheck.ToolTip"));
             this.ShortenTcoCheck.UseVisualStyleBackColor = true;
             // 
             // CheckForceResolve
             // 
             resources.ApplyResources(this.CheckForceResolve, "CheckForceResolve");
             this.CheckForceResolve.Name = "CheckForceResolve";
+            this.ToolTip1.SetToolTip(this.CheckForceResolve, resources.GetString("CheckForceResolve.ToolTip"));
             this.CheckForceResolve.UseVisualStyleBackColor = true;
             // 
             // CheckTinyURL
             // 
             resources.ApplyResources(this.CheckTinyURL, "CheckTinyURL");
             this.CheckTinyURL.Name = "CheckTinyURL";
+            this.ToolTip1.SetToolTip(this.CheckTinyURL, resources.GetString("CheckTinyURL.ToolTip"));
             this.CheckTinyURL.UseVisualStyleBackColor = true;
             // 
             // TextBitlyPw
             // 
             resources.ApplyResources(this.TextBitlyPw, "TextBitlyPw");
             this.TextBitlyPw.Name = "TextBitlyPw";
+            this.ToolTip1.SetToolTip(this.TextBitlyPw, resources.GetString("TextBitlyPw.ToolTip"));
             // 
             // CheckAutoConvertUrl
             // 
             resources.ApplyResources(this.CheckAutoConvertUrl, "CheckAutoConvertUrl");
             this.CheckAutoConvertUrl.Name = "CheckAutoConvertUrl";
+            this.ToolTip1.SetToolTip(this.CheckAutoConvertUrl, resources.GetString("CheckAutoConvertUrl.ToolTip"));
             this.CheckAutoConvertUrl.UseVisualStyleBackColor = true;
             this.CheckAutoConvertUrl.CheckedChanged += new System.EventHandler(this.CheckAutoConvertUrl_CheckedChanged);
             // 
@@ -785,9 +849,11 @@
             // 
             resources.ApplyResources(this.Label71, "Label71");
             this.Label71.Name = "Label71";
+            this.ToolTip1.SetToolTip(this.Label71, resources.GetString("Label71.ToolTip"));
             // 
             // ComboBoxAutoShortUrlFirst
             // 
+            resources.ApplyResources(this.ComboBoxAutoShortUrlFirst, "ComboBoxAutoShortUrlFirst");
             this.ComboBoxAutoShortUrlFirst.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ComboBoxAutoShortUrlFirst.FormattingEnabled = true;
             this.ComboBoxAutoShortUrlFirst.Items.AddRange(new object[] {
@@ -797,68 +863,77 @@
             resources.GetString("ComboBoxAutoShortUrlFirst.Items3"),
             resources.GetString("ComboBoxAutoShortUrlFirst.Items4"),
             resources.GetString("ComboBoxAutoShortUrlFirst.Items5")});
-            resources.ApplyResources(this.ComboBoxAutoShortUrlFirst, "ComboBoxAutoShortUrlFirst");
             this.ComboBoxAutoShortUrlFirst.Name = "ComboBoxAutoShortUrlFirst";
+            this.ToolTip1.SetToolTip(this.ComboBoxAutoShortUrlFirst, resources.GetString("ComboBoxAutoShortUrlFirst.ToolTip"));
             this.ComboBoxAutoShortUrlFirst.SelectedIndexChanged += new System.EventHandler(this.ComboBoxAutoShortUrlFirst_SelectedIndexChanged);
             // 
             // Label76
             // 
             resources.ApplyResources(this.Label76, "Label76");
             this.Label76.Name = "Label76";
+            this.ToolTip1.SetToolTip(this.Label76, resources.GetString("Label76.ToolTip"));
             // 
             // Label77
             // 
             resources.ApplyResources(this.Label77, "Label77");
             this.Label77.Name = "Label77";
+            this.ToolTip1.SetToolTip(this.Label77, resources.GetString("Label77.ToolTip"));
             // 
             // TextBitlyId
             // 
             resources.ApplyResources(this.TextBitlyId, "TextBitlyId");
             this.TextBitlyId.Name = "TextBitlyId";
+            this.ToolTip1.SetToolTip(this.TextBitlyId, resources.GetString("TextBitlyId.ToolTip"));
             // 
             // BasedPanel
             // 
+            resources.ApplyResources(this.BasedPanel, "BasedPanel");
             this.BasedPanel.Controls.Add(this.AuthUserCombo);
             this.BasedPanel.Controls.Add(this.GroupBox2);
             this.BasedPanel.Controls.Add(this.CreateAccountButton);
             this.BasedPanel.Controls.Add(this.StartAuthButton);
             this.BasedPanel.Controls.Add(this.AuthClearButton);
             this.BasedPanel.Controls.Add(this.Label4);
-            resources.ApplyResources(this.BasedPanel, "BasedPanel");
             this.BasedPanel.Name = "BasedPanel";
+            this.ToolTip1.SetToolTip(this.BasedPanel, resources.GetString("BasedPanel.ToolTip"));
             // 
             // AuthUserCombo
             // 
+            resources.ApplyResources(this.AuthUserCombo, "AuthUserCombo");
             this.AuthUserCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.AuthUserCombo.FormattingEnabled = true;
-            resources.ApplyResources(this.AuthUserCombo, "AuthUserCombo");
             this.AuthUserCombo.Name = "AuthUserCombo";
+            this.ToolTip1.SetToolTip(this.AuthUserCombo, resources.GetString("AuthUserCombo.ToolTip"));
             // 
             // GroupBox2
             // 
+            resources.ApplyResources(this.GroupBox2, "GroupBox2");
             this.GroupBox2.Controls.Add(this.Label1);
             this.GroupBox2.Controls.Add(this.EmailText);
             this.GroupBox2.Controls.Add(this.Label6);
             this.GroupBox2.Controls.Add(this.FollowCheckBox);
             this.GroupBox2.Controls.Add(this.Label43);
-            resources.ApplyResources(this.GroupBox2, "GroupBox2");
             this.GroupBox2.Name = "GroupBox2";
             this.GroupBox2.TabStop = false;
+            this.ToolTip1.SetToolTip(this.GroupBox2, resources.GetString("GroupBox2.ToolTip"));
             // 
             // Label1
             // 
             resources.ApplyResources(this.Label1, "Label1");
             this.Label1.Name = "Label1";
+            this.ToolTip1.SetToolTip(this.Label1, resources.GetString("Label1.ToolTip"));
             // 
             // EmailText
             // 
             resources.ApplyResources(this.EmailText, "EmailText");
             this.EmailText.Name = "EmailText";
+            this.ToolTip1.SetToolTip(this.EmailText, resources.GetString("EmailText.ToolTip"));
             // 
             // Label6
             // 
             resources.ApplyResources(this.Label6, "Label6");
             this.Label6.Name = "Label6";
+            this.ToolTip1.SetToolTip(this.Label6, resources.GetString("Label6.ToolTip"));
             // 
             // FollowCheckBox
             // 
@@ -866,18 +941,21 @@
             this.FollowCheckBox.Checked = true;
             this.FollowCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.FollowCheckBox.Name = "FollowCheckBox";
+            this.ToolTip1.SetToolTip(this.FollowCheckBox, resources.GetString("FollowCheckBox.ToolTip"));
             this.FollowCheckBox.UseVisualStyleBackColor = true;
             // 
             // Label43
             // 
-            this.Label43.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.Label43, "Label43");
+            this.Label43.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.Label43.Name = "Label43";
+            this.ToolTip1.SetToolTip(this.Label43, resources.GetString("Label43.ToolTip"));
             // 
             // CreateAccountButton
             // 
             resources.ApplyResources(this.CreateAccountButton, "CreateAccountButton");
             this.CreateAccountButton.Name = "CreateAccountButton";
+            this.ToolTip1.SetToolTip(this.CreateAccountButton, resources.GetString("CreateAccountButton.ToolTip"));
             this.CreateAccountButton.UseVisualStyleBackColor = true;
             this.CreateAccountButton.Click += new System.EventHandler(this.CreateAccountButton_Click);
             // 
@@ -885,6 +963,7 @@
             // 
             resources.ApplyResources(this.StartAuthButton, "StartAuthButton");
             this.StartAuthButton.Name = "StartAuthButton";
+            this.ToolTip1.SetToolTip(this.StartAuthButton, resources.GetString("StartAuthButton.ToolTip"));
             this.StartAuthButton.UseVisualStyleBackColor = true;
             this.StartAuthButton.Click += new System.EventHandler(this.StartAuthButton_Click);
             // 
@@ -892,6 +971,7 @@
             // 
             resources.ApplyResources(this.AuthClearButton, "AuthClearButton");
             this.AuthClearButton.Name = "AuthClearButton";
+            this.ToolTip1.SetToolTip(this.AuthClearButton, resources.GetString("AuthClearButton.ToolTip"));
             this.AuthClearButton.UseVisualStyleBackColor = true;
             this.AuthClearButton.Click += new System.EventHandler(this.AuthClearButton_Click);
             // 
@@ -899,9 +979,11 @@
             // 
             resources.ApplyResources(this.Label4, "Label4");
             this.Label4.Name = "Label4";
+            this.ToolTip1.SetToolTip(this.Label4, resources.GetString("Label4.ToolTip"));
             // 
             // TweetPrvPanel
             // 
+            resources.ApplyResources(this.TweetPrvPanel, "TweetPrvPanel");
             this.TweetPrvPanel.Controls.Add(this.IsListsIncludeRtsCheckBox);
             this.TweetPrvPanel.Controls.Add(this.HideDuplicatedRetweetsCheck);
             this.TweetPrvPanel.Controls.Add(this.Label47);
@@ -912,23 +994,26 @@
             this.TweetPrvPanel.Controls.Add(this.Label11);
             this.TweetPrvPanel.Controls.Add(this.IconSize);
             this.TweetPrvPanel.Controls.Add(this.TextBox3);
+            this.TweetPrvPanel.Controls.Add(this.CheckViewTabBottom);
             this.TweetPrvPanel.Controls.Add(this.CheckSortOrderLock);
             this.TweetPrvPanel.Controls.Add(this.CheckShowGrid);
             this.TweetPrvPanel.Controls.Add(this.chkUnreadStyle);
             this.TweetPrvPanel.Controls.Add(this.OneWayLv);
-            resources.ApplyResources(this.TweetPrvPanel, "TweetPrvPanel");
             this.TweetPrvPanel.Name = "TweetPrvPanel";
+            this.ToolTip1.SetToolTip(this.TweetPrvPanel, resources.GetString("TweetPrvPanel.ToolTip"));
             // 
             // IsListsIncludeRtsCheckBox
             // 
             resources.ApplyResources(this.IsListsIncludeRtsCheckBox, "IsListsIncludeRtsCheckBox");
             this.IsListsIncludeRtsCheckBox.Name = "IsListsIncludeRtsCheckBox";
+            this.ToolTip1.SetToolTip(this.IsListsIncludeRtsCheckBox, resources.GetString("IsListsIncludeRtsCheckBox.ToolTip"));
             this.IsListsIncludeRtsCheckBox.UseVisualStyleBackColor = true;
             // 
             // HideDuplicatedRetweetsCheck
             // 
             resources.ApplyResources(this.HideDuplicatedRetweetsCheck, "HideDuplicatedRetweetsCheck");
             this.HideDuplicatedRetweetsCheck.Name = "HideDuplicatedRetweetsCheck";
+            this.ToolTip1.SetToolTip(this.HideDuplicatedRetweetsCheck, resources.GetString("HideDuplicatedRetweetsCheck.ToolTip"));
             this.HideDuplicatedRetweetsCheck.UseVisualStyleBackColor = true;
             // 
             // Label47
@@ -937,17 +1022,20 @@
             this.Label47.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Label47.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.Label47.Name = "Label47";
+            this.ToolTip1.SetToolTip(this.Label47, resources.GetString("Label47.ToolTip"));
             // 
             // LabelDateTimeFormatApplied
             // 
             resources.ApplyResources(this.LabelDateTimeFormatApplied, "LabelDateTimeFormatApplied");
             this.LabelDateTimeFormatApplied.Name = "LabelDateTimeFormatApplied";
+            this.ToolTip1.SetToolTip(this.LabelDateTimeFormatApplied, resources.GetString("LabelDateTimeFormatApplied.ToolTip"));
             this.LabelDateTimeFormatApplied.VisibleChanged += new System.EventHandler(this.LabelDateTimeFormatApplied_VisibleChanged);
             // 
             // Label62
             // 
             resources.ApplyResources(this.Label62, "Label62");
             this.Label62.Name = "Label62";
+            this.ToolTip1.SetToolTip(this.Label62, resources.GetString("Label62.ToolTip"));
             // 
             // CmbDateTimeFormat
             // 
@@ -965,6 +1053,7 @@
             resources.GetString("CmbDateTimeFormat.Items9"),
             resources.GetString("CmbDateTimeFormat.Items10")});
             this.CmbDateTimeFormat.Name = "CmbDateTimeFormat";
+            this.ToolTip1.SetToolTip(this.CmbDateTimeFormat, resources.GetString("CmbDateTimeFormat.ToolTip"));
             this.CmbDateTimeFormat.SelectedIndexChanged += new System.EventHandler(this.CmbDateTimeFormat_SelectedIndexChanged);
             this.CmbDateTimeFormat.TextUpdate += new System.EventHandler(this.CmbDateTimeFormat_TextUpdate);
             this.CmbDateTimeFormat.Validating += new System.ComponentModel.CancelEventHandler(this.CmbDateTimeFormat_Validating);
@@ -973,14 +1062,17 @@
             // 
             resources.ApplyResources(this.Label23, "Label23");
             this.Label23.Name = "Label23";
+            this.ToolTip1.SetToolTip(this.Label23, resources.GetString("Label23.ToolTip"));
             // 
             // Label11
             // 
             resources.ApplyResources(this.Label11, "Label11");
             this.Label11.Name = "Label11";
+            this.ToolTip1.SetToolTip(this.Label11, resources.GetString("Label11.ToolTip"));
             // 
             // IconSize
             // 
+            resources.ApplyResources(this.IconSize, "IconSize");
             this.IconSize.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.IconSize.FormattingEnabled = true;
             this.IconSize.Items.AddRange(new object[] {
@@ -989,40 +1081,55 @@
             resources.GetString("IconSize.Items2"),
             resources.GetString("IconSize.Items3"),
             resources.GetString("IconSize.Items4")});
-            resources.ApplyResources(this.IconSize, "IconSize");
             this.IconSize.Name = "IconSize";
+            this.ToolTip1.SetToolTip(this.IconSize, resources.GetString("IconSize.ToolTip"));
             // 
             // TextBox3
             // 
             resources.ApplyResources(this.TextBox3, "TextBox3");
             this.TextBox3.Name = "TextBox3";
+            this.ToolTip1.SetToolTip(this.TextBox3, resources.GetString("TextBox3.ToolTip"));
+            // 
+            // CheckViewTabBottom
+            // 
+            resources.ApplyResources(this.CheckViewTabBottom, "CheckViewTabBottom");
+            this.CheckViewTabBottom.Checked = true;
+            this.CheckViewTabBottom.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CheckViewTabBottom.Name = "CheckViewTabBottom";
+            this.ToolTip1.SetToolTip(this.CheckViewTabBottom, resources.GetString("CheckViewTabBottom.ToolTip"));
+            this.CheckViewTabBottom.UseVisualStyleBackColor = true;
             // 
             // CheckSortOrderLock
             // 
             resources.ApplyResources(this.CheckSortOrderLock, "CheckSortOrderLock");
             this.CheckSortOrderLock.Name = "CheckSortOrderLock";
+            this.ToolTip1.SetToolTip(this.CheckSortOrderLock, resources.GetString("CheckSortOrderLock.ToolTip"));
             this.CheckSortOrderLock.UseVisualStyleBackColor = true;
             // 
             // CheckShowGrid
             // 
             resources.ApplyResources(this.CheckShowGrid, "CheckShowGrid");
             this.CheckShowGrid.Name = "CheckShowGrid";
+            this.ToolTip1.SetToolTip(this.CheckShowGrid, resources.GetString("CheckShowGrid.ToolTip"));
             this.CheckShowGrid.UseVisualStyleBackColor = true;
             // 
             // chkUnreadStyle
             // 
             resources.ApplyResources(this.chkUnreadStyle, "chkUnreadStyle");
             this.chkUnreadStyle.Name = "chkUnreadStyle";
+            this.ToolTip1.SetToolTip(this.chkUnreadStyle, resources.GetString("chkUnreadStyle.ToolTip"));
             this.chkUnreadStyle.UseVisualStyleBackColor = true;
             // 
             // OneWayLv
             // 
             resources.ApplyResources(this.OneWayLv, "OneWayLv");
             this.OneWayLv.Name = "OneWayLv";
+            this.ToolTip1.SetToolTip(this.OneWayLv, resources.GetString("OneWayLv.ToolTip"));
             this.OneWayLv.UseVisualStyleBackColor = true;
             // 
             // NotifyPanel
             // 
+            resources.ApplyResources(this.NotifyPanel, "NotifyPanel");
             this.NotifyPanel.Controls.Add(this.IsRemoveSameFavEventCheckBox);
             this.NotifyPanel.Controls.Add(this.CheckUserUpdateEvent);
             this.NotifyPanel.Controls.Add(this.Label35);
@@ -1037,13 +1144,14 @@
             this.NotifyPanel.Controls.Add(this.CheckUnfavoritesEvent);
             this.NotifyPanel.Controls.Add(this.CheckFavoritesEvent);
             this.NotifyPanel.Controls.Add(this.CheckEventNotify);
-            resources.ApplyResources(this.NotifyPanel, "NotifyPanel");
             this.NotifyPanel.Name = "NotifyPanel";
+            this.ToolTip1.SetToolTip(this.NotifyPanel, resources.GetString("NotifyPanel.ToolTip"));
             // 
             // IsRemoveSameFavEventCheckBox
             // 
             resources.ApplyResources(this.IsRemoveSameFavEventCheckBox, "IsRemoveSameFavEventCheckBox");
             this.IsRemoveSameFavEventCheckBox.Name = "IsRemoveSameFavEventCheckBox";
+            this.ToolTip1.SetToolTip(this.IsRemoveSameFavEventCheckBox, resources.GetString("IsRemoveSameFavEventCheckBox.ToolTip"));
             this.IsRemoveSameFavEventCheckBox.UseVisualStyleBackColor = true;
             // 
             // CheckUserUpdateEvent
@@ -1060,12 +1168,14 @@
             // 
             resources.ApplyResources(this.Label35, "Label35");
             this.Label35.Name = "Label35";
+            this.ToolTip1.SetToolTip(this.Label35, resources.GetString("Label35.ToolTip"));
             // 
             // ComboBoxEventNotifySound
             // 
-            this.ComboBoxEventNotifySound.FormattingEnabled = true;
             resources.ApplyResources(this.ComboBoxEventNotifySound, "ComboBoxEventNotifySound");
+            this.ComboBoxEventNotifySound.FormattingEnabled = true;
             this.ComboBoxEventNotifySound.Name = "ComboBoxEventNotifySound";
+            this.ToolTip1.SetToolTip(this.ComboBoxEventNotifySound, resources.GetString("ComboBoxEventNotifySound.ToolTip"));
             // 
             // CheckFavEventUnread
             // 
@@ -1073,6 +1183,7 @@
             this.CheckFavEventUnread.Checked = true;
             this.CheckFavEventUnread.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CheckFavEventUnread.Name = "CheckFavEventUnread";
+            this.ToolTip1.SetToolTip(this.CheckFavEventUnread, resources.GetString("CheckFavEventUnread.ToolTip"));
             this.CheckFavEventUnread.UseVisualStyleBackColor = true;
             // 
             // CheckListCreatedEvent
@@ -1101,6 +1212,7 @@
             this.CheckForceEventNotify.Checked = true;
             this.CheckForceEventNotify.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CheckForceEventNotify.Name = "CheckForceEventNotify";
+            this.ToolTip1.SetToolTip(this.CheckForceEventNotify, resources.GetString("CheckForceEventNotify.ToolTip"));
             this.CheckForceEventNotify.UseVisualStyleBackColor = true;
             // 
             // CheckListMemberRemovedEvent
@@ -1159,11 +1271,13 @@
             this.CheckEventNotify.Checked = true;
             this.CheckEventNotify.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CheckEventNotify.Name = "CheckEventNotify";
+            this.ToolTip1.SetToolTip(this.CheckEventNotify, resources.GetString("CheckEventNotify.ToolTip"));
             this.CheckEventNotify.UseVisualStyleBackColor = true;
             this.CheckEventNotify.CheckedChanged += new System.EventHandler(this.CheckEventNotify_CheckedChanged);
             // 
             // CooperatePanel
             // 
+            resources.ApplyResources(this.CooperatePanel, "CooperatePanel");
             this.CooperatePanel.Controls.Add(this.IsPreviewFoursquareCheckBox);
             this.CooperatePanel.Controls.Add(this.MapThumbnailGroupBox);
             this.CooperatePanel.Controls.Add(this.Label39);
@@ -1176,17 +1290,19 @@
             this.CooperatePanel.Controls.Add(this.Label60);
             this.CooperatePanel.Controls.Add(this.Label59);
             this.CooperatePanel.Controls.Add(this.ComboBoxOutputzUrlmode);
-            resources.ApplyResources(this.CooperatePanel, "CooperatePanel");
             this.CooperatePanel.Name = "CooperatePanel";
+            this.ToolTip1.SetToolTip(this.CooperatePanel, resources.GetString("CooperatePanel.ToolTip"));
             // 
             // IsPreviewFoursquareCheckBox
             // 
             resources.ApplyResources(this.IsPreviewFoursquareCheckBox, "IsPreviewFoursquareCheckBox");
             this.IsPreviewFoursquareCheckBox.Name = "IsPreviewFoursquareCheckBox";
+            this.ToolTip1.SetToolTip(this.IsPreviewFoursquareCheckBox, resources.GetString("IsPreviewFoursquareCheckBox.ToolTip"));
             this.IsPreviewFoursquareCheckBox.UseVisualStyleBackColor = true;
             // 
             // MapThumbnailGroupBox
             // 
+            resources.ApplyResources(this.MapThumbnailGroupBox, "MapThumbnailGroupBox");
             this.MapThumbnailGroupBox.Controls.Add(this.MapThumbnailProviderComboBox);
             this.MapThumbnailGroupBox.Controls.Add(this.label48);
             this.MapThumbnailGroupBox.Controls.Add(this.Label42);
@@ -1195,68 +1311,79 @@
             this.MapThumbnailGroupBox.Controls.Add(this.MapThumbnailHeightTextBox);
             this.MapThumbnailGroupBox.Controls.Add(this.Label41);
             this.MapThumbnailGroupBox.Controls.Add(this.Label40);
-            resources.ApplyResources(this.MapThumbnailGroupBox, "MapThumbnailGroupBox");
             this.MapThumbnailGroupBox.Name = "MapThumbnailGroupBox";
             this.MapThumbnailGroupBox.TabStop = false;
+            this.ToolTip1.SetToolTip(this.MapThumbnailGroupBox, resources.GetString("MapThumbnailGroupBox.ToolTip"));
             // 
             // MapThumbnailProviderComboBox
             // 
+            resources.ApplyResources(this.MapThumbnailProviderComboBox, "MapThumbnailProviderComboBox");
             this.MapThumbnailProviderComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.MapThumbnailProviderComboBox.FormattingEnabled = true;
             this.MapThumbnailProviderComboBox.Items.AddRange(new object[] {
             resources.GetString("MapThumbnailProviderComboBox.Items"),
             resources.GetString("MapThumbnailProviderComboBox.Items1")});
-            resources.ApplyResources(this.MapThumbnailProviderComboBox, "MapThumbnailProviderComboBox");
             this.MapThumbnailProviderComboBox.Name = "MapThumbnailProviderComboBox";
+            this.ToolTip1.SetToolTip(this.MapThumbnailProviderComboBox, resources.GetString("MapThumbnailProviderComboBox.ToolTip"));
             // 
             // label48
             // 
             resources.ApplyResources(this.label48, "label48");
             this.label48.Name = "label48";
+            this.ToolTip1.SetToolTip(this.label48, resources.GetString("label48.ToolTip"));
             // 
             // Label42
             // 
             resources.ApplyResources(this.Label42, "Label42");
             this.Label42.Name = "Label42";
+            this.ToolTip1.SetToolTip(this.Label42, resources.GetString("Label42.ToolTip"));
             // 
             // MapThumbnailWidthTextBox
             // 
             resources.ApplyResources(this.MapThumbnailWidthTextBox, "MapThumbnailWidthTextBox");
             this.MapThumbnailWidthTextBox.Name = "MapThumbnailWidthTextBox";
+            this.ToolTip1.SetToolTip(this.MapThumbnailWidthTextBox, resources.GetString("MapThumbnailWidthTextBox.ToolTip"));
             // 
             // MapThumbnailZoomTextBox
             // 
             resources.ApplyResources(this.MapThumbnailZoomTextBox, "MapThumbnailZoomTextBox");
             this.MapThumbnailZoomTextBox.Name = "MapThumbnailZoomTextBox";
+            this.ToolTip1.SetToolTip(this.MapThumbnailZoomTextBox, resources.GetString("MapThumbnailZoomTextBox.ToolTip"));
             // 
             // MapThumbnailHeightTextBox
             // 
             resources.ApplyResources(this.MapThumbnailHeightTextBox, "MapThumbnailHeightTextBox");
             this.MapThumbnailHeightTextBox.Name = "MapThumbnailHeightTextBox";
+            this.ToolTip1.SetToolTip(this.MapThumbnailHeightTextBox, resources.GetString("MapThumbnailHeightTextBox.ToolTip"));
             // 
             // Label41
             // 
             resources.ApplyResources(this.Label41, "Label41");
             this.Label41.Name = "Label41";
+            this.ToolTip1.SetToolTip(this.Label41, resources.GetString("Label41.ToolTip"));
             // 
             // Label40
             // 
             resources.ApplyResources(this.Label40, "Label40");
             this.Label40.Name = "Label40";
+            this.ToolTip1.SetToolTip(this.Label40, resources.GetString("Label40.ToolTip"));
             // 
             // Label39
             // 
             resources.ApplyResources(this.Label39, "Label39");
             this.Label39.Name = "Label39";
+            this.ToolTip1.SetToolTip(this.Label39, resources.GetString("Label39.ToolTip"));
             // 
             // UserAppointUrlText
             // 
             resources.ApplyResources(this.UserAppointUrlText, "UserAppointUrlText");
             this.UserAppointUrlText.Name = "UserAppointUrlText";
+            this.ToolTip1.SetToolTip(this.UserAppointUrlText, resources.GetString("UserAppointUrlText.ToolTip"));
             this.UserAppointUrlText.Validating += new System.ComponentModel.CancelEventHandler(this.UserAppointUrlText_Validating);
             // 
             // ComboBoxTranslateLanguage
             // 
+            resources.ApplyResources(this.ComboBoxTranslateLanguage, "ComboBoxTranslateLanguage");
             this.ComboBoxTranslateLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ComboBoxTranslateLanguage.FormattingEnabled = true;
             this.ComboBoxTranslateLanguage.Items.AddRange(new object[] {
@@ -1384,18 +1511,20 @@
             resources.GetString("ComboBoxTranslateLanguage.Items121"),
             resources.GetString("ComboBoxTranslateLanguage.Items122"),
             resources.GetString("ComboBoxTranslateLanguage.Items123")});
-            resources.ApplyResources(this.ComboBoxTranslateLanguage, "ComboBoxTranslateLanguage");
             this.ComboBoxTranslateLanguage.Name = "ComboBoxTranslateLanguage";
+            this.ToolTip1.SetToolTip(this.ComboBoxTranslateLanguage, resources.GetString("ComboBoxTranslateLanguage.ToolTip"));
             // 
             // Label29
             // 
             resources.ApplyResources(this.Label29, "Label29");
             this.Label29.Name = "Label29";
+            this.ToolTip1.SetToolTip(this.Label29, resources.GetString("Label29.ToolTip"));
             // 
             // CheckOutputz
             // 
             resources.ApplyResources(this.CheckOutputz, "CheckOutputz");
             this.CheckOutputz.Name = "CheckOutputz";
+            this.ToolTip1.SetToolTip(this.CheckOutputz, resources.GetString("CheckOutputz.ToolTip"));
             this.CheckOutputz.UseVisualStyleBackColor = true;
             this.CheckOutputz.CheckedChanged += new System.EventHandler(this.CheckOutputz_CheckedChanged);
             // 
@@ -1403,36 +1532,42 @@
             // 
             resources.ApplyResources(this.CheckNicoms, "CheckNicoms");
             this.CheckNicoms.Name = "CheckNicoms";
+            this.ToolTip1.SetToolTip(this.CheckNicoms, resources.GetString("CheckNicoms.ToolTip"));
             this.CheckNicoms.UseVisualStyleBackColor = true;
             // 
             // TextBoxOutputzKey
             // 
             resources.ApplyResources(this.TextBoxOutputzKey, "TextBoxOutputzKey");
             this.TextBoxOutputzKey.Name = "TextBoxOutputzKey";
+            this.ToolTip1.SetToolTip(this.TextBoxOutputzKey, resources.GetString("TextBoxOutputzKey.ToolTip"));
             this.TextBoxOutputzKey.Validating += new System.ComponentModel.CancelEventHandler(this.TextBoxOutputzKey_Validating);
             // 
             // Label60
             // 
             resources.ApplyResources(this.Label60, "Label60");
             this.Label60.Name = "Label60";
+            this.ToolTip1.SetToolTip(this.Label60, resources.GetString("Label60.ToolTip"));
             // 
             // Label59
             // 
             resources.ApplyResources(this.Label59, "Label59");
             this.Label59.Name = "Label59";
+            this.ToolTip1.SetToolTip(this.Label59, resources.GetString("Label59.ToolTip"));
             // 
             // ComboBoxOutputzUrlmode
             // 
+            resources.ApplyResources(this.ComboBoxOutputzUrlmode, "ComboBoxOutputzUrlmode");
             this.ComboBoxOutputzUrlmode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ComboBoxOutputzUrlmode.FormattingEnabled = true;
             this.ComboBoxOutputzUrlmode.Items.AddRange(new object[] {
             resources.GetString("ComboBoxOutputzUrlmode.Items"),
             resources.GetString("ComboBoxOutputzUrlmode.Items1")});
-            resources.ApplyResources(this.ComboBoxOutputzUrlmode, "ComboBoxOutputzUrlmode");
             this.ComboBoxOutputzUrlmode.Name = "ComboBoxOutputzUrlmode";
+            this.ToolTip1.SetToolTip(this.ComboBoxOutputzUrlmode, resources.GetString("ComboBoxOutputzUrlmode.ToolTip"));
             // 
             // ProxyPanel
             // 
+            resources.ApplyResources(this.ProxyPanel, "ProxyPanel");
             this.ProxyPanel.Controls.Add(this.Label55);
             this.ProxyPanel.Controls.Add(this.TextProxyPassword);
             this.ProxyPanel.Controls.Add(this.RadioProxyNone);
@@ -1445,8 +1580,8 @@
             this.ProxyPanel.Controls.Add(this.TextProxyPort);
             this.ProxyPanel.Controls.Add(this.TextProxyAddress);
             this.ProxyPanel.Controls.Add(this.LabelProxyPort);
-            resources.ApplyResources(this.ProxyPanel, "ProxyPanel");
             this.ProxyPanel.Name = "ProxyPanel";
+            this.ToolTip1.SetToolTip(this.ProxyPanel, resources.GetString("ProxyPanel.ToolTip"));
             // 
             // Label55
             // 
@@ -1454,23 +1589,27 @@
             this.Label55.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Label55.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.Label55.Name = "Label55";
+            this.ToolTip1.SetToolTip(this.Label55, resources.GetString("Label55.ToolTip"));
             // 
             // TextProxyPassword
             // 
             resources.ApplyResources(this.TextProxyPassword, "TextProxyPassword");
             this.TextProxyPassword.Name = "TextProxyPassword";
+            this.ToolTip1.SetToolTip(this.TextProxyPassword, resources.GetString("TextProxyPassword.ToolTip"));
             this.TextProxyPassword.UseSystemPasswordChar = true;
             // 
             // RadioProxyNone
             // 
             resources.ApplyResources(this.RadioProxyNone, "RadioProxyNone");
             this.RadioProxyNone.Name = "RadioProxyNone";
+            this.ToolTip1.SetToolTip(this.RadioProxyNone, resources.GetString("RadioProxyNone.ToolTip"));
             this.RadioProxyNone.UseVisualStyleBackColor = true;
             // 
             // LabelProxyPassword
             // 
             resources.ApplyResources(this.LabelProxyPassword, "LabelProxyPassword");
             this.LabelProxyPassword.Name = "LabelProxyPassword";
+            this.ToolTip1.SetToolTip(this.LabelProxyPassword, resources.GetString("LabelProxyPassword.ToolTip"));
             // 
             // RadioProxyIE
             // 
@@ -1478,17 +1617,20 @@
             this.RadioProxyIE.Checked = true;
             this.RadioProxyIE.Name = "RadioProxyIE";
             this.RadioProxyIE.TabStop = true;
+            this.ToolTip1.SetToolTip(this.RadioProxyIE, resources.GetString("RadioProxyIE.ToolTip"));
             this.RadioProxyIE.UseVisualStyleBackColor = true;
             // 
             // TextProxyUser
             // 
             resources.ApplyResources(this.TextProxyUser, "TextProxyUser");
             this.TextProxyUser.Name = "TextProxyUser";
+            this.ToolTip1.SetToolTip(this.TextProxyUser, resources.GetString("TextProxyUser.ToolTip"));
             // 
             // RadioProxySpecified
             // 
             resources.ApplyResources(this.RadioProxySpecified, "RadioProxySpecified");
             this.RadioProxySpecified.Name = "RadioProxySpecified";
+            this.ToolTip1.SetToolTip(this.RadioProxySpecified, resources.GetString("RadioProxySpecified.ToolTip"));
             this.RadioProxySpecified.UseVisualStyleBackColor = true;
             this.RadioProxySpecified.CheckedChanged += new System.EventHandler(this.RadioProxySpecified_CheckedChanged);
             // 
@@ -1496,30 +1638,36 @@
             // 
             resources.ApplyResources(this.LabelProxyUser, "LabelProxyUser");
             this.LabelProxyUser.Name = "LabelProxyUser";
+            this.ToolTip1.SetToolTip(this.LabelProxyUser, resources.GetString("LabelProxyUser.ToolTip"));
             // 
             // LabelProxyAddress
             // 
             resources.ApplyResources(this.LabelProxyAddress, "LabelProxyAddress");
             this.LabelProxyAddress.Name = "LabelProxyAddress";
+            this.ToolTip1.SetToolTip(this.LabelProxyAddress, resources.GetString("LabelProxyAddress.ToolTip"));
             // 
             // TextProxyPort
             // 
             resources.ApplyResources(this.TextProxyPort, "TextProxyPort");
             this.TextProxyPort.Name = "TextProxyPort";
+            this.ToolTip1.SetToolTip(this.TextProxyPort, resources.GetString("TextProxyPort.ToolTip"));
             this.TextProxyPort.Validating += new System.ComponentModel.CancelEventHandler(this.TextProxyPort_Validating);
             // 
             // TextProxyAddress
             // 
             resources.ApplyResources(this.TextProxyAddress, "TextProxyAddress");
             this.TextProxyAddress.Name = "TextProxyAddress";
+            this.ToolTip1.SetToolTip(this.TextProxyAddress, resources.GetString("TextProxyAddress.ToolTip"));
             // 
             // LabelProxyPort
             // 
             resources.ApplyResources(this.LabelProxyPort, "LabelProxyPort");
             this.LabelProxyPort.Name = "LabelProxyPort";
+            this.ToolTip1.SetToolTip(this.LabelProxyPort, resources.GetString("LabelProxyPort.ToolTip"));
             // 
             // ConnectionPanel
             // 
+            resources.ApplyResources(this.ConnectionPanel, "ConnectionPanel");
             this.ConnectionPanel.Controls.Add(this.TwitterSearchAPIText);
             this.ConnectionPanel.Controls.Add(this.Label31);
             this.ConnectionPanel.Controls.Add(this.TwitterAPIText);
@@ -1528,33 +1676,38 @@
             this.ConnectionPanel.Controls.Add(this.Label64);
             this.ConnectionPanel.Controls.Add(this.ConnectionTimeOut);
             this.ConnectionPanel.Controls.Add(this.Label63);
-            resources.ApplyResources(this.ConnectionPanel, "ConnectionPanel");
             this.ConnectionPanel.Name = "ConnectionPanel";
+            this.ToolTip1.SetToolTip(this.ConnectionPanel, resources.GetString("ConnectionPanel.ToolTip"));
             // 
             // TwitterSearchAPIText
             // 
             resources.ApplyResources(this.TwitterSearchAPIText, "TwitterSearchAPIText");
             this.TwitterSearchAPIText.Name = "TwitterSearchAPIText";
+            this.ToolTip1.SetToolTip(this.TwitterSearchAPIText, resources.GetString("TwitterSearchAPIText.ToolTip"));
             // 
             // Label31
             // 
             resources.ApplyResources(this.Label31, "Label31");
             this.Label31.Name = "Label31";
+            this.ToolTip1.SetToolTip(this.Label31, resources.GetString("Label31.ToolTip"));
             // 
             // TwitterAPIText
             // 
             resources.ApplyResources(this.TwitterAPIText, "TwitterAPIText");
             this.TwitterAPIText.Name = "TwitterAPIText";
+            this.ToolTip1.SetToolTip(this.TwitterAPIText, resources.GetString("TwitterAPIText.ToolTip"));
             // 
             // Label8
             // 
             resources.ApplyResources(this.Label8, "Label8");
             this.Label8.Name = "Label8";
+            this.ToolTip1.SetToolTip(this.Label8, resources.GetString("Label8.ToolTip"));
             // 
             // CheckUseSsl
             // 
             resources.ApplyResources(this.CheckUseSsl, "CheckUseSsl");
             this.CheckUseSsl.Name = "CheckUseSsl";
+            this.ToolTip1.SetToolTip(this.CheckUseSsl, resources.GetString("CheckUseSsl.ToolTip"));
             this.CheckUseSsl.UseVisualStyleBackColor = true;
             // 
             // Label64
@@ -1563,20 +1716,24 @@
             this.Label64.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Label64.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.Label64.Name = "Label64";
+            this.ToolTip1.SetToolTip(this.Label64, resources.GetString("Label64.ToolTip"));
             // 
             // ConnectionTimeOut
             // 
             resources.ApplyResources(this.ConnectionTimeOut, "ConnectionTimeOut");
             this.ConnectionTimeOut.Name = "ConnectionTimeOut";
+            this.ToolTip1.SetToolTip(this.ConnectionTimeOut, resources.GetString("ConnectionTimeOut.ToolTip"));
             this.ConnectionTimeOut.Validating += new System.ComponentModel.CancelEventHandler(this.ConnectionTimeOut_Validating);
             // 
             // Label63
             // 
             resources.ApplyResources(this.Label63, "Label63");
             this.Label63.Name = "Label63";
+            this.ToolTip1.SetToolTip(this.Label63, resources.GetString("Label63.ToolTip"));
             // 
             // GetPeriodPanel
             // 
+            resources.ApplyResources(this.GetPeriodPanel, "GetPeriodPanel");
             this.GetPeriodPanel.Controls.Add(this.UserstreamPeriod);
             this.GetPeriodPanel.Controls.Add(this.Label46);
             this.GetPeriodPanel.Controls.Add(this.LabelApiUsingUserStreamEnabled);
@@ -1599,56 +1756,65 @@
             this.GetPeriodPanel.Controls.Add(this.Label5);
             this.GetPeriodPanel.Controls.Add(this.DMPeriod);
             this.GetPeriodPanel.Controls.Add(this.StartupUserstreamCheck);
-            resources.ApplyResources(this.GetPeriodPanel, "GetPeriodPanel");
             this.GetPeriodPanel.Name = "GetPeriodPanel";
+            this.ToolTip1.SetToolTip(this.GetPeriodPanel, resources.GetString("GetPeriodPanel.ToolTip"));
             // 
             // UserstreamPeriod
             // 
             resources.ApplyResources(this.UserstreamPeriod, "UserstreamPeriod");
             this.UserstreamPeriod.Name = "UserstreamPeriod";
+            this.ToolTip1.SetToolTip(this.UserstreamPeriod, resources.GetString("UserstreamPeriod.ToolTip"));
             this.UserstreamPeriod.Validating += new System.ComponentModel.CancelEventHandler(this.UserstreamPeriod_Validating);
             // 
             // Label46
             // 
             resources.ApplyResources(this.Label46, "Label46");
             this.Label46.Name = "Label46";
+            this.ToolTip1.SetToolTip(this.Label46, resources.GetString("Label46.ToolTip"));
             // 
             // LabelApiUsingUserStreamEnabled
             // 
             resources.ApplyResources(this.LabelApiUsingUserStreamEnabled, "LabelApiUsingUserStreamEnabled");
             this.LabelApiUsingUserStreamEnabled.Name = "LabelApiUsingUserStreamEnabled";
+            this.ToolTip1.SetToolTip(this.LabelApiUsingUserStreamEnabled, resources.GetString("LabelApiUsingUserStreamEnabled.ToolTip"));
             // 
             // LabelUserStreamActive
             // 
             resources.ApplyResources(this.LabelUserStreamActive, "LabelUserStreamActive");
             this.LabelUserStreamActive.Name = "LabelUserStreamActive";
+            this.ToolTip1.SetToolTip(this.LabelUserStreamActive, resources.GetString("LabelUserStreamActive.ToolTip"));
             // 
             // Label21
             // 
             resources.ApplyResources(this.Label21, "Label21");
             this.Label21.Name = "Label21";
+            this.ToolTip1.SetToolTip(this.Label21, resources.GetString("Label21.ToolTip"));
             // 
             // UserTimelinePeriod
             // 
             resources.ApplyResources(this.UserTimelinePeriod, "UserTimelinePeriod");
             this.UserTimelinePeriod.Name = "UserTimelinePeriod";
+            this.ToolTip1.SetToolTip(this.UserTimelinePeriod, resources.GetString("UserTimelinePeriod.ToolTip"));
             this.UserTimelinePeriod.Validating += new System.ComponentModel.CancelEventHandler(this.UserTimeline_Validating);
             // 
             // TimelinePeriod
             // 
             resources.ApplyResources(this.TimelinePeriod, "TimelinePeriod");
             this.TimelinePeriod.Name = "TimelinePeriod";
+            this.ToolTip1.SetToolTip(this.TimelinePeriod, resources.GetString("TimelinePeriod.ToolTip"));
             this.TimelinePeriod.Validating += new System.ComponentModel.CancelEventHandler(this.TimelinePeriod_Validating);
             // 
             // Label3
             // 
             resources.ApplyResources(this.Label3, "Label3");
             this.Label3.Name = "Label3";
+            this.ToolTip1.SetToolTip(this.Label3, resources.GetString("Label3.ToolTip"));
             // 
             // ButtonApiCalc
             // 
             resources.ApplyResources(this.ButtonApiCalc, "ButtonApiCalc");
             this.ButtonApiCalc.Name = "ButtonApiCalc";
+            this.ToolTip1.SetToolTip(this.ButtonApiCalc, resources.GetString("ButtonApiCalc.ToolTip"));
             this.ButtonApiCalc.UseVisualStyleBackColor = true;
             this.ButtonApiCalc.Click += new System.EventHandler(this.ButtonApiCalc_Click);
             // 
@@ -1656,49 +1822,58 @@
             // 
             resources.ApplyResources(this.LabelPostAndGet, "LabelPostAndGet");
             this.LabelPostAndGet.Name = "LabelPostAndGet";
+            this.ToolTip1.SetToolTip(this.LabelPostAndGet, resources.GetString("LabelPostAndGet.ToolTip"));
             // 
             // LabelApiUsing
             // 
             resources.ApplyResources(this.LabelApiUsing, "LabelApiUsing");
             this.LabelApiUsing.Name = "LabelApiUsing";
+            this.ToolTip1.SetToolTip(this.LabelApiUsing, resources.GetString("LabelApiUsing.ToolTip"));
             // 
             // Label33
             // 
             resources.ApplyResources(this.Label33, "Label33");
             this.Label33.Name = "Label33";
+            this.ToolTip1.SetToolTip(this.Label33, resources.GetString("Label33.ToolTip"));
             // 
             // ListsPeriod
             // 
             resources.ApplyResources(this.ListsPeriod, "ListsPeriod");
             this.ListsPeriod.Name = "ListsPeriod";
+            this.ToolTip1.SetToolTip(this.ListsPeriod, resources.GetString("ListsPeriod.ToolTip"));
             this.ListsPeriod.Validating += new System.ComponentModel.CancelEventHandler(this.ListsPeriod_Validating);
             // 
             // Label7
             // 
             resources.ApplyResources(this.Label7, "Label7");
             this.Label7.Name = "Label7";
+            this.ToolTip1.SetToolTip(this.Label7, resources.GetString("Label7.ToolTip"));
             // 
             // PubSearchPeriod
             // 
             resources.ApplyResources(this.PubSearchPeriod, "PubSearchPeriod");
             this.PubSearchPeriod.Name = "PubSearchPeriod";
+            this.ToolTip1.SetToolTip(this.PubSearchPeriod, resources.GetString("PubSearchPeriod.ToolTip"));
             this.PubSearchPeriod.Validating += new System.ComponentModel.CancelEventHandler(this.PubSearchPeriod_Validating);
             // 
             // Label69
             // 
             resources.ApplyResources(this.Label69, "Label69");
             this.Label69.Name = "Label69";
+            this.ToolTip1.SetToolTip(this.Label69, resources.GetString("Label69.ToolTip"));
             // 
             // ReplyPeriod
             // 
             resources.ApplyResources(this.ReplyPeriod, "ReplyPeriod");
             this.ReplyPeriod.Name = "ReplyPeriod";
+            this.ToolTip1.SetToolTip(this.ReplyPeriod, resources.GetString("ReplyPeriod.ToolTip"));
             this.ReplyPeriod.Validating += new System.ComponentModel.CancelEventHandler(this.ReplyPeriod_Validating);
             // 
             // CheckPostAndGet
             // 
             resources.ApplyResources(this.CheckPostAndGet, "CheckPostAndGet");
             this.CheckPostAndGet.Name = "CheckPostAndGet";
+            this.ToolTip1.SetToolTip(this.CheckPostAndGet, resources.GetString("CheckPostAndGet.ToolTip"));
             this.CheckPostAndGet.UseVisualStyleBackColor = true;
             this.CheckPostAndGet.CheckedChanged += new System.EventHandler(this.CheckPostAndGet_CheckedChanged);
             // 
@@ -1706,27 +1881,32 @@
             // 
             resources.ApplyResources(this.CheckPeriodAdjust, "CheckPeriodAdjust");
             this.CheckPeriodAdjust.Name = "CheckPeriodAdjust";
+            this.ToolTip1.SetToolTip(this.CheckPeriodAdjust, resources.GetString("CheckPeriodAdjust.ToolTip"));
             this.CheckPeriodAdjust.UseVisualStyleBackColor = true;
             // 
             // Label5
             // 
             resources.ApplyResources(this.Label5, "Label5");
             this.Label5.Name = "Label5";
+            this.ToolTip1.SetToolTip(this.Label5, resources.GetString("Label5.ToolTip"));
             // 
             // DMPeriod
             // 
             resources.ApplyResources(this.DMPeriod, "DMPeriod");
             this.DMPeriod.Name = "DMPeriod";
+            this.ToolTip1.SetToolTip(this.DMPeriod, resources.GetString("DMPeriod.ToolTip"));
             this.DMPeriod.Validating += new System.ComponentModel.CancelEventHandler(this.DMPeriod_Validating);
             // 
             // StartupUserstreamCheck
             // 
             resources.ApplyResources(this.StartupUserstreamCheck, "StartupUserstreamCheck");
             this.StartupUserstreamCheck.Name = "StartupUserstreamCheck";
+            this.ToolTip1.SetToolTip(this.StartupUserstreamCheck, resources.GetString("StartupUserstreamCheck.ToolTip"));
             this.StartupUserstreamCheck.UseVisualStyleBackColor = true;
             // 
             // ActionPanel
             // 
+            resources.ApplyResources(this.ActionPanel, "ActionPanel");
             this.ActionPanel.Controls.Add(this.TabMouseLockCheck);
             this.ActionPanel.Controls.Add(this.Label38);
             this.ActionPanel.Controls.Add(this.ListDoubleClickActionComboBox);
@@ -1744,22 +1924,25 @@
             this.ActionPanel.Controls.Add(this.CheckCloseToExit);
             this.ActionPanel.Controls.Add(this.CheckMinimizeToTray);
             this.ActionPanel.Controls.Add(this.CheckReadOldPosts);
-            resources.ApplyResources(this.ActionPanel, "ActionPanel");
             this.ActionPanel.Name = "ActionPanel";
+            this.ToolTip1.SetToolTip(this.ActionPanel, resources.GetString("ActionPanel.ToolTip"));
             // 
             // TabMouseLockCheck
             // 
             resources.ApplyResources(this.TabMouseLockCheck, "TabMouseLockCheck");
             this.TabMouseLockCheck.Name = "TabMouseLockCheck";
+            this.ToolTip1.SetToolTip(this.TabMouseLockCheck, resources.GetString("TabMouseLockCheck.ToolTip"));
             this.TabMouseLockCheck.UseVisualStyleBackColor = true;
             // 
             // Label38
             // 
             resources.ApplyResources(this.Label38, "Label38");
             this.Label38.Name = "Label38";
+            this.ToolTip1.SetToolTip(this.Label38, resources.GetString("Label38.ToolTip"));
             // 
             // ListDoubleClickActionComboBox
             // 
+            resources.ApplyResources(this.ListDoubleClickActionComboBox, "ListDoubleClickActionComboBox");
             this.ListDoubleClickActionComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.ListDoubleClickActionComboBox.FormattingEnabled = true;
             this.ListDoubleClickActionComboBox.Items.AddRange(new object[] {
@@ -1771,17 +1954,19 @@
             resources.GetString("ListDoubleClickActionComboBox.Items5"),
             resources.GetString("ListDoubleClickActionComboBox.Items6"),
             resources.GetString("ListDoubleClickActionComboBox.Items7")});
-            resources.ApplyResources(this.ListDoubleClickActionComboBox, "ListDoubleClickActionComboBox");
             this.ListDoubleClickActionComboBox.Name = "ListDoubleClickActionComboBox";
+            this.ToolTip1.SetToolTip(this.ListDoubleClickActionComboBox, resources.GetString("ListDoubleClickActionComboBox.ToolTip"));
             // 
             // CheckOpenUserTimeline
             // 
             resources.ApplyResources(this.CheckOpenUserTimeline, "CheckOpenUserTimeline");
             this.CheckOpenUserTimeline.Name = "CheckOpenUserTimeline";
+            this.ToolTip1.SetToolTip(this.CheckOpenUserTimeline, resources.GetString("CheckOpenUserTimeline.ToolTip"));
             this.CheckOpenUserTimeline.UseVisualStyleBackColor = true;
             // 
             // GroupBox3
             // 
+            resources.ApplyResources(this.GroupBox3, "GroupBox3");
             this.GroupBox3.Controls.Add(this.HotkeyCheck);
             this.GroupBox3.Controls.Add(this.HotkeyCode);
             this.GroupBox3.Controls.Add(this.HotkeyText);
@@ -1789,14 +1974,15 @@
             this.GroupBox3.Controls.Add(this.HotkeyAlt);
             this.GroupBox3.Controls.Add(this.HotkeyShift);
             this.GroupBox3.Controls.Add(this.HotkeyCtrl);
-            resources.ApplyResources(this.GroupBox3, "GroupBox3");
             this.GroupBox3.Name = "GroupBox3";
             this.GroupBox3.TabStop = false;
+            this.ToolTip1.SetToolTip(this.GroupBox3, resources.GetString("GroupBox3.ToolTip"));
             // 
             // HotkeyCheck
             // 
             resources.ApplyResources(this.HotkeyCheck, "HotkeyCheck");
             this.HotkeyCheck.Name = "HotkeyCheck";
+            this.ToolTip1.SetToolTip(this.HotkeyCheck, resources.GetString("HotkeyCheck.ToolTip"));
             this.HotkeyCheck.UseVisualStyleBackColor = true;
             this.HotkeyCheck.CheckedChanged += new System.EventHandler(this.HotkeyCheck_CheckedChanged);
             // 
@@ -1805,36 +1991,42 @@
             resources.ApplyResources(this.HotkeyCode, "HotkeyCode");
             this.HotkeyCode.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.HotkeyCode.Name = "HotkeyCode";
+            this.ToolTip1.SetToolTip(this.HotkeyCode, resources.GetString("HotkeyCode.ToolTip"));
             // 
             // HotkeyText
             // 
             resources.ApplyResources(this.HotkeyText, "HotkeyText");
             this.HotkeyText.Name = "HotkeyText";
             this.HotkeyText.ReadOnly = true;
+            this.ToolTip1.SetToolTip(this.HotkeyText, resources.GetString("HotkeyText.ToolTip"));
             this.HotkeyText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HotkeyText_KeyDown);
             // 
             // HotkeyWin
             // 
             resources.ApplyResources(this.HotkeyWin, "HotkeyWin");
             this.HotkeyWin.Name = "HotkeyWin";
+            this.ToolTip1.SetToolTip(this.HotkeyWin, resources.GetString("HotkeyWin.ToolTip"));
             this.HotkeyWin.UseVisualStyleBackColor = true;
             // 
             // HotkeyAlt
             // 
             resources.ApplyResources(this.HotkeyAlt, "HotkeyAlt");
             this.HotkeyAlt.Name = "HotkeyAlt";
+            this.ToolTip1.SetToolTip(this.HotkeyAlt, resources.GetString("HotkeyAlt.ToolTip"));
             this.HotkeyAlt.UseVisualStyleBackColor = true;
             // 
             // HotkeyShift
             // 
             resources.ApplyResources(this.HotkeyShift, "HotkeyShift");
             this.HotkeyShift.Name = "HotkeyShift";
+            this.ToolTip1.SetToolTip(this.HotkeyShift, resources.GetString("HotkeyShift.ToolTip"));
             this.HotkeyShift.UseVisualStyleBackColor = true;
             // 
             // HotkeyCtrl
             // 
             resources.ApplyResources(this.HotkeyCtrl, "HotkeyCtrl");
             this.HotkeyCtrl.Name = "HotkeyCtrl";
+            this.ToolTip1.SetToolTip(this.HotkeyCtrl, resources.GetString("HotkeyCtrl.ToolTip"));
             this.HotkeyCtrl.UseVisualStyleBackColor = true;
             // 
             // Label57
@@ -1843,17 +2035,20 @@
             this.Label57.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Label57.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
             this.Label57.Name = "Label57";
+            this.ToolTip1.SetToolTip(this.Label57, resources.GetString("Label57.ToolTip"));
             // 
             // CheckFavRestrict
             // 
             resources.ApplyResources(this.CheckFavRestrict, "CheckFavRestrict");
             this.CheckFavRestrict.Name = "CheckFavRestrict";
+            this.ToolTip1.SetToolTip(this.CheckFavRestrict, resources.GetString("CheckFavRestrict.ToolTip"));
             this.CheckFavRestrict.UseVisualStyleBackColor = true;
             // 
             // Button3
             // 
             resources.ApplyResources(this.Button3, "Button3");
             this.Button3.Name = "Button3";
+            this.ToolTip1.SetToolTip(this.Button3, resources.GetString("Button3.ToolTip"));
             this.Button3.UseVisualStyleBackColor = true;
             this.Button3.Click += new System.EventHandler(this.Button3_Click);
             // 
@@ -1861,30 +2056,35 @@
             // 
             resources.ApplyResources(this.PlaySnd, "PlaySnd");
             this.PlaySnd.Name = "PlaySnd";
+            this.ToolTip1.SetToolTip(this.PlaySnd, resources.GetString("PlaySnd.ToolTip"));
             this.PlaySnd.UseVisualStyleBackColor = true;
             // 
             // chkReadOwnPost
             // 
             resources.ApplyResources(this.chkReadOwnPost, "chkReadOwnPost");
             this.chkReadOwnPost.Name = "chkReadOwnPost";
+            this.ToolTip1.SetToolTip(this.chkReadOwnPost, resources.GetString("chkReadOwnPost.ToolTip"));
             this.chkReadOwnPost.UseVisualStyleBackColor = true;
             // 
             // Label15
             // 
+            resources.ApplyResources(this.Label15, "Label15");
             this.Label15.BackColor = System.Drawing.SystemColors.ActiveCaption;
             this.Label15.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
-            resources.ApplyResources(this.Label15, "Label15");
             this.Label15.Name = "Label15";
+            this.ToolTip1.SetToolTip(this.Label15, resources.GetString("Label15.ToolTip"));
             // 
             // BrowserPathText
             // 
             resources.ApplyResources(this.BrowserPathText, "BrowserPathText");
             this.BrowserPathText.Name = "BrowserPathText";
+            this.ToolTip1.SetToolTip(this.BrowserPathText, resources.GetString("BrowserPathText.ToolTip"));
             // 
             // UReadMng
             // 
             resources.ApplyResources(this.UReadMng, "UReadMng");
             this.UReadMng.Name = "UReadMng";
+            this.ToolTip1.SetToolTip(this.UReadMng, resources.GetString("UReadMng.ToolTip"));
             this.UReadMng.UseVisualStyleBackColor = true;
             this.UReadMng.CheckedChanged += new System.EventHandler(this.UReadMng_CheckedChanged);
             // 
@@ -1892,33 +2092,39 @@
             // 
             resources.ApplyResources(this.Label44, "Label44");
             this.Label44.Name = "Label44";
+            this.ToolTip1.SetToolTip(this.Label44, resources.GetString("Label44.ToolTip"));
             // 
             // CheckCloseToExit
             // 
             resources.ApplyResources(this.CheckCloseToExit, "CheckCloseToExit");
             this.CheckCloseToExit.Name = "CheckCloseToExit";
+            this.ToolTip1.SetToolTip(this.CheckCloseToExit, resources.GetString("CheckCloseToExit.ToolTip"));
             this.CheckCloseToExit.UseVisualStyleBackColor = true;
             // 
             // CheckMinimizeToTray
             // 
             resources.ApplyResources(this.CheckMinimizeToTray, "CheckMinimizeToTray");
             this.CheckMinimizeToTray.Name = "CheckMinimizeToTray";
+            this.ToolTip1.SetToolTip(this.CheckMinimizeToTray, resources.GetString("CheckMinimizeToTray.ToolTip"));
             this.CheckMinimizeToTray.UseVisualStyleBackColor = true;
             // 
             // CheckReadOldPosts
             // 
             resources.ApplyResources(this.CheckReadOldPosts, "CheckReadOldPosts");
             this.CheckReadOldPosts.Name = "CheckReadOldPosts";
+            this.ToolTip1.SetToolTip(this.CheckReadOldPosts, resources.GetString("CheckReadOldPosts.ToolTip"));
             this.CheckReadOldPosts.UseVisualStyleBackColor = true;
             // 
             // FontPanel
             // 
-            this.FontPanel.Controls.Add(this.GroupBox1);
             resources.ApplyResources(this.FontPanel, "FontPanel");
+            this.FontPanel.Controls.Add(this.GroupBox1);
             this.FontPanel.Name = "FontPanel";
+            this.ToolTip1.SetToolTip(this.FontPanel, resources.GetString("FontPanel.ToolTip"));
             // 
             // GroupBox1
             // 
+            resources.ApplyResources(this.GroupBox1, "GroupBox1");
             this.GroupBox1.Controls.Add(this.btnRetweet);
             this.GroupBox1.Controls.Add(this.lblRetweet);
             this.GroupBox1.Controls.Add(this.Label80);
@@ -1944,32 +2150,36 @@
             this.GroupBox1.Controls.Add(this.btnListFont);
             this.GroupBox1.Controls.Add(this.lblListFont);
             this.GroupBox1.Controls.Add(this.Label61);
-            resources.ApplyResources(this.GroupBox1, "GroupBox1");
             this.GroupBox1.Name = "GroupBox1";
             this.GroupBox1.TabStop = false;
+            this.ToolTip1.SetToolTip(this.GroupBox1, resources.GetString("GroupBox1.ToolTip"));
             // 
             // btnRetweet
             // 
             resources.ApplyResources(this.btnRetweet, "btnRetweet");
             this.btnRetweet.Name = "btnRetweet";
+            this.ToolTip1.SetToolTip(this.btnRetweet, resources.GetString("btnRetweet.ToolTip"));
             this.btnRetweet.UseVisualStyleBackColor = true;
             this.btnRetweet.Click += new System.EventHandler(this.btnColor_Click);
             // 
             // lblRetweet
             // 
-            this.lblRetweet.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblRetweet, "lblRetweet");
+            this.lblRetweet.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblRetweet.Name = "lblRetweet";
+            this.ToolTip1.SetToolTip(this.lblRetweet, resources.GetString("lblRetweet.ToolTip"));
             // 
             // Label80
             // 
             resources.ApplyResources(this.Label80, "Label80");
             this.Label80.Name = "Label80";
+            this.ToolTip1.SetToolTip(this.Label80, resources.GetString("Label80.ToolTip"));
             // 
             // ButtonBackToDefaultFontColor
             // 
             resources.ApplyResources(this.ButtonBackToDefaultFontColor, "ButtonBackToDefaultFontColor");
             this.ButtonBackToDefaultFontColor.Name = "ButtonBackToDefaultFontColor";
+            this.ToolTip1.SetToolTip(this.ButtonBackToDefaultFontColor, resources.GetString("ButtonBackToDefaultFontColor.ToolTip"));
             this.ButtonBackToDefaultFontColor.UseVisualStyleBackColor = true;
             this.ButtonBackToDefaultFontColor.Click += new System.EventHandler(this.ButtonBackToDefaultFontColor_Click);
             // 
@@ -1977,136 +2187,159 @@
             // 
             resources.ApplyResources(this.btnDetailLink, "btnDetailLink");
             this.btnDetailLink.Name = "btnDetailLink";
+            this.ToolTip1.SetToolTip(this.btnDetailLink, resources.GetString("btnDetailLink.ToolTip"));
             this.btnDetailLink.UseVisualStyleBackColor = true;
             this.btnDetailLink.Click += new System.EventHandler(this.btnColor_Click);
             // 
             // lblDetailLink
             // 
-            this.lblDetailLink.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblDetailLink, "lblDetailLink");
+            this.lblDetailLink.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblDetailLink.Name = "lblDetailLink";
+            this.ToolTip1.SetToolTip(this.lblDetailLink, resources.GetString("lblDetailLink.ToolTip"));
             // 
             // Label18
             // 
             resources.ApplyResources(this.Label18, "Label18");
             this.Label18.Name = "Label18";
+            this.ToolTip1.SetToolTip(this.Label18, resources.GetString("Label18.ToolTip"));
             // 
             // btnUnread
             // 
             resources.ApplyResources(this.btnUnread, "btnUnread");
             this.btnUnread.Name = "btnUnread";
+            this.ToolTip1.SetToolTip(this.btnUnread, resources.GetString("btnUnread.ToolTip"));
             this.btnUnread.UseVisualStyleBackColor = true;
             this.btnUnread.Click += new System.EventHandler(this.btnFontAndColor_Click);
             // 
             // lblUnread
             // 
-            this.lblUnread.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblUnread, "lblUnread");
+            this.lblUnread.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblUnread.Name = "lblUnread";
+            this.ToolTip1.SetToolTip(this.lblUnread, resources.GetString("lblUnread.ToolTip"));
             // 
             // Label20
             // 
             resources.ApplyResources(this.Label20, "Label20");
             this.Label20.Name = "Label20";
+            this.ToolTip1.SetToolTip(this.Label20, resources.GetString("Label20.ToolTip"));
             // 
             // btnDetailBack
             // 
             resources.ApplyResources(this.btnDetailBack, "btnDetailBack");
             this.btnDetailBack.Name = "btnDetailBack";
+            this.ToolTip1.SetToolTip(this.btnDetailBack, resources.GetString("btnDetailBack.ToolTip"));
             this.btnDetailBack.UseVisualStyleBackColor = true;
             this.btnDetailBack.Click += new System.EventHandler(this.btnColor_Click);
             // 
             // lblDetailBackcolor
             // 
-            this.lblDetailBackcolor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblDetailBackcolor, "lblDetailBackcolor");
+            this.lblDetailBackcolor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblDetailBackcolor.Name = "lblDetailBackcolor";
+            this.ToolTip1.SetToolTip(this.lblDetailBackcolor, resources.GetString("lblDetailBackcolor.ToolTip"));
             // 
             // Label37
             // 
             resources.ApplyResources(this.Label37, "Label37");
             this.Label37.Name = "Label37";
+            this.ToolTip1.SetToolTip(this.Label37, resources.GetString("Label37.ToolTip"));
             // 
             // btnDetail
             // 
             resources.ApplyResources(this.btnDetail, "btnDetail");
             this.btnDetail.Name = "btnDetail";
+            this.ToolTip1.SetToolTip(this.btnDetail, resources.GetString("btnDetail.ToolTip"));
             this.btnDetail.UseVisualStyleBackColor = true;
             this.btnDetail.Click += new System.EventHandler(this.btnFontAndColor_Click);
             // 
             // lblDetail
             // 
-            this.lblDetail.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblDetail, "lblDetail");
+            this.lblDetail.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblDetail.Name = "lblDetail";
+            this.ToolTip1.SetToolTip(this.lblDetail, resources.GetString("lblDetail.ToolTip"));
             // 
             // Label26
             // 
             resources.ApplyResources(this.Label26, "Label26");
             this.Label26.Name = "Label26";
+            this.ToolTip1.SetToolTip(this.Label26, resources.GetString("Label26.ToolTip"));
             // 
             // btnOWL
             // 
             resources.ApplyResources(this.btnOWL, "btnOWL");
             this.btnOWL.Name = "btnOWL";
+            this.ToolTip1.SetToolTip(this.btnOWL, resources.GetString("btnOWL.ToolTip"));
             this.btnOWL.UseVisualStyleBackColor = true;
             this.btnOWL.Click += new System.EventHandler(this.btnColor_Click);
             // 
             // lblOWL
             // 
-            this.lblOWL.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblOWL, "lblOWL");
+            this.lblOWL.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblOWL.Name = "lblOWL";
+            this.ToolTip1.SetToolTip(this.lblOWL, resources.GetString("lblOWL.ToolTip"));
             // 
             // Label24
             // 
             resources.ApplyResources(this.Label24, "Label24");
             this.Label24.Name = "Label24";
+            this.ToolTip1.SetToolTip(this.Label24, resources.GetString("Label24.ToolTip"));
             // 
             // btnFav
             // 
             resources.ApplyResources(this.btnFav, "btnFav");
             this.btnFav.Name = "btnFav";
+            this.ToolTip1.SetToolTip(this.btnFav, resources.GetString("btnFav.ToolTip"));
             this.btnFav.UseVisualStyleBackColor = true;
             this.btnFav.Click += new System.EventHandler(this.btnColor_Click);
             // 
             // lblFav
             // 
-            this.lblFav.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblFav, "lblFav");
+            this.lblFav.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblFav.Name = "lblFav";
+            this.ToolTip1.SetToolTip(this.lblFav, resources.GetString("lblFav.ToolTip"));
             // 
             // Label22
             // 
             resources.ApplyResources(this.Label22, "Label22");
             this.Label22.Name = "Label22";
+            this.ToolTip1.SetToolTip(this.Label22, resources.GetString("Label22.ToolTip"));
             // 
             // btnListFont
             // 
             resources.ApplyResources(this.btnListFont, "btnListFont");
             this.btnListFont.Name = "btnListFont";
+            this.ToolTip1.SetToolTip(this.btnListFont, resources.GetString("btnListFont.ToolTip"));
             this.btnListFont.UseVisualStyleBackColor = true;
             this.btnListFont.Click += new System.EventHandler(this.btnFontAndColor_Click);
             // 
             // lblListFont
             // 
-            this.lblListFont.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblListFont, "lblListFont");
+            this.lblListFont.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblListFont.Name = "lblListFont";
+            this.ToolTip1.SetToolTip(this.lblListFont, resources.GetString("lblListFont.ToolTip"));
             // 
             // Label61
             // 
             resources.ApplyResources(this.Label61, "Label61");
             this.Label61.Name = "Label61";
+            this.ToolTip1.SetToolTip(this.Label61, resources.GetString("Label61.ToolTip"));
             // 
             // FontPanel2
             // 
-            this.FontPanel2.Controls.Add(this.GroupBox5);
             resources.ApplyResources(this.FontPanel2, "FontPanel2");
+            this.FontPanel2.Controls.Add(this.GroupBox5);
             this.FontPanel2.Name = "FontPanel2";
+            this.ToolTip1.SetToolTip(this.FontPanel2, resources.GetString("FontPanel2.ToolTip"));
             // 
             // GroupBox5
             // 
+            resources.ApplyResources(this.GroupBox5, "GroupBox5");
             this.GroupBox5.Controls.Add(this.Label65);
             this.GroupBox5.Controls.Add(this.Label52);
             this.GroupBox5.Controls.Add(this.Label49);
@@ -2135,59 +2368,69 @@
             this.GroupBox5.Controls.Add(this.lblAtSelf);
             this.GroupBox5.Controls.Add(this.lblSelf);
             this.GroupBox5.Controls.Add(this.ButtonBackToDefaultFontColor2);
-            resources.ApplyResources(this.GroupBox5, "GroupBox5");
             this.GroupBox5.Name = "GroupBox5";
             this.GroupBox5.TabStop = false;
+            this.ToolTip1.SetToolTip(this.GroupBox5, resources.GetString("GroupBox5.ToolTip"));
             // 
             // Label65
             // 
             resources.ApplyResources(this.Label65, "Label65");
             this.Label65.Name = "Label65";
+            this.ToolTip1.SetToolTip(this.Label65, resources.GetString("Label65.ToolTip"));
             // 
             // Label52
             // 
             resources.ApplyResources(this.Label52, "Label52");
             this.Label52.Name = "Label52";
+            this.ToolTip1.SetToolTip(this.Label52, resources.GetString("Label52.ToolTip"));
             // 
             // Label49
             // 
             resources.ApplyResources(this.Label49, "Label49");
             this.Label49.Name = "Label49";
+            this.ToolTip1.SetToolTip(this.Label49, resources.GetString("Label49.ToolTip"));
             // 
             // Label9
             // 
             resources.ApplyResources(this.Label9, "Label9");
             this.Label9.Name = "Label9";
+            this.ToolTip1.SetToolTip(this.Label9, resources.GetString("Label9.ToolTip"));
             // 
             // Label14
             // 
             resources.ApplyResources(this.Label14, "Label14");
             this.Label14.Name = "Label14";
+            this.ToolTip1.SetToolTip(this.Label14, resources.GetString("Label14.ToolTip"));
             // 
             // Label16
             // 
             resources.ApplyResources(this.Label16, "Label16");
             this.Label16.Name = "Label16";
+            this.ToolTip1.SetToolTip(this.Label16, resources.GetString("Label16.ToolTip"));
             // 
             // Label32
             // 
             resources.ApplyResources(this.Label32, "Label32");
             this.Label32.Name = "Label32";
+            this.ToolTip1.SetToolTip(this.Label32, resources.GetString("Label32.ToolTip"));
             // 
             // Label34
             // 
             resources.ApplyResources(this.Label34, "Label34");
             this.Label34.Name = "Label34";
+            this.ToolTip1.SetToolTip(this.Label34, resources.GetString("Label34.ToolTip"));
             // 
             // Label36
             // 
             resources.ApplyResources(this.Label36, "Label36");
             this.Label36.Name = "Label36";
+            this.ToolTip1.SetToolTip(this.Label36, resources.GetString("Label36.ToolTip"));
             // 
             // btnInputFont
             // 
             resources.ApplyResources(this.btnInputFont, "btnInputFont");
             this.btnInputFont.Name = "btnInputFont";
+            this.ToolTip1.SetToolTip(this.btnInputFont, resources.GetString("btnInputFont.ToolTip"));
             this.btnInputFont.UseVisualStyleBackColor = true;
             this.btnInputFont.Click += new System.EventHandler(this.btnFontAndColor_Click);
             // 
@@ -2195,6 +2438,7 @@
             // 
             resources.ApplyResources(this.btnInputBackcolor, "btnInputBackcolor");
             this.btnInputBackcolor.Name = "btnInputBackcolor";
+            this.ToolTip1.SetToolTip(this.btnInputBackcolor, resources.GetString("btnInputBackcolor.ToolTip"));
             this.btnInputBackcolor.UseVisualStyleBackColor = true;
             this.btnInputBackcolor.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2202,6 +2446,7 @@
             // 
             resources.ApplyResources(this.btnAtTo, "btnAtTo");
             this.btnAtTo.Name = "btnAtTo";
+            this.ToolTip1.SetToolTip(this.btnAtTo, resources.GetString("btnAtTo.ToolTip"));
             this.btnAtTo.UseVisualStyleBackColor = true;
             this.btnAtTo.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2209,6 +2454,7 @@
             // 
             resources.ApplyResources(this.btnListBack, "btnListBack");
             this.btnListBack.Name = "btnListBack";
+            this.ToolTip1.SetToolTip(this.btnListBack, resources.GetString("btnListBack.ToolTip"));
             this.btnListBack.UseVisualStyleBackColor = true;
             this.btnListBack.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2216,6 +2462,7 @@
             // 
             resources.ApplyResources(this.btnAtFromTarget, "btnAtFromTarget");
             this.btnAtFromTarget.Name = "btnAtFromTarget";
+            this.ToolTip1.SetToolTip(this.btnAtFromTarget, resources.GetString("btnAtFromTarget.ToolTip"));
             this.btnAtFromTarget.UseVisualStyleBackColor = true;
             this.btnAtFromTarget.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2223,6 +2470,7 @@
             // 
             resources.ApplyResources(this.btnAtTarget, "btnAtTarget");
             this.btnAtTarget.Name = "btnAtTarget";
+            this.ToolTip1.SetToolTip(this.btnAtTarget, resources.GetString("btnAtTarget.ToolTip"));
             this.btnAtTarget.UseVisualStyleBackColor = true;
             this.btnAtTarget.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2230,6 +2478,7 @@
             // 
             resources.ApplyResources(this.btnTarget, "btnTarget");
             this.btnTarget.Name = "btnTarget";
+            this.ToolTip1.SetToolTip(this.btnTarget, resources.GetString("btnTarget.ToolTip"));
             this.btnTarget.UseVisualStyleBackColor = true;
             this.btnTarget.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2237,6 +2486,7 @@
             // 
             resources.ApplyResources(this.btnAtSelf, "btnAtSelf");
             this.btnAtSelf.Name = "btnAtSelf";
+            this.ToolTip1.SetToolTip(this.btnAtSelf, resources.GetString("btnAtSelf.ToolTip"));
             this.btnAtSelf.UseVisualStyleBackColor = true;
             this.btnAtSelf.Click += new System.EventHandler(this.btnColor_Click);
             // 
@@ -2244,84 +2494,97 @@
             // 
             resources.ApplyResources(this.btnSelf, "btnSelf");
             this.btnSelf.Name = "btnSelf";
+            this.ToolTip1.SetToolTip(this.btnSelf, resources.GetString("btnSelf.ToolTip"));
             this.btnSelf.UseVisualStyleBackColor = true;
             this.btnSelf.Click += new System.EventHandler(this.btnColor_Click);
             // 
             // lblInputFont
             // 
-            this.lblInputFont.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblInputFont, "lblInputFont");
+            this.lblInputFont.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblInputFont.Name = "lblInputFont";
+            this.ToolTip1.SetToolTip(this.lblInputFont, resources.GetString("lblInputFont.ToolTip"));
             // 
             // lblInputBackcolor
             // 
-            this.lblInputBackcolor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblInputBackcolor, "lblInputBackcolor");
+            this.lblInputBackcolor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblInputBackcolor.Name = "lblInputBackcolor";
+            this.ToolTip1.SetToolTip(this.lblInputBackcolor, resources.GetString("lblInputBackcolor.ToolTip"));
             // 
             // lblAtTo
             // 
-            this.lblAtTo.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblAtTo, "lblAtTo");
+            this.lblAtTo.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblAtTo.Name = "lblAtTo";
+            this.ToolTip1.SetToolTip(this.lblAtTo, resources.GetString("lblAtTo.ToolTip"));
             // 
             // lblListBackcolor
             // 
-            this.lblListBackcolor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblListBackcolor, "lblListBackcolor");
+            this.lblListBackcolor.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblListBackcolor.Name = "lblListBackcolor";
+            this.ToolTip1.SetToolTip(this.lblListBackcolor, resources.GetString("lblListBackcolor.ToolTip"));
             // 
             // lblAtFromTarget
             // 
-            this.lblAtFromTarget.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblAtFromTarget, "lblAtFromTarget");
+            this.lblAtFromTarget.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblAtFromTarget.Name = "lblAtFromTarget";
+            this.ToolTip1.SetToolTip(this.lblAtFromTarget, resources.GetString("lblAtFromTarget.ToolTip"));
             // 
             // lblAtTarget
             // 
-            this.lblAtTarget.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblAtTarget, "lblAtTarget");
+            this.lblAtTarget.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblAtTarget.Name = "lblAtTarget";
+            this.ToolTip1.SetToolTip(this.lblAtTarget, resources.GetString("lblAtTarget.ToolTip"));
             // 
             // lblTarget
             // 
-            this.lblTarget.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblTarget, "lblTarget");
+            this.lblTarget.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblTarget.Name = "lblTarget";
+            this.ToolTip1.SetToolTip(this.lblTarget, resources.GetString("lblTarget.ToolTip"));
             // 
             // lblAtSelf
             // 
-            this.lblAtSelf.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblAtSelf, "lblAtSelf");
+            this.lblAtSelf.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblAtSelf.Name = "lblAtSelf";
+            this.ToolTip1.SetToolTip(this.lblAtSelf, resources.GetString("lblAtSelf.ToolTip"));
             // 
             // lblSelf
             // 
-            this.lblSelf.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             resources.ApplyResources(this.lblSelf, "lblSelf");
+            this.lblSelf.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.lblSelf.Name = "lblSelf";
+            this.ToolTip1.SetToolTip(this.lblSelf, resources.GetString("lblSelf.ToolTip"));
             // 
             // ButtonBackToDefaultFontColor2
             // 
             resources.ApplyResources(this.ButtonBackToDefaultFontColor2, "ButtonBackToDefaultFontColor2");
             this.ButtonBackToDefaultFontColor2.Name = "ButtonBackToDefaultFontColor2";
+            this.ToolTip1.SetToolTip(this.ButtonBackToDefaultFontColor2, resources.GetString("ButtonBackToDefaultFontColor2.ToolTip"));
             this.ButtonBackToDefaultFontColor2.UseVisualStyleBackColor = true;
             this.ButtonBackToDefaultFontColor2.Click += new System.EventHandler(this.ButtonBackToDefaultFontColor_Click);
             // 
             // Save
             // 
-            this.Save.DialogResult = System.Windows.Forms.DialogResult.OK;
             resources.ApplyResources(this.Save, "Save");
+            this.Save.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.Save.Name = "Save";
+            this.ToolTip1.SetToolTip(this.Save, resources.GetString("Save.ToolTip"));
             this.Save.UseVisualStyleBackColor = true;
             this.Save.Click += new System.EventHandler(this.Save_Click);
             // 
             // Cancel
             // 
+            resources.ApplyResources(this.Cancel, "Cancel");
             this.Cancel.CausesValidation = false;
             this.Cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            resources.ApplyResources(this.Cancel, "Cancel");
             this.Cancel.Name = "Cancel";
+            this.ToolTip1.SetToolTip(this.Cancel, resources.GetString("Cancel.ToolTip"));
             this.Cancel.UseVisualStyleBackColor = true;
             this.Cancel.Click += new System.EventHandler(this.Cancel_Click);
             // 
@@ -2337,6 +2600,7 @@
             this.MinimizeBox = false;
             this.Name = "AppendSettingDialog";
             this.ShowInTaskbar = false;
+            this.ToolTip1.SetToolTip(this, resources.GetString("$this.ToolTip"));
             this.TopMost = true;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Setting_FormClosing);
             this.Load += new System.EventHandler(this.Setting_Load);
@@ -2649,5 +2913,6 @@
         internal System.Windows.Forms.FontDialog FontDialog1;
         private System.Windows.Forms.ComboBox MapThumbnailProviderComboBox;
         private System.Windows.Forms.Label label48;
+        internal System.Windows.Forms.CheckBox CheckViewTabBottom;
     }
 }

--- a/OpenTween/AppendSettingDialog.cs
+++ b/OpenTween/AppendSettingDialog.cs
@@ -368,6 +368,7 @@ namespace OpenTween
                         break;
                 }
                 SortOrderLock = CheckSortOrderLock.Checked;
+                ViewTabBottom = CheckViewTabBottom.Checked;
                 TinyUrlResolve = CheckTinyURL.Checked;
                 ShortUrlForceResolve = CheckForceResolve.Checked;
                 ShortUrl.IsResolve = TinyUrlResolve;
@@ -735,6 +736,7 @@ namespace OpenTween
                     break;
             }
             CheckSortOrderLock.Checked = SortOrderLock;
+            CheckViewTabBottom.Checked = ViewTabBottom;
             CheckTinyURL.Checked = TinyUrlResolve;
             CheckForceResolve.Checked = ShortUrlForceResolve;
             switch (_MyProxyType)
@@ -1349,6 +1351,10 @@ namespace OpenTween
                 _MyProxyType = value;
             }
         }
+        /// <summary>
+        /// タブを下部に表示するかどうかを取得または設定する
+        /// </summary>
+        public bool ViewTabBottom { get; set; }
 
         public string ProxyAddress { get; set; }
         public int ProxyPort { get; set; }

--- a/OpenTween/AppendSettingDialog.en.resx
+++ b/OpenTween/AppendSettingDialog.en.resx
@@ -121,230 +121,101 @@
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQsAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIBAQAAAQABAAQEBAEICAgdU3lzdGVtLldpbmRvd3MuRm9y
-        bXMuVHJlZU5vZGUCAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2lu
-        ZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMAAAAHR2VuZXJhbAYEAAAACUJhc2VkTm9kZQD/////
-        BgUAAAAA/////wkFAAAAAwAAAAkGAAAACQcAAAAJCAAAAAUGAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1z
-        LlRyZWVOb2RlCAAAAARUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0
-        ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAAABAAEAAQgICAIAAAAGCQAA
-        AAhJbnRlcnZhbAYKAAAAClBlcmlvZE5vZGUA/////wkFAAAA/////wkFAAAAAAAAAAUHAAAAHVN5c3Rl
-        bS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCAAAAARUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgI
-        SW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAAAB
-        AAEAAQgICAIAAAAGDAAAAAdTdGFydHVwBg0AAAALU3RhcnRVcE5vZGUA/////wkFAAAA/////wkFAAAA
-        AAAAAAUIAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCAAAAARUZXh0BE5hbWUJSXNDaGVj
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQwAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIBAQEAAAEAAQAEBAQBCAgIHVN5c3Rl
+        bS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIA
+        AAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUCAAAAAgAAAAYDAAAAB0dlbmVyYWwGBAAAAAAG
+        BQAAAAlCYXNlZE5vZGUA/////wkEAAAA/////wkEAAAAAwAAAAkHAAAACQgAAAAJCQAAAAUHAAAAHVN5
+        c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCQAAAARUZXh0C1Rvb2xUaXBUZXh0BE5hbWUJSXNDaGVj
         a2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkK
-        Q2hpbGRDb3VudAEBAAABAAEAAQgICAIAAAAGDwAAAAZDb3VudHMGEAAAAAxHZXRDb3VudE5vZGUA////
-        /wkFAAAA/////wkFAAAAAAAAAAs=
+        Q2hpbGRDb3VudAEBAQAAAQABAAEICAgCAAAABgoAAAAISW50ZXJ2YWwJBAAAAAYMAAAAClBlcmlvZE5v
+        ZGUA/////wkEAAAA/////wkEAAAAAAAAAAUIAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2Rl
+        CQAAAARUZXh0C1Rvb2xUaXBUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2Vs
+        ZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAQAAAQABAAEICAgCAAAA
+        Bg4AAAAHU3RhcnR1cAkEAAAABhAAAAALU3RhcnRVcE5vZGUA/////wkEAAAA/////wkEAAAAAAAAAAUJ
+        AAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCQAAAARUZXh0C1Rvb2xUaXBUZXh0BE5hbWUJ
+        SXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1h
+        Z2VLZXkKQ2hpbGRDb3VudAEBAQAAAQABAAEICAgCAAAABhIAAAAGQ291bnRzCQQAAAAGFAAAAAxHZXRD
+        b3VudE5vZGUA/////wkEAAAA/////wkEAAAAAAAAAAs=
 </value>
   </data>
   <data name="TreeViewSetting.Nodes1" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQkAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wAQEAAAEAAQAEAQgICB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMA
-        AAAIQmVoYXZpb3IGBAAAAApBY3Rpb25Ob2RlAP////8GBQAAAAD/////CQUAAAABAAAACQYAAAAFBgAA
-        AB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQgAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFn
-        ZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291
-        bnQBAQAAAQABAAEICAgCAAAABgcAAAAKUG9zdCB0d2VldAYIAAAADFR3ZWV0QWN0Tm9kZQD/////CQUA
-        AAD/////CQUAAAAAAAAACw==
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQoAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wAQEBAAABAAEABAEICAgdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5v
+        ZGUCAAAAAgAAAAYDAAAACEJlaGF2aW9yBgQAAAAABgUAAAAKQWN0aW9uTm9kZQD/////CQQAAAD/////
+        CQQAAAABAAAACQcAAAAFBwAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQkAAAAEVGV4dAtU
+        b29sVGlwVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJ
+        bmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQBAQEAAAEAAQABCAgIAgAAAAYIAAAAClBvc3Qg
+        dHdlZXQJBAAAAAYKAAAADFR3ZWV0QWN0Tm9kZQD/////CQQAAAD/////CQQAAAAAAAAACw==
 </value>
   </data>
   <data name="TreeViewSetting.Nodes2" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQoAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wCWNoaWxkcmVuMQEBAAABAAEABAQBCAgIHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2Rl
-        AgAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMAAAAHRGlzcGxheQYEAAAA
-        C1ByZXZpZXdOb2RlAP////8GBQAAAAD/////CQUAAAACAAAACQYAAAAJBwAAAAUGAAAAHVN5c3RlbS5X
-        aW5kb3dzLkZvcm1zLlRyZWVOb2RlCAAAAARUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1h
-        Z2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAAABAAEA
-        AQgICAIAAAAGCAAAAAVMaXN0cwYJAAAADFR3ZWV0UHJ2Tm9kZQD/////CQUAAAD/////CQUAAAAAAAAA
-        BQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQK
-        SW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGls
-        ZENvdW50AQEAAAEAAQABCAgIAgAAAAYLAAAAEkV2ZW50IE5vdGlmaWNhdGlvbgYMAAAACk5vdGlmeU5v
-        ZGUA/////wkFAAAA/////wkFAAAAAAAAAAs=
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQsAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wCWNoaWxkcmVuMQEBAQAAAQABAAQEAQgICB1TeXN0ZW0uV2luZG93cy5G
+        b3Jtcy5UcmVlTm9kZQIAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUCAAAAAgAAAAYDAAAA
+        B0Rpc3BsYXkGBAAAAAAGBQAAAAtQcmV2aWV3Tm9kZQD/////CQQAAAD/////CQQAAAACAAAACQcAAAAJ
+        CAAAAAUHAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCQAAAARUZXh0C1Rvb2xUaXBUZXh0
+        BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVj
+        dGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAQAAAQABAAEICAgCAAAABgkAAAAFTGlzdHMJBAAAAAYLAAAA
+        DFR3ZWV0UHJ2Tm9kZQD/////CQQAAAD/////CQQAAAAAAAAABQgAAAAdU3lzdGVtLldpbmRvd3MuRm9y
+        bXMuVHJlZU5vZGUJAAAABFRleHQLVG9vbFRpcFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJ
+        bWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAAB
+        AAEAAQgICAIAAAAGDQAAABJFdmVudCBOb3RpZmljYXRpb24JBAAAAAYPAAAACk5vdGlmeU5vZGUA////
+        /wkEAAAA/////wkEAAAAAAAAAAs=
 </value>
   </data>
   <data name="TreeViewSetting.Nodes3" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQkAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wAQEAAAEAAQAEAQgICB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMA
-        AAAFRm9udHMGBAAAAAhGb250Tm9kZQD/////BgUAAAAA/////wkFAAAAAQAAAAkGAAAABQYAAAAdU3lz
-        dGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRl
-        eAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEA
-        AAEAAQABCAgIAgAAAAYHAAAAC0JhY2tncm91bmRzBggAAAAJRm9udE5vZGUyAP////8JBQAAAP////8J
-        BQAAAAAAAAAL
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQoAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wAQEBAAABAAEABAEICAgdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5v
+        ZGUCAAAAAgAAAAYDAAAABUZvbnRzBgQAAAAABgUAAAAIRm9udE5vZGUA/////wkEAAAA/////wkEAAAA
+        AQAAAAkHAAAABQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUJAAAABFRleHQLVG9vbFRp
+        cFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQ
+        U2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIAAAAGCAAAAAtCYWNrZ3JvdW5k
+        cwkEAAAABgoAAAAJRm9udE5vZGUyAP////8JBAAAAP////8JBAAAAAAAAAAL
 </value>
   </data>
   <data name="TreeViewSetting.Nodes4" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQsAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIBAQAAAQABAAQEBAEICAgdU3lzdGVtLldpbmRvd3MuRm9y
-        bXMuVHJlZU5vZGUCAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2lu
-        ZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMAAAAKQ29ubmVjdGlvbgYEAAAADkNvbm5lY3Rpb25O
-        b2RlAP////8GBQAAAAD/////CQUAAAADAAAACQYAAAAJBwAAAAkIAAAABQYAAAAdU3lzdGVtLldpbmRv
-        d3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtl
-        eRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEAAAEAAQABCAgI
-        AgAAAAYJAAAABVByb3h5BgoAAAAJUHJveHlOb2RlAP////8JBQAAAP////8JBQAAAAAAAAAFBwAAAB1T
-        eXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQgAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUlu
-        ZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQB
-        AQAAAQABAAEICAgCAAAABgwAAAATQ29vcGVyYXRpdmUgU2VydmljZQYNAAAADUNvb3BlcmF0ZU5vZGUA
-        /////wkFAAAA/////wkFAAAAAAAAAAUIAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCAAA
-        AARUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4
-        EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAAABAAEAAQgICAIAAAAGDwAAAAtTaG9ydGVuIFVS
-        TAYQAAAADFNob3J0VXJsTm9kZQD/////CQUAAAD/////CQUAAAAAAAAACw==
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQwAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIBAQEAAAEAAQAEBAQBCAgIHVN5c3Rl
+        bS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIA
+        AAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUCAAAAAgAAAAYDAAAACkNvbm5lY3Rpb24GBAAA
+        AAAGBQAAAA5Db25uZWN0aW9uTm9kZQD/////CQQAAAD/////CQQAAAADAAAACQcAAAAJCAAAAAkJAAAA
+        BQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUJAAAABFRleHQLVG9vbFRpcFRleHQETmFt
+        ZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJ
+        bWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIAAAAGCgAAAAVQcm94eQkEAAAABgwAAAAJUHJv
+        eHlOb2RlAP////8JBAAAAP////8JBAAAAAAAAAAFCAAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVl
+        Tm9kZQkAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4CEltYWdlS2V5
+        ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQBAQEAAAEAAQABCAgI
+        AgAAAAYOAAAAE0Nvb3BlcmF0aXZlIFNlcnZpY2UJBAAAAAYQAAAADUNvb3BlcmF0ZU5vZGUA/////wkE
+        AAAA/////wkEAAAAAAAAAAUJAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCQAAAARUZXh0
+        C1Rvb2xUaXBUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFn
+        ZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAQAAAQABAAEICAgCAAAABhIAAAALU2hv
+        cnRlbiBVUkwJBAAAAAYUAAAADFNob3J0VXJsTm9kZQD/////CQQAAAD/////CQQAAAAAAAAACw==
 </value>
   </data>
-  <data name="TreeViewSetting.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="SplitContainer1.Panel1.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="IsPreviewFoursquareCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>239, 16</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.Text" xml:space="preserve">
-    <value>Get map thumbnails from Foursquare urls.</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="MapThumbnailProviderComboBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 12</value>
-  </data>
-  <data name="label48.Text" xml:space="preserve">
-    <value>Map Provider</value>
-  </data>
-  <data name="label48.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label42.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="MapThumbnailWidthTextBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="MapThumbnailZoomTextBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="MapThumbnailHeightTextBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label41.Text" xml:space="preserve">
-    <value>Zoom Level</value>
-  </data>
-  <data name="Label41.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 12</value>
-  </data>
-  <data name="Label40.Text" xml:space="preserve">
-    <value>Thumbnail Size</value>
-  </data>
-  <data name="Label40.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="MapThumbnailGroupBox.Text" xml:space="preserve">
-    <value>Map Thumbnail</value>
-  </data>
-  <data name="MapThumbnailGroupBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label39.Size" type="System.Drawing.Size, System.Drawing">
-    <value>299, 12</value>
-  </data>
-  <data name="Label39.Text" xml:space="preserve">
-    <value>Your appoint URL(Replace "{ID}" to tweet's ScreenName)</value>
-  </data>
-  <data name="Label39.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="UserAppointUrlText.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ComboBoxTranslateLanguage.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>185, 12</value>
-  </data>
-  <data name="Label29.Text" xml:space="preserve">
-    <value>Language at translation destination</value>
-  </data>
-  <data name="Label29.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="CheckOutputz.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 16</value>
-  </data>
-  <data name="CheckOutputz.Text" xml:space="preserve">
-    <value>Use Outputz</value>
-  </data>
-  <data name="CheckOutputz.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="CheckNicoms.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 16</value>
-  </data>
-  <data name="CheckNicoms.Text" xml:space="preserve">
-    <value>Shorten nicovideo urls by nico.ms</value>
-  </data>
-  <data name="CheckNicoms.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextBoxOutputzKey.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label60.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 12</value>
-  </data>
-  <data name="Label60.Text" xml:space="preserve">
-    <value>URI of your Outputz</value>
-  </data>
-  <data name="Label60.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label59.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 12</value>
-  </data>
-  <data name="Label59.Text" xml:space="preserve">
-    <value>Your secret key</value>
-  </data>
-  <data name="Label59.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ComboBoxOutputzUrlmode.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="CooperatePanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="StartupReaded.Size" type="System.Drawing.Size, System.Drawing">
     <value>91, 16</value>
   </data>
   <data name="StartupReaded.Text" xml:space="preserve">
     <value>Mark as read</value>
-  </data>
-  <data name="StartupReaded.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckStartupFollowers.Size" type="System.Drawing.Size, System.Drawing">
     <value>123, 16</value>
@@ -352,29 +223,17 @@
   <data name="CheckStartupFollowers.Text" xml:space="preserve">
     <value>Fetch followers list</value>
   </data>
-  <data name="CheckStartupFollowers.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckStartupVersion.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 16</value>
   </data>
   <data name="CheckStartupVersion.Text" xml:space="preserve">
     <value>Check new version</value>
   </data>
-  <data name="CheckStartupVersion.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkGetFav.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 16</value>
   </data>
   <data name="chkGetFav.Text" xml:space="preserve">
     <value>Fetch Favorites</value>
-  </data>
-  <data name="chkGetFav.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="StartupPanel.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>224, 12</value>
@@ -395,9 +254,6 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="IsNotifyUseGrowlCheckBox.Text" xml:space="preserve">
     <value>Use 'Growl for Windows' to notify</value>
   </data>
-  <data name="IsNotifyUseGrowlCheckBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="ReplyIconStateCombo.Items" xml:space="preserve">
     <value>Don't notify</value>
   </data>
@@ -407,17 +263,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="ReplyIconStateCombo.Items2" xml:space="preserve">
     <value>Change icon&amp;blink</value>
   </data>
-  <data name="ReplyIconStateCombo.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label72.Size" type="System.Drawing.Size, System.Drawing">
     <value>188, 12</value>
   </data>
   <data name="Label72.Text" xml:space="preserve">
     <value>Tasktray icon with unread mentions</value>
-  </data>
-  <data name="Label72.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="ChkNewMentionsBlink.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 16</value>
@@ -425,17 +275,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="ChkNewMentionsBlink.Text" xml:space="preserve">
     <value>Blink window mentions arrived</value>
   </data>
-  <data name="ChkNewMentionsBlink.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkTabIconDisp.Size" type="System.Drawing.Size, System.Drawing">
     <value>210, 16</value>
   </data>
   <data name="chkTabIconDisp.Text" xml:space="preserve">
     <value>Show icon on tab has unread tweets</value>
-  </data>
-  <data name="chkTabIconDisp.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckPreviewEnable.Size" type="System.Drawing.Size, System.Drawing">
     <value>138, 16</value>
@@ -443,26 +287,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckPreviewEnable.Text" xml:space="preserve">
     <value>Show image thumbnail</value>
   </data>
-  <data name="CheckPreviewEnable.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label81.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="LanguageCombo.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label13.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckAlwaysTop.Size" type="System.Drawing.Size, System.Drawing">
     <value>97, 16</value>
   </data>
   <data name="CheckAlwaysTop.Text" xml:space="preserve">
     <value>Always on top</value>
-  </data>
-  <data name="CheckAlwaysTop.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckMonospace.Size" type="System.Drawing.Size, System.Drawing">
     <value>232, 16</value>
@@ -470,26 +299,17 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckMonospace.Text" xml:space="preserve">
     <value>Use monospace font in tweet detail area</value>
   </data>
-  <data name="CheckMonospace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckBalloonLimit.Size" type="System.Drawing.Size, System.Drawing">
     <value>293, 16</value>
   </data>
   <data name="CheckBalloonLimit.Text" xml:space="preserve">
     <value>Popup balloon only at the minimization or iconization</value>
   </data>
-  <data name="CheckBalloonLimit.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label10.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 12</value>
   </data>
   <data name="Label10.Text" xml:space="preserve">
     <value>Username in popup</value>
-  </data>
-  <data name="Label10.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="ComboDispTitle.Items" xml:space="preserve">
     <value>None</value>
@@ -515,17 +335,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="ComboDispTitle.Items7" xml:space="preserve">
     <value>Count of Status/Follow/Follower</value>
   </data>
-  <data name="ComboDispTitle.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label45.Size" type="System.Drawing.Size, System.Drawing">
     <value>65, 12</value>
   </data>
   <data name="Label45.Text" xml:space="preserve">
     <value>Title format</value>
-  </data>
-  <data name="Label45.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="cmbNameBalloon.Items" xml:space="preserve">
     <value>None</value>
@@ -536,17 +350,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="cmbNameBalloon.Items2" xml:space="preserve">
     <value>Nickname</value>
   </data>
-  <data name="cmbNameBalloon.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckDispUsername.Size" type="System.Drawing.Size, System.Drawing">
     <value>278, 16</value>
   </data>
   <data name="CheckDispUsername.Text" xml:space="preserve">
     <value>Show username in application titlebar and balloon</value>
-  </data>
-  <data name="CheckDispUsername.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckBox3.Size" type="System.Drawing.Size, System.Drawing">
     <value>148, 16</value>
@@ -554,20 +362,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckBox3.Text" xml:space="preserve">
     <value>Show icon in detail view</value>
   </data>
-  <data name="CheckBox3.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="PreviewPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckHashSupple.Size" type="System.Drawing.Size, System.Drawing">
     <value>213, 16</value>
   </data>
   <data name="CheckHashSupple.Text" xml:space="preserve">
     <value>Use Hashtag supplementary function</value>
-  </data>
-  <data name="CheckHashSupple.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckAtIdSupple.Size" type="System.Drawing.Size, System.Drawing">
     <value>188, 16</value>
@@ -575,20 +374,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckAtIdSupple.Text" xml:space="preserve">
     <value>Use @id supplementary function</value>
   </data>
-  <data name="CheckAtIdSupple.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ComboBoxPostKeySelect.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label27.Size" type="System.Drawing.Size, System.Drawing">
     <value>50, 12</value>
   </data>
   <data name="Label27.Text" xml:space="preserve">
     <value>Post key</value>
-  </data>
-  <data name="Label27.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckRetweetNoConfirm.Size" type="System.Drawing.Size, System.Drawing">
     <value>239, 16</value>
@@ -596,17 +386,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckRetweetNoConfirm.Text" xml:space="preserve">
     <value>Bypass confirm dialog at posting Retweet</value>
   </data>
-  <data name="CheckRetweetNoConfirm.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label12.Size" type="System.Drawing.Size, System.Drawing">
     <value>38, 12</value>
   </data>
   <data name="Label12.Text" xml:space="preserve">
     <value>Footer</value>
-  </data>
-  <data name="Label12.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckUseRecommendStatus.Size" type="System.Drawing.Size, System.Drawing">
     <value>151, 16</value>
@@ -614,29 +398,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckUseRecommendStatus.Text" xml:space="preserve">
     <value>Use Default [TWNvNNN]</value>
   </data>
-  <data name="CheckUseRecommendStatus.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="StatusText.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TweetActPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ListTextCountApi.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label25.Size" type="System.Drawing.Size, System.Drawing">
     <value>30, 12</value>
   </data>
   <data name="Label25.Text" xml:space="preserve">
     <value>Lists</value>
-  </data>
-  <data name="Label25.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="UserTimelineTextCountApi.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label17.Size" type="System.Drawing.Size, System.Drawing">
     <value>72, 12</value>
@@ -644,17 +410,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label17.Text" xml:space="preserve">
     <value>UserTimeline</value>
   </data>
-  <data name="Label17.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label30.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 12</value>
   </data>
   <data name="Label30.Text" xml:space="preserve">
     <value>Public Search</value>
-  </data>
-  <data name="Label30.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label28.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 12</value>
@@ -662,23 +422,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label28.Text" xml:space="preserve">
     <value>Timeline at starting</value>
   </data>
-  <data name="Label28.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
     <value>51, 12</value>
   </data>
   <data name="Label19.Text" xml:space="preserve">
     <value>Mentions</value>
-  </data>
-  <data name="Label19.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="FavoritesTextCountApi.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="SearchTextCountApi.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label66.Size" type="System.Drawing.Size, System.Drawing">
     <value>53, 12</value>
@@ -686,23 +434,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label66.Text" xml:space="preserve">
     <value>Favorites</value>
   </data>
-  <data name="Label66.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="FirstTextCountApi.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GetMoreTextCountApi.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label53.Size" type="System.Drawing.Size, System.Drawing">
     <value>52, 12</value>
   </data>
   <data name="Label53.Text" xml:space="preserve">
     <value>Get more</value>
-  </data>
-  <data name="Label53.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="UseChangeGetCount.Size" type="System.Drawing.Size, System.Drawing">
     <value>233, 16</value>
@@ -710,26 +446,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="UseChangeGetCount.Text" xml:space="preserve">
     <value>Enable to edit fetching number of tweets</value>
   </data>
-  <data name="UseChangeGetCount.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextCountApiReply.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label67.Size" type="System.Drawing.Size, System.Drawing">
     <value>199, 12</value>
   </data>
   <data name="Label67.Text" xml:space="preserve">
     <value>Fetching number of tweets in timeline</value>
-  </data>
-  <data name="Label67.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextCountApi.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GetCountPanel.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="ShortenTcoCheck.Size" type="System.Drawing.Size, System.Drawing">
     <value>91, 16</value>
@@ -737,17 +458,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="ShortenTcoCheck.Text" xml:space="preserve">
     <value>t.co wrapping</value>
   </data>
-  <data name="ShortenTcoCheck.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckForceResolve.Size" type="System.Drawing.Size, System.Drawing">
     <value>142, 16</value>
   </data>
   <data name="CheckForceResolve.Text" xml:space="preserve">
     <value>Force Resolve All URL</value>
-  </data>
-  <data name="CheckForceResolve.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckTinyURL.Size" type="System.Drawing.Size, System.Drawing">
     <value>145, 16</value>
@@ -755,20 +470,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckTinyURL.Text" xml:space="preserve">
     <value>Resolve shortend URLs</value>
   </data>
-  <data name="CheckTinyURL.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextBitlyPw.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckAutoConvertUrl.Size" type="System.Drawing.Size, System.Drawing">
     <value>205, 16</value>
   </data>
   <data name="CheckAutoConvertUrl.Text" xml:space="preserve">
     <value>Auto shorten Urls in posting status</value>
-  </data>
-  <data name="CheckAutoConvertUrl.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label71.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 12</value>
@@ -776,38 +482,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label71.Text" xml:space="preserve">
     <value>Primary URLshorten service</value>
   </data>
-  <data name="Label71.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label76.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label77.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextBitlyId.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ShortUrlPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="AuthUserCombo.ToolTip" xml:space="preserve">
-    <value />
+  <data name="GroupBox2.Text" xml:space="preserve">
+    <value>Tween support</value>
   </data>
   <data name="Label1.Text" xml:space="preserve">
     <value>We recommend to follow @TweenApp.</value>
-  </data>
-  <data name="Label1.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="EmailText.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label6.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="FollowCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>73, 16</value>
@@ -815,38 +494,17 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="FollowCheckBox.Text" xml:space="preserve">
     <value>Follow {0}</value>
   </data>
-  <data name="FollowCheckBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label43.Text" xml:space="preserve">
     <value>This account will accept, and answer demanding and inquiring besides the upgrade and useful information are passed on.</value>
-  </data>
-  <data name="Label43.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GroupBox2.Text" xml:space="preserve">
-    <value>Tween support</value>
-  </data>
-  <data name="GroupBox2.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CreateAccountButton.Text" xml:space="preserve">
     <value>Sign up for Twitter account</value>
   </data>
-  <data name="CreateAccountButton.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="StartAuthButton.Text" xml:space="preserve">
     <value>Start Authentiation</value>
   </data>
-  <data name="StartAuthButton.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="AuthClearButton.Text" xml:space="preserve">
     <value>Remove</value>
-  </data>
-  <data name="AuthClearButton.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label4.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 12</value>
@@ -854,20 +512,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label4.Text" xml:space="preserve">
     <value>Account</value>
   </data>
-  <data name="Label4.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="BasedPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="IsListsIncludeRtsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>127, 16</value>
   </data>
   <data name="IsListsIncludeRtsCheckBox.Text" xml:space="preserve">
     <value>Include RTs in Lists</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="HideDuplicatedRetweetsCheck.Size" type="System.Drawing.Size, System.Drawing">
     <value>151, 16</value>
@@ -875,26 +524,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="HideDuplicatedRetweetsCheck.Text" xml:space="preserve">
     <value>Hide duplicated retweets</value>
   </data>
-  <data name="HideDuplicatedRetweetsCheck.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label47.Size" type="System.Drawing.Size, System.Drawing">
     <value>115, 12</value>
   </data>
   <data name="Label47.Text" xml:space="preserve">
     <value>Apply after restarting</value>
-  </data>
-  <data name="Label47.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="LabelDateTimeFormatApplied.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label62.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="CmbDateTimeFormat.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label23.Size" type="System.Drawing.Size, System.Drawing">
     <value>105, 12</value>
@@ -902,26 +536,20 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label23.Text" xml:space="preserve">
     <value>Date Format in List</value>
   </data>
-  <data name="Label23.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
     <value>162, 12</value>
   </data>
   <data name="Label11.Text" xml:space="preserve">
     <value>Icon size in List (16 in default)</value>
   </data>
-  <data name="Label11.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="IconSize.Items" xml:space="preserve">
     <value>None</value>
   </data>
-  <data name="IconSize.ToolTip" xml:space="preserve">
-    <value />
+  <data name="CheckViewTabBottom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>202, 16</value>
   </data>
-  <data name="TextBox3.ToolTip" xml:space="preserve">
-    <value />
+  <data name="CheckViewTabBottom.Text" xml:space="preserve">
+    <value>View tabs at the bottom of the list</value>
   </data>
   <data name="CheckSortOrderLock.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 16</value>
@@ -929,17 +557,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckSortOrderLock.Text" xml:space="preserve">
     <value>Lock sort order</value>
   </data>
-  <data name="CheckSortOrderLock.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckShowGrid.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 16</value>
   </data>
   <data name="CheckShowGrid.Text" xml:space="preserve">
     <value>Show separator line</value>
-  </data>
-  <data name="CheckShowGrid.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkUnreadStyle.Size" type="System.Drawing.Size, System.Drawing">
     <value>393, 16</value>
@@ -947,29 +569,17 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="chkUnreadStyle.Text" xml:space="preserve">
     <value>Enable unread style(font and color). (Unread can be found by star mark)</value>
   </data>
-  <data name="chkUnreadStyle.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="OneWayLv.Size" type="System.Drawing.Size, System.Drawing">
     <value>379, 16</value>
   </data>
   <data name="OneWayLv.Text" xml:space="preserve">
     <value>Colorize one way love user's tweets (following and not followed user)</value>
   </data>
-  <data name="OneWayLv.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TweetPrvPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="IsRemoveSameFavEventCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>254, 16</value>
   </data>
   <data name="IsRemoveSameFavEventCheckBox.Text" xml:space="preserve">
     <value>Ignore duplicated Favorite/Unfavorite events</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckUserUpdateEvent.Size" type="System.Drawing.Size, System.Drawing">
     <value>85, 16</value>
@@ -986,20 +596,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label35.Text" xml:space="preserve">
     <value>Play sound notify events</value>
   </data>
-  <data name="Label35.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ComboBoxEventNotifySound.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckFavEventUnread.Size" type="System.Drawing.Size, System.Drawing">
     <value>190, 16</value>
   </data>
   <data name="CheckFavEventUnread.Text" xml:space="preserve">
     <value>Mark favorited tweets as unread</value>
-  </data>
-  <data name="CheckFavEventUnread.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckListCreatedEvent.Size" type="System.Drawing.Size, System.Drawing">
     <value>91, 16</value>
@@ -1024,9 +625,6 @@ This file is released for developers in Growl for Windows web site.</value>
   </data>
   <data name="CheckForceEventNotify.Text" xml:space="preserve">
     <value>Notify Events even if disable alert popup</value>
-  </data>
-  <data name="CheckForceEventNotify.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckListMemberRemovedEvent.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 16</value>
@@ -1079,11 +677,65 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckEventNotify.Text" xml:space="preserve">
     <value>Notify Events(Only UserStream)</value>
   </data>
-  <data name="CheckEventNotify.ToolTip" xml:space="preserve">
-    <value />
+  <data name="IsPreviewFoursquareCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>239, 16</value>
   </data>
-  <data name="NotifyPanel.ToolTip" xml:space="preserve">
-    <value />
+  <data name="IsPreviewFoursquareCheckBox.Text" xml:space="preserve">
+    <value>Get map thumbnails from Foursquare urls.</value>
+  </data>
+  <data name="MapThumbnailGroupBox.Text" xml:space="preserve">
+    <value>Map Thumbnail</value>
+  </data>
+  <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 12</value>
+  </data>
+  <data name="label48.Text" xml:space="preserve">
+    <value>Map Provider</value>
+  </data>
+  <data name="Label41.Text" xml:space="preserve">
+    <value>Zoom Level</value>
+  </data>
+  <data name="Label40.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 12</value>
+  </data>
+  <data name="Label40.Text" xml:space="preserve">
+    <value>Thumbnail Size</value>
+  </data>
+  <data name="Label39.Size" type="System.Drawing.Size, System.Drawing">
+    <value>299, 12</value>
+  </data>
+  <data name="Label39.Text" xml:space="preserve">
+    <value>Your appoint URL(Replace "{ID}" to tweet's ScreenName)</value>
+  </data>
+  <data name="Label29.Size" type="System.Drawing.Size, System.Drawing">
+    <value>185, 12</value>
+  </data>
+  <data name="Label29.Text" xml:space="preserve">
+    <value>Language at translation destination</value>
+  </data>
+  <data name="CheckOutputz.Size" type="System.Drawing.Size, System.Drawing">
+    <value>87, 16</value>
+  </data>
+  <data name="CheckOutputz.Text" xml:space="preserve">
+    <value>Use Outputz</value>
+  </data>
+  <data name="CheckNicoms.Size" type="System.Drawing.Size, System.Drawing">
+    <value>196, 16</value>
+  </data>
+  <data name="CheckNicoms.Text" xml:space="preserve">
+    <value>Shorten nicovideo urls by nico.ms</value>
+  </data>
+  <data name="Label60.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 12</value>
+  </data>
+  <data name="Label60.Text" xml:space="preserve">
+    <value>URI of your Outputz</value>
+  </data>
+  <data name="Label59.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 12</value>
+  </data>
+  <data name="Label59.Text" xml:space="preserve">
+    <value>Your secret key</value>
   </data>
   <data name="Label55.Size" type="System.Drawing.Size, System.Drawing">
     <value>320, 12</value>
@@ -1091,20 +743,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label55.Text" xml:space="preserve">
     <value>Keep credential empty if the proxy server don't need to log in</value>
   </data>
-  <data name="Label55.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextProxyPassword.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="RadioProxyNone.Size" type="System.Drawing.Size, System.Drawing">
     <value>73, 16</value>
   </data>
   <data name="RadioProxyNone.Text" xml:space="preserve">
     <value>Don't Use</value>
-  </data>
-  <data name="RadioProxyNone.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="LabelProxyPassword.Size" type="System.Drawing.Size, System.Drawing">
     <value>54, 12</value>
@@ -1112,20 +755,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="LabelProxyPassword.Text" xml:space="preserve">
     <value>Pass&amp;word</value>
   </data>
-  <data name="LabelProxyPassword.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="RadioProxyIE.Size" type="System.Drawing.Size, System.Drawing">
     <value>200, 16</value>
   </data>
   <data name="RadioProxyIE.Text" xml:space="preserve">
     <value>Refer Settings of Internet Explorer</value>
-  </data>
-  <data name="RadioProxyIE.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextProxyUser.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="RadioProxySpecified.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 16</value>
@@ -1133,17 +767,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="RadioProxySpecified.Text" xml:space="preserve">
     <value>Use Below:</value>
   </data>
-  <data name="RadioProxySpecified.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="LabelProxyUser.Size" type="System.Drawing.Size, System.Drawing">
     <value>56, 12</value>
   </data>
   <data name="LabelProxyUser.Text" xml:space="preserve">
     <value>&amp;Username</value>
-  </data>
-  <data name="LabelProxyUser.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="LabelProxyAddress.Size" type="System.Drawing.Size, System.Drawing">
     <value>62, 12</value>
@@ -1151,38 +779,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="LabelProxyAddress.Text" xml:space="preserve">
     <value>Pro&amp;xy Host</value>
   </data>
-  <data name="LabelProxyAddress.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextProxyPort.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TextProxyAddress.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="LabelProxyPort.Size" type="System.Drawing.Size, System.Drawing">
     <value>26, 12</value>
   </data>
   <data name="LabelProxyPort.Text" xml:space="preserve">
     <value>&amp;Port</value>
-  </data>
-  <data name="LabelProxyPort.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ProxyPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TwitterSearchAPIText.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label31.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TwitterAPIText.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label8.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckUseSsl.Size" type="System.Drawing.Size, System.Drawing">
     <value>130, 16</value>
@@ -1190,20 +791,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="CheckUseSsl.Text" xml:space="preserve">
     <value>Use HTTPS Protocol</value>
   </data>
-  <data name="CheckUseSsl.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label64.Size" type="System.Drawing.Size, System.Drawing">
     <value>371, 12</value>
   </data>
   <data name="Label64.Text" xml:space="preserve">
     <value>※Adjust Connection timeout if the error of timeout happens frequently.</value>
-  </data>
-  <data name="Label64.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ConnectionTimeOut.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label63.Size" type="System.Drawing.Size, System.Drawing">
     <value>130, 12</value>
@@ -1211,26 +803,11 @@ This file is released for developers in Growl for Windows web site.</value>
   <data name="Label63.Text" xml:space="preserve">
     <value>Connection timeout(sec)</value>
   </data>
-  <data name="Label63.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ConnectionPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="UserstreamPeriod.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label46.Size" type="System.Drawing.Size, System.Drawing">
     <value>191, 12</value>
   </data>
   <data name="Label46.Text" xml:space="preserve">
     <value>User Streams Refresh Interval (sec)</value>
-  </data>
-  <data name="Label46.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="LabelApiUsingUserStreamEnabled.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="LabelUserStreamActive.Size" type="System.Drawing.Size, System.Drawing">
     <value>395, 24</value>
@@ -1239,20 +816,8 @@ This file is released for developers in Growl for Windows web site.</value>
     <value>UserStream is enable.
 Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.</value>
   </data>
-  <data name="LabelUserStreamActive.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label21.Text" xml:space="preserve">
     <value>UserTimeline Interval (sec)</value>
-  </data>
-  <data name="Label21.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="UserTimelinePeriod.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="TimelinePeriod.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>170, 12</value>
@@ -1260,14 +825,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label3.Text" xml:space="preserve">
     <value>Timeline Fetching Interval (sec.)</value>
   </data>
-  <data name="Label3.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="ButtonApiCalc.Text" xml:space="preserve">
     <value>Recalculation</value>
-  </data>
-  <data name="ButtonApiCalc.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="LabelPostAndGet.Size" type="System.Drawing.Size, System.Drawing">
     <value>358, 12</value>
@@ -1275,23 +834,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="LabelPostAndGet.Text" xml:space="preserve">
     <value>Because "Post &amp;&amp; fetch" is enabled, the API for each post consumed.</value>
   </data>
-  <data name="LabelPostAndGet.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="LabelApiUsing.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label33.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 12</value>
   </data>
   <data name="Label33.Text" xml:space="preserve">
     <value>Lists Fetching Interval (sec)</value>
-  </data>
-  <data name="Label33.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ListsPeriod.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label7.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 12</value>
@@ -1299,23 +846,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label7.Text" xml:space="preserve">
     <value>Public Search Interval (sec.)</value>
   </data>
-  <data name="Label7.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="PubSearchPeriod.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label69.Size" type="System.Drawing.Size, System.Drawing">
     <value>156, 12</value>
   </data>
   <data name="Label69.Text" xml:space="preserve">
     <value>Reply Fetching Interval (sec.)</value>
-  </data>
-  <data name="Label69.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ReplyPeriod.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckPostAndGet.Size" type="System.Drawing.Size, System.Drawing">
     <value>88, 16</value>
@@ -1323,17 +858,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="CheckPostAndGet.Text" xml:space="preserve">
     <value>Post &amp;&amp; fetch</value>
   </data>
-  <data name="CheckPostAndGet.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckPeriodAdjust.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 16</value>
   </data>
   <data name="CheckPeriodAdjust.Text" xml:space="preserve">
     <value>Enable Auto-Adjustment</value>
-  </data>
-  <data name="CheckPeriodAdjust.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 12</value>
@@ -1341,32 +870,17 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label5.Text" xml:space="preserve">
     <value>DM Fetching Interval (sec.)</value>
   </data>
-  <data name="Label5.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="DMPeriod.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="StartupUserstreamCheck.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 16</value>
   </data>
   <data name="StartupUserstreamCheck.Text" xml:space="preserve">
     <value>Auto connect at starting</value>
   </data>
-  <data name="StartupUserstreamCheck.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GetPeriodPanel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="TabMouseLockCheck.Size" type="System.Drawing.Size, System.Drawing">
     <value>157, 16</value>
   </data>
   <data name="TabMouseLockCheck.Text" xml:space="preserve">
     <value>Disable Drag&amp;&amp;Drop on tab</value>
-  </data>
-  <data name="TabMouseLockCheck.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label38.Location" type="System.Drawing.Point, System.Drawing">
     <value>20, 282</value>
@@ -1376,9 +890,6 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   </data>
   <data name="Label38.Text" xml:space="preserve">
     <value>Behavier when doubleclick a tweet</value>
-  </data>
-  <data name="Label38.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="ListDoubleClickActionComboBox.Items2" xml:space="preserve">
     <value>Show user's profile</value>
@@ -1398,50 +909,20 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="ListDoubleClickActionComboBox.Items7" xml:space="preserve">
     <value>Not bihavier</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckOpenUserTimeline.Size" type="System.Drawing.Size, System.Drawing">
     <value>189, 16</value>
   </data>
   <data name="CheckOpenUserTimeline.Text" xml:space="preserve">
     <value>Open user's home URL with Tab</value>
   </data>
-  <data name="CheckOpenUserTimeline.ToolTip" xml:space="preserve">
-    <value />
+  <data name="GroupBox3.Text" xml:space="preserve">
+    <value>Hotkey</value>
   </data>
   <data name="HotkeyCheck.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 16</value>
   </data>
   <data name="HotkeyCheck.Text" xml:space="preserve">
     <value>Enable</value>
-  </data>
-  <data name="HotkeyCheck.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="HotkeyCode.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="HotkeyText.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="HotkeyWin.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="HotkeyAlt.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="HotkeyShift.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="HotkeyCtrl.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GroupBox3.Text" xml:space="preserve">
-    <value>Hotkey</value>
-  </data>
-  <data name="GroupBox3.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Label57.AutoSize" type="System.Boolean, mscorlib">
@@ -1453,23 +934,14 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label57.Text" xml:space="preserve">
     <value>Refetch tweets and verify whether marked favorites. This option causes traffic increasement.</value>
   </data>
-  <data name="Label57.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckFavRestrict.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 16</value>
   </data>
   <data name="CheckFavRestrict.Text" xml:space="preserve">
     <value>Check fav result strictly</value>
   </data>
-  <data name="CheckFavRestrict.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Button3.Text" xml:space="preserve">
     <value>Open...</value>
-  </data>
-  <data name="Button3.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="PlaySnd.Size" type="System.Drawing.Size, System.Drawing">
     <value>215, 16</value>
@@ -1477,26 +949,14 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="PlaySnd.Text" xml:space="preserve">
     <value>Play sounds when new status arrived</value>
   </data>
-  <data name="PlaySnd.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkReadOwnPost.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 16</value>
   </data>
   <data name="chkReadOwnPost.Text" xml:space="preserve">
     <value>Mark your tweets as read</value>
   </data>
-  <data name="chkReadOwnPost.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label15.Text" xml:space="preserve">
     <value>Sounds will play when you enable this option and set sound file for each tabs.</value>
-  </data>
-  <data name="Label15.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="BrowserPathText.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="UReadMng.Size" type="System.Drawing.Size, System.Drawing">
     <value>126, 16</value>
@@ -1504,17 +964,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="UReadMng.Text" xml:space="preserve">
     <value>Enable unread state</value>
   </data>
-  <data name="UReadMng.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label44.Size" type="System.Drawing.Size, System.Drawing">
     <value>88, 12</value>
   </data>
   <data name="Label44.Text" xml:space="preserve">
     <value>Path to Browser</value>
-  </data>
-  <data name="Label44.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckCloseToExit.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 16</value>
@@ -1522,17 +976,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="CheckCloseToExit.Text" xml:space="preserve">
     <value>Close to Exit application</value>
   </data>
-  <data name="CheckCloseToExit.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="CheckMinimizeToTray.Size" type="System.Drawing.Size, System.Drawing">
     <value>106, 16</value>
   </data>
   <data name="CheckMinimizeToTray.Text" xml:space="preserve">
     <value>Minimize to tray</value>
-  </data>
-  <data name="CheckMinimizeToTray.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="CheckReadOldPosts.Size" type="System.Drawing.Size, System.Drawing">
     <value>311, 16</value>
@@ -1540,23 +988,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="CheckReadOldPosts.Text" xml:space="preserve">
     <value>Mark acquired tweets as  read when new tweets arrived</value>
   </data>
-  <data name="CheckReadOldPosts.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ActionPanel.ToolTip" xml:space="preserve">
-    <value />
+  <data name="GroupBox1.Text" xml:space="preserve">
+    <value>Font &amp;&amp; Color</value>
   </data>
   <data name="btnRetweet.Text" xml:space="preserve">
     <value>Fore...</value>
-  </data>
-  <data name="btnRetweet.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblRetweet.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Label80.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="ButtonBackToDefaultFontColor.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 22</value>
@@ -1564,17 +1000,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="ButtonBackToDefaultFontColor.Text" xml:space="preserve">
     <value>Back to Default</value>
   </data>
-  <data name="ButtonBackToDefaultFontColor.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnDetailLink.Text" xml:space="preserve">
     <value>Fore...</value>
-  </data>
-  <data name="btnDetailLink.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblDetailLink.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label18.Size" type="System.Drawing.Size, System.Drawing">
     <value>119, 12</value>
@@ -1582,17 +1009,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label18.Text" xml:space="preserve">
     <value>Details of Tweet(Link)</value>
   </data>
-  <data name="Label18.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnUnread.Text" xml:space="preserve">
     <value>Font&amp;&amp;Fore...</value>
-  </data>
-  <data name="btnUnread.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblUnread.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label20.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 12</value>
@@ -1600,17 +1018,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label20.Text" xml:space="preserve">
     <value>Unread Tweet</value>
   </data>
-  <data name="Label20.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnDetailBack.Text" xml:space="preserve">
     <value>Back...</value>
-  </data>
-  <data name="btnDetailBack.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblDetailBackcolor.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label37.Size" type="System.Drawing.Size, System.Drawing">
     <value>110, 12</value>
@@ -1618,17 +1027,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label37.Text" xml:space="preserve">
     <value>Backcolor of Details</value>
   </data>
-  <data name="Label37.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnDetail.Text" xml:space="preserve">
     <value>Font&amp;&amp;Fore...</value>
-  </data>
-  <data name="btnDetail.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblDetail.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label26.Size" type="System.Drawing.Size, System.Drawing">
     <value>90, 12</value>
@@ -1636,17 +1036,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label26.Text" xml:space="preserve">
     <value>Details of Tweet</value>
   </data>
-  <data name="Label26.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnOWL.Text" xml:space="preserve">
     <value>Fore...</value>
-  </data>
-  <data name="btnOWL.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblOWL.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label24.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 12</value>
@@ -1654,17 +1045,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label24.Text" xml:space="preserve">
     <value>One-way following</value>
   </data>
-  <data name="Label24.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnFav.Text" xml:space="preserve">
     <value>Fore...</value>
-  </data>
-  <data name="btnFav.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblFav.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label22.Size" type="System.Drawing.Size, System.Drawing">
     <value>53, 12</value>
@@ -1672,17 +1054,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label22.Text" xml:space="preserve">
     <value>Favorited</value>
   </data>
-  <data name="Label22.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnListFont.Text" xml:space="preserve">
     <value>Font&amp;&amp;Fore...</value>
-  </data>
-  <data name="btnListFont.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblListFont.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label61.Size" type="System.Drawing.Size, System.Drawing">
     <value>94, 12</value>
@@ -1690,17 +1063,8 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label61.Text" xml:space="preserve">
     <value>Font of tweet list</value>
   </data>
-  <data name="Label61.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GroupBox1.Text" xml:space="preserve">
+  <data name="GroupBox5.Text" xml:space="preserve">
     <value>Font &amp;&amp; Color</value>
-  </data>
-  <data name="GroupBox1.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="FontPanel.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label65.Size" type="System.Drawing.Size, System.Drawing">
     <value>97, 12</value>
@@ -1708,17 +1072,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label65.Text" xml:space="preserve">
     <value>Font of input field</value>
   </data>
-  <data name="Label65.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label52.Size" type="System.Drawing.Size, System.Drawing">
     <value>169, 12</value>
   </data>
   <data name="Label52.Text" xml:space="preserve">
     <value>Backcolor of focused input field</value>
-  </data>
-  <data name="Label52.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label49.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 12</value>
@@ -1726,17 +1084,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label49.Text" xml:space="preserve">
     <value>Replied Tweet</value>
   </data>
-  <data name="Label49.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label9.Size" type="System.Drawing.Size, System.Drawing">
     <value>135, 12</value>
   </data>
   <data name="Label9.Text" xml:space="preserve">
     <value>First-time Reading Posts</value>
-  </data>
-  <data name="Label9.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label14.Size" type="System.Drawing.Size, System.Drawing">
     <value>42, 12</value>
@@ -1744,17 +1096,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label14.Text" xml:space="preserve">
     <value>Sounds</value>
   </data>
-  <data name="Label14.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label16.Size" type="System.Drawing.Size, System.Drawing">
     <value>145, 12</value>
   </data>
   <data name="Label16.Text" xml:space="preserve">
     <value>Colorize One-way following</value>
-  </data>
-  <data name="Label16.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label32.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 12</value>
@@ -1762,17 +1108,11 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label32.Text" xml:space="preserve">
     <value>Selected User's Tweet</value>
   </data>
-  <data name="Label32.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Label34.Size" type="System.Drawing.Size, System.Drawing">
     <value>84, 12</value>
   </data>
   <data name="Label34.Text" xml:space="preserve">
     <value>Replies for You</value>
-  </data>
-  <data name="Label34.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="Label36.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 12</value>
@@ -1780,89 +1120,32 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="Label36.Text" xml:space="preserve">
     <value>Your Own Tweet</value>
   </data>
-  <data name="Label36.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnInputFont.Text" xml:space="preserve">
     <value>Font...</value>
-  </data>
-  <data name="btnInputFont.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="btnInputBackcolor.Text" xml:space="preserve">
     <value>Back...</value>
   </data>
-  <data name="btnInputBackcolor.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnAtTo.Text" xml:space="preserve">
     <value>Back...</value>
-  </data>
-  <data name="btnAtTo.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="btnListBack.Text" xml:space="preserve">
     <value>Back...</value>
   </data>
-  <data name="btnListBack.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnAtFromTarget.Text" xml:space="preserve">
     <value>Back...</value>
-  </data>
-  <data name="btnAtFromTarget.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="btnAtTarget.Text" xml:space="preserve">
     <value>Back...</value>
   </data>
-  <data name="btnAtTarget.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnTarget.Text" xml:space="preserve">
     <value>Back...</value>
-  </data>
-  <data name="btnTarget.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="btnAtSelf.Text" xml:space="preserve">
     <value>Back...</value>
   </data>
-  <data name="btnAtSelf.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnSelf.Text" xml:space="preserve">
     <value>Back...</value>
-  </data>
-  <data name="btnSelf.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblInputFont.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblInputBackcolor.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblAtTo.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblListBackcolor.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblAtFromTarget.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblAtTarget.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblTarget.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblAtSelf.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblSelf.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="ButtonBackToDefaultFontColor2.Size" type="System.Drawing.Size, System.Drawing">
     <value>96, 22</value>
@@ -1870,37 +1153,10 @@ Periodic fetching, Timeline/Mentions/DM, and Post&amp;Fetch function is disable.
   <data name="ButtonBackToDefaultFontColor2.Text" xml:space="preserve">
     <value>Back to Default</value>
   </data>
-  <data name="ButtonBackToDefaultFontColor2.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="GroupBox5.Text" xml:space="preserve">
-    <value>Font &amp;&amp; Color</value>
-  </data>
-  <data name="GroupBox5.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="FontPanel2.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="SplitContainer1.Panel2.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="SplitContainer1.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="Save.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="Cancel.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="Cancel.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Settings</value>
-  </data>
-  <data name="$this.ToolTip" xml:space="preserve">
-    <value />
   </data>
 </root>

--- a/OpenTween/AppendSettingDialog.resx
+++ b/OpenTween/AppendSettingDialog.resx
@@ -117,3905 +117,1881 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="SplitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="Label39.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 203</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="SplitContainer1.IsSplitterFixed" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="SplitContainer1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="SplitContainer1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TreeViewSetting.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="TreeViewSetting.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="TreeViewSetting.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TreeViewSetting.Nodes" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
-        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQwAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIIVXNlckRhdGEBAQAAAQABAAQEBAEBCAgIHVN5c3RlbS5X
-        aW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAAd
-        U3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUCAAAAAgAAAAYDAAAABuWfuuacrAYEAAAACUJhc2Vk
-        Tm9kZQD/////BgUAAAAA/////wkFAAAAAwAAAAkGAAAACQcAAAAJCAAAAAkFAAAABQYAAAAdU3lzdGVt
-        LldpbmRvd3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJ
-        bWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEAAAEA
-        AQABCAgIAgAAAAYKAAAADOabtOaWsOmWk+malAYLAAAAClBlcmlvZE5vZGUA/////wkFAAAA/////wkF
-        AAAAAAAAAAUHAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCAAAAARUZXh0BE5hbWUJSXND
-        aGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VL
-        ZXkKQ2hpbGRDb3VudAEBAAABAAEAAQgICAIAAAAGDQAAABLotbfli5XmmYLjga7li5XkvZwGDgAAAAtT
-        dGFydFVwTm9kZQD/////CQUAAAD/////CQUAAAAAAAAABQgAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMu
-        VHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3Rl
-        ZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEAAAEAAQABCAgIAgAAAAYQAAAA
-        DOWPluW+l+S7tuaVsAYRAAAADEdldENvdW50Tm9kZQD/////CQUAAAD/////CQUAAAAAAAAACw==
-</value>
-  </data>
-  <data name="TreeViewSetting.Nodes1" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
-        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQkAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wAQEAAAEAAQAEAQgICB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMA
-        AAAG5YuV5L2cBgQAAAAKQWN0aW9uTm9kZQD/////BgUAAAAA/////wkFAAAAAQAAAAkGAAAABQYAAAAd
-        U3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJ
-        bmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50
-        AQEAAAEAAQABCAgIAgAAAAYHAAAABuaKleeovwYIAAAADFR3ZWV0QWN0Tm9kZQD/////CQUAAAD/////
-        CQUAAAAAAAAACw==
-</value>
-  </data>
-  <data name="TreeViewSetting.Nodes2" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
-        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQoAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wCWNoaWxkcmVuMQEBAAABAAEABAQBCAgIHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2Rl
-        AgAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMAAAAG6KGo56S6BgQAAAAL
-        UHJldmlld05vZGUA/////wYFAAAAAP////8JBQAAAAIAAAAJBgAAAAkHAAAABQYAAAAdU3lzdGVtLldp
-        bmRvd3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFn
-        ZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEAAAEAAQAB
-        CAgIAgAAAAYIAAAADOeZuuiogOS4gOimpwYJAAAADFR3ZWV0UHJ2Tm9kZQD/////CQUAAAD/////CQUA
-        AAAAAAAABQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUIAAAABFRleHQETmFtZQlJc0No
-        ZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtl
-        eQpDaGlsZENvdW50AQEAAAEAAQABCAgIAgAAAAYLAAAAEuOCpOODmeODs+ODiOmAmuefpQYMAAAACk5v
-        dGlmeU5vZGUA/////wkFAAAA/////wkFAAAAAAAAAAs=
-</value>
-  </data>
-  <data name="TreeViewSetting.Nodes3" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
-        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQkAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wAQEAAAEAAQAEAQgICB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMA
-        AAAM44OV44Kp44Oz44OIBgQAAAAIRm9udE5vZGUA/////wYFAAAAAP////8JBQAAAAEAAAAJBgAAAAUG
-        AAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCAAAAARUZXh0BE5hbWUJSXNDaGVja2VkCklt
-        YWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRD
-        b3VudAEBAAABAAEAAQgICAIAAAAGBwAAAA3jg5Xjgqnjg7Pjg4gyBggAAAAJRm9udE5vZGUyAP////8J
-        BQAAAP////8JBQAAAAAAAAAL
-</value>
-  </data>
-  <data name="TreeViewSetting.Nodes4" mimetype="application/x-microsoft.net.object.binary.base64">
-    <value>
-        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
-        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQsAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4
-        CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQJY2hp
-        bGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIBAQAAAQABAAQEBAEICAgdU3lzdGVtLldpbmRvd3MuRm9y
-        bXMuVHJlZU5vZGUCAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2lu
-        ZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAACAAAABgMAAAAG6YCa5L+hBgQAAAAOQ29ubmVjdGlvbk5vZGUA
-        /////wYFAAAAAP////8JBQAAAAMAAAAJBgAAAAkHAAAACQgAAAAFBgAAAB1TeXN0ZW0uV2luZG93cy5G
-        b3Jtcy5UcmVlTm9kZQgAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4CEltYWdlS2V5ElNl
-        bGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQBAQAAAQABAAEICAgCAAAA
-        BgkAAAAM44OX44Ot44Kt44K3BgoAAAAJUHJveHlOb2RlAP////8JBQAAAP////8JBQAAAAAAAAAFBwAA
-        AB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQgAAAAEVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFn
-        ZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291
-        bnQBAQAAAQABAAEICAgCAAAABgwAAAAS6YCj5pC644K144O844OT44K5Bg0AAAANQ29vcGVyYXRlTm9k
-        ZQD/////CQUAAAD/////CQUAAAAAAAAABQgAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUI
-        AAAABFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5k
-        ZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEAAAEAAQABCAgIAgAAAAYPAAAACeefree4rlVS
-        TAYQAAAADFNob3J0VXJsTm9kZQD/////CQUAAAD/////CQUAAAAAAAAACw==
-</value>
-  </data>
-  <data name="TreeViewSetting.Size" type="System.Drawing.Size, System.Drawing">
-    <value>225, 460</value>
-  </data>
-  <data name="TreeViewSetting.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;TreeViewSetting.Name" xml:space="preserve">
-    <value>TreeViewSetting</value>
-  </data>
-  <data name="&gt;&gt;TreeViewSetting.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TreeViewSetting.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel1</value>
-  </data>
-  <data name="&gt;&gt;TreeViewSetting.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel1.Name" xml:space="preserve">
-    <value>SplitContainer1.Panel1</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel1.Parent" xml:space="preserve">
-    <value>SplitContainer1</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="StartupReaded.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="StartupReaded.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="StartupReaded.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 31</value>
-  </data>
-  <data name="StartupReaded.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="StartupReaded.Size" type="System.Drawing.Size, System.Drawing">
-    <value>207, 19</value>
-  </data>
-  <data name="StartupReaded.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="StartupReaded.Text" xml:space="preserve">
-    <value>読み込んだポストを既読にする</value>
-  </data>
-  <data name="&gt;&gt;StartupReaded.Name" xml:space="preserve">
-    <value>StartupReaded</value>
-  </data>
-  <data name="&gt;&gt;StartupReaded.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;StartupReaded.Parent" xml:space="preserve">
-    <value>StartupPanel</value>
-  </data>
-  <data name="&gt;&gt;StartupReaded.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CheckStartupFollowers.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckStartupFollowers.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckStartupFollowers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 88</value>
-  </data>
-  <data name="CheckStartupFollowers.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckStartupFollowers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 19</value>
-  </data>
-  <data name="CheckStartupFollowers.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="CheckStartupFollowers.Text" xml:space="preserve">
-    <value>片思いユーザーリストを取得する</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupFollowers.Name" xml:space="preserve">
-    <value>CheckStartupFollowers</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupFollowers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupFollowers.Parent" xml:space="preserve">
-    <value>StartupPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupFollowers.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="CheckStartupVersion.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckStartupVersion.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckStartupVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 59</value>
-  </data>
-  <data name="CheckStartupVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckStartupVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 19</value>
-  </data>
-  <data name="CheckStartupVersion.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="CheckStartupVersion.Text" xml:space="preserve">
-    <value>最新版のチェックをする</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupVersion.Name" xml:space="preserve">
-    <value>CheckStartupVersion</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupVersion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupVersion.Parent" xml:space="preserve">
-    <value>StartupPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckStartupVersion.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="chkGetFav.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkGetFav.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkGetFav.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 116</value>
-  </data>
-  <data name="chkGetFav.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="chkGetFav.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 19</value>
-  </data>
-  <data name="chkGetFav.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="chkGetFav.Text" xml:space="preserve">
-    <value>Favoritesを取得する</value>
-  </data>
-  <data name="&gt;&gt;chkGetFav.Name" xml:space="preserve">
-    <value>chkGetFav</value>
-  </data>
-  <data name="&gt;&gt;chkGetFav.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkGetFav.Parent" xml:space="preserve">
-    <value>StartupPanel</value>
-  </data>
-  <data name="&gt;&gt;chkGetFav.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="StartupPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="StartupPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="StartupPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="StartupPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="StartupPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="StartupPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="StartupPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;StartupPanel.Name" xml:space="preserve">
-    <value>StartupPanel</value>
-  </data>
-  <data name="&gt;&gt;StartupPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;StartupPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;StartupPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>307, 394</value>
-  </data>
-  <data name="Label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>278, 15</value>
-  </data>
-  <data name="Label2.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="Label2.Text" xml:space="preserve">
-    <value>※別途DLLが必要です(マウスオーバーで表示)</value>
-  </data>
-  <metadata name="ToolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>268, 17</value>
-  </metadata>
-  <data name="Label2.ToolTip" xml:space="preserve">
-    <value>Growl for Windowsの開発者向けに公開されている、
-Growl_NET_Connector_SDK.zipに同梱の次のDLLが必要です
-Growl.Connector.DLL
-Growl.CoreLibrary.DLL</value>
-  </data>
-  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
-    <value>Label2</value>
-  </data>
-  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="IsNotifyUseGrowlCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="IsNotifyUseGrowlCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 392</value>
-  </data>
-  <data name="IsNotifyUseGrowlCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="IsNotifyUseGrowlCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 19</value>
-  </data>
-  <data name="IsNotifyUseGrowlCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="IsNotifyUseGrowlCheckBox.Text" xml:space="preserve">
-    <value>通知にGrowlを使用</value>
-  </data>
-  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.Name" xml:space="preserve">
-    <value>IsNotifyUseGrowlCheckBox</value>
-  </data>
-  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ReplyIconStateCombo.Items" xml:space="preserve">
-    <value>通知なし</value>
-  </data>
-  <data name="ReplyIconStateCombo.Items1" xml:space="preserve">
-    <value>アイコン変更</value>
-  </data>
-  <data name="ReplyIconStateCombo.Items2" xml:space="preserve">
-    <value>アイコン変更＆点滅</value>
-  </data>
-  <data name="ReplyIconStateCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 178</value>
-  </data>
-  <data name="ReplyIconStateCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ReplyIconStateCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 23</value>
-  </data>
-  <data name="ReplyIconStateCombo.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;ReplyIconStateCombo.Name" xml:space="preserve">
-    <value>ReplyIconStateCombo</value>
-  </data>
-  <data name="&gt;&gt;ReplyIconStateCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ReplyIconStateCombo.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;ReplyIconStateCombo.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="Label72.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label72.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label72.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 181</value>
-  </data>
-  <data name="Label72.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label72.Size" type="System.Drawing.Size, System.Drawing">
-    <value>168, 15</value>
-  </data>
-  <data name="Label72.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="Label72.Text" xml:space="preserve">
-    <value>未読Mentions通知アイコン</value>
-  </data>
-  <data name="&gt;&gt;Label72.Name" xml:space="preserve">
-    <value>Label72</value>
-  </data>
-  <data name="&gt;&gt;Label72.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label72.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;Label72.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ChkNewMentionsBlink.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="ChkNewMentionsBlink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ChkNewMentionsBlink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 208</value>
-  </data>
-  <data name="ChkNewMentionsBlink.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ChkNewMentionsBlink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>316, 19</value>
-  </data>
-  <data name="ChkNewMentionsBlink.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="ChkNewMentionsBlink.Text" xml:space="preserve">
-    <value>Mentionsの新着があるときにウインドウを点滅する</value>
-  </data>
-  <data name="&gt;&gt;ChkNewMentionsBlink.Name" xml:space="preserve">
-    <value>ChkNewMentionsBlink</value>
-  </data>
-  <data name="&gt;&gt;ChkNewMentionsBlink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ChkNewMentionsBlink.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;ChkNewMentionsBlink.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="chkTabIconDisp.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkTabIconDisp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkTabIconDisp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 148</value>
-  </data>
-  <data name="chkTabIconDisp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="chkTabIconDisp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 19</value>
-  </data>
-  <data name="chkTabIconDisp.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="chkTabIconDisp.Text" xml:space="preserve">
-    <value>タブに未読アイコンを表示する</value>
-  </data>
-  <data name="&gt;&gt;chkTabIconDisp.Name" xml:space="preserve">
-    <value>chkTabIconDisp</value>
-  </data>
-  <data name="&gt;&gt;chkTabIconDisp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkTabIconDisp.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;chkTabIconDisp.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CheckPreviewEnable.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckPreviewEnable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckPreviewEnable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 239</value>
-  </data>
-  <data name="CheckPreviewEnable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckPreviewEnable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 19</value>
-  </data>
-  <data name="CheckPreviewEnable.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="CheckPreviewEnable.Text" xml:space="preserve">
-    <value>画像リンクがあった場合にサムネイルを表示する</value>
-  </data>
-  <data name="&gt;&gt;CheckPreviewEnable.Name" xml:space="preserve">
-    <value>CheckPreviewEnable</value>
-  </data>
-  <data name="&gt;&gt;CheckPreviewEnable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckPreviewEnable.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckPreviewEnable.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Label81.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label81.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label81.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 362</value>
-  </data>
-  <data name="Label81.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label81.Size" type="System.Drawing.Size, System.Drawing">
-    <value>140, 15</value>
-  </data>
-  <data name="Label81.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="Label81.Text" xml:space="preserve">
-    <value>Apply after restarting</value>
-  </data>
-  <data name="&gt;&gt;Label81.Name" xml:space="preserve">
-    <value>Label81</value>
-  </data>
-  <data name="&gt;&gt;Label81.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label81.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;Label81.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="LanguageCombo.Items" xml:space="preserve">
-    <value>OS Default</value>
-  </data>
-  <data name="LanguageCombo.Items1" xml:space="preserve">
-    <value>Japanese</value>
-  </data>
-  <data name="LanguageCombo.Items2" xml:space="preserve">
-    <value>English</value>
-  </data>
-  <data name="LanguageCombo.Items3" xml:space="preserve">
-    <value>Simplified Chinese</value>
-  </data>
-  <data name="LanguageCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 356</value>
-  </data>
-  <data name="LanguageCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="LanguageCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 23</value>
-  </data>
-  <data name="LanguageCombo.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;LanguageCombo.Name" xml:space="preserve">
-    <value>LanguageCombo</value>
-  </data>
-  <data name="&gt;&gt;LanguageCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LanguageCombo.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;LanguageCombo.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Label13.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label13.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 362</value>
-  </data>
-  <data name="Label13.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 15</value>
-  </data>
-  <data name="Label13.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="Label13.Text" xml:space="preserve">
-    <value>Language</value>
-  </data>
-  <data name="&gt;&gt;Label13.Name" xml:space="preserve">
-    <value>Label13</value>
-  </data>
-  <data name="&gt;&gt;Label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label13.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;Label13.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="CheckAlwaysTop.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckAlwaysTop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckAlwaysTop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 329</value>
-  </data>
-  <data name="CheckAlwaysTop.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckAlwaysTop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 19</value>
-  </data>
-  <data name="CheckAlwaysTop.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="CheckAlwaysTop.Text" xml:space="preserve">
-    <value>常に最前面に表示する</value>
-  </data>
-  <data name="&gt;&gt;CheckAlwaysTop.Name" xml:space="preserve">
-    <value>CheckAlwaysTop</value>
-  </data>
-  <data name="&gt;&gt;CheckAlwaysTop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckAlwaysTop.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckAlwaysTop.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="CheckMonospace.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckMonospace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckMonospace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 298</value>
-  </data>
-  <data name="CheckMonospace.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckMonospace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>426, 19</value>
-  </data>
-  <data name="CheckMonospace.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="CheckMonospace.Text" xml:space="preserve">
-    <value>発言詳細を等幅フォントで表示（AA対応、フォント適用不具合あり）</value>
-  </data>
-  <data name="&gt;&gt;CheckMonospace.Name" xml:space="preserve">
-    <value>CheckMonospace</value>
-  </data>
-  <data name="&gt;&gt;CheckMonospace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckMonospace.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckMonospace.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="CheckBalloonLimit.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckBalloonLimit.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckBalloonLimit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 82</value>
-  </data>
-  <data name="CheckBalloonLimit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckBalloonLimit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>308, 19</value>
-  </data>
-  <data name="CheckBalloonLimit.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="CheckBalloonLimit.Text" xml:space="preserve">
-    <value>画面最小化・アイコン時のみバルーンを表示する</value>
-  </data>
-  <data name="&gt;&gt;CheckBalloonLimit.Name" xml:space="preserve">
-    <value>CheckBalloonLimit</value>
-  </data>
-  <data name="&gt;&gt;CheckBalloonLimit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckBalloonLimit.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckBalloonLimit.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="Label10.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 25</value>
-  </data>
-  <data name="Label10.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 15</value>
-  </data>
-  <data name="Label10.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label10.Text" xml:space="preserve">
-    <value>新着バルーンのユーザー名</value>
-  </data>
-  <data name="&gt;&gt;Label10.Name" xml:space="preserve">
-    <value>Label10</value>
-  </data>
-  <data name="&gt;&gt;Label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label10.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;Label10.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="ComboDispTitle.Items" xml:space="preserve">
-    <value>（なし）</value>
-  </data>
-  <data name="ComboDispTitle.Items1" xml:space="preserve">
-    <value>バージョン</value>
-  </data>
-  <data name="ComboDispTitle.Items2" xml:space="preserve">
-    <value>最終発言</value>
-  </data>
-  <data name="ComboDispTitle.Items3" xml:space="preserve">
-    <value>＠未読数</value>
-  </data>
-  <data name="ComboDispTitle.Items4" xml:space="preserve">
-    <value>未読数</value>
-  </data>
-  <data name="ComboDispTitle.Items5" xml:space="preserve">
-    <value>未読数(@未読数)</value>
-  </data>
-  <data name="ComboDispTitle.Items6" xml:space="preserve">
-    <value>全未読/全発言数</value>
-  </data>
-  <data name="ComboDispTitle.Items7" xml:space="preserve">
-    <value>発言数/フォロー数/フォロワー数</value>
-  </data>
-  <data name="ComboDispTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 110</value>
-  </data>
-  <data name="ComboDispTitle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ComboDispTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>261, 23</value>
-  </data>
-  <data name="ComboDispTitle.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ComboDispTitle.Name" xml:space="preserve">
-    <value>ComboDispTitle</value>
-  </data>
-  <data name="&gt;&gt;ComboDispTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ComboDispTitle.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;ComboDispTitle.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="Label45.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label45.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label45.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 114</value>
-  </data>
-  <data name="Label45.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label45.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 15</value>
-  </data>
-  <data name="Label45.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="Label45.Text" xml:space="preserve">
-    <value>タイトルバー</value>
-  </data>
-  <data name="&gt;&gt;Label45.Name" xml:space="preserve">
-    <value>Label45</value>
-  </data>
-  <data name="&gt;&gt;Label45.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label45.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;Label45.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="cmbNameBalloon.Items" xml:space="preserve">
-    <value>なし</value>
-  </data>
-  <data name="cmbNameBalloon.Items1" xml:space="preserve">
-    <value>ユーザーID</value>
-  </data>
-  <data name="cmbNameBalloon.Items2" xml:space="preserve">
-    <value>ニックネーム</value>
-  </data>
-  <data name="cmbNameBalloon.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 19</value>
-  </data>
-  <data name="cmbNameBalloon.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="cmbNameBalloon.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 23</value>
-  </data>
-  <data name="cmbNameBalloon.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cmbNameBalloon.Name" xml:space="preserve">
-    <value>cmbNameBalloon</value>
-  </data>
-  <data name="&gt;&gt;cmbNameBalloon.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmbNameBalloon.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;cmbNameBalloon.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="CheckDispUsername.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckDispUsername.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckDispUsername.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 54</value>
-  </data>
-  <data name="CheckDispUsername.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckDispUsername.Size" type="System.Drawing.Size, System.Drawing">
-    <value>290, 19</value>
-  </data>
-  <data name="CheckDispUsername.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="CheckDispUsername.Text" xml:space="preserve">
-    <value>タイトルバーとツールチップにユーザー名を表示</value>
-  </data>
-  <data name="&gt;&gt;CheckDispUsername.Name" xml:space="preserve">
-    <value>CheckDispUsername</value>
-  </data>
-  <data name="&gt;&gt;CheckDispUsername.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckDispUsername.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckDispUsername.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="CheckBox3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckBox3.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="CheckBox3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckBox3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 269</value>
-  </data>
-  <data name="CheckBox3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 19</value>
-  </data>
-  <data name="CheckBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="CheckBox3.Text" xml:space="preserve">
-    <value>発言詳細部にアイコンを表示する</value>
-  </data>
-  <data name="&gt;&gt;CheckBox3.Name" xml:space="preserve">
-    <value>CheckBox3</value>
-  </data>
-  <data name="&gt;&gt;CheckBox3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckBox3.Parent" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckBox3.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="PreviewPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="PreviewPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="PreviewPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="PreviewPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="PreviewPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
   <data name="PreviewPanel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="PreviewPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;PreviewPanel.Name" xml:space="preserve">
-    <value>PreviewPanel</value>
-  </data>
-  <data name="&gt;&gt;PreviewPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PreviewPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;PreviewPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="CheckHashSupple.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckHashSupple.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Label31.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="CheckHashSupple.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 212</value>
+  <data name="btnUnread.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 25</value>
   </data>
-  <data name="CheckHashSupple.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckHashSupple.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 19</value>
-  </data>
-  <data name="CheckHashSupple.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="CheckHashSupple.Text" xml:space="preserve">
-    <value>#タグの入力補助を使用する</value>
-  </data>
-  <data name="&gt;&gt;CheckHashSupple.Name" xml:space="preserve">
-    <value>CheckHashSupple</value>
-  </data>
-  <data name="&gt;&gt;CheckHashSupple.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckHashSupple.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckHashSupple.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CheckAtIdSupple.AutoSize" type="System.Boolean, mscorlib">
+  <data name="StartupUserstreamCheck.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="CheckAtIdSupple.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckAtIdSupple.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 182</value>
-  </data>
-  <data name="CheckAtIdSupple.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckAtIdSupple.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 19</value>
-  </data>
-  <data name="CheckAtIdSupple.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="CheckAtIdSupple.Text" xml:space="preserve">
-    <value>@IDの入力補助を使用する</value>
-  </data>
-  <data name="&gt;&gt;CheckAtIdSupple.Name" xml:space="preserve">
-    <value>CheckAtIdSupple</value>
-  </data>
-  <data name="&gt;&gt;CheckAtIdSupple.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckAtIdSupple.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckAtIdSupple.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.Items" xml:space="preserve">
-    <value>Enter</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.Items1" xml:space="preserve">
-    <value>Ctrl+Enter</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.Items2" xml:space="preserve">
-    <value>Shift+Enter</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>245, 24</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>327, 23</value>
-  </data>
-  <data name="ComboBoxPostKeySelect.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxPostKeySelect.Name" xml:space="preserve">
-    <value>ComboBoxPostKeySelect</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxPostKeySelect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxPostKeySelect.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxPostKeySelect.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="Label27.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label27.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label27.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 28</value>
-  </data>
-  <data name="Label27.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label27.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 15</value>
-  </data>
-  <data name="Label27.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="Label27.Text" xml:space="preserve">
-    <value>POSTキー（デフォルトEnter）</value>
-  </data>
-  <data name="&gt;&gt;Label27.Name" xml:space="preserve">
-    <value>Label27</value>
-  </data>
-  <data name="&gt;&gt;Label27.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label27.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;Label27.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 62</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 19</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="CheckRetweetNoConfirm.Text" xml:space="preserve">
-    <value>公式RTする際に確認をしない</value>
-  </data>
-  <data name="&gt;&gt;CheckRetweetNoConfirm.Name" xml:space="preserve">
-    <value>CheckRetweetNoConfirm</value>
-  </data>
-  <data name="&gt;&gt;CheckRetweetNoConfirm.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckRetweetNoConfirm.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckRetweetNoConfirm.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label12.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>31, 118</value>
-  </data>
-  <data name="Label12.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 15</value>
-  </data>
-  <data name="Label12.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="Label12.Text" xml:space="preserve">
-    <value>フッター（文末に付加）</value>
-  </data>
-  <data name="&gt;&gt;Label12.Name" xml:space="preserve">
-    <value>Label12</value>
-  </data>
-  <data name="&gt;&gt;Label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label12.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;Label12.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CheckUseRecommendStatus.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckUseRecommendStatus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckUseRecommendStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>247, 118</value>
-  </data>
-  <data name="CheckUseRecommendStatus.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckUseRecommendStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>242, 19</value>
-  </data>
-  <data name="CheckUseRecommendStatus.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="CheckUseRecommendStatus.Text" xml:space="preserve">
-    <value>推奨フッターを使用する[TWNv○○]</value>
-  </data>
-  <data name="&gt;&gt;CheckUseRecommendStatus.Name" xml:space="preserve">
-    <value>CheckUseRecommendStatus</value>
-  </data>
-  <data name="&gt;&gt;CheckUseRecommendStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckUseRecommendStatus.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckUseRecommendStatus.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="StatusText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>247, 145</value>
-  </data>
-  <data name="StatusText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="StatusText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>308, 22</value>
-  </data>
-  <data name="StatusText.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;StatusText.Name" xml:space="preserve">
-    <value>StatusText</value>
-  </data>
-  <data name="&gt;&gt;StatusText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;StatusText.Parent" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;StatusText.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="TweetActPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="TweetActPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="TweetActPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="TweetActPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TweetActPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="TweetActPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="TweetActPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;TweetActPanel.Name" xml:space="preserve">
-    <value>TweetActPanel</value>
-  </data>
-  <data name="&gt;&gt;TweetActPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TweetActPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;TweetActPanel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ListTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="ListTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 229</value>
-  </data>
-  <data name="ListTextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ListTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="ListTextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;ListTextCountApi.Name" xml:space="preserve">
-    <value>ListTextCountApi</value>
-  </data>
-  <data name="&gt;&gt;ListTextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ListTextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;ListTextCountApi.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Label25.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label25.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 232</value>
-  </data>
-  <data name="Label25.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label25.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 15</value>
-  </data>
-  <data name="Label25.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="Label25.Text" xml:space="preserve">
-    <value>Listsの取得数</value>
-  </data>
-  <data name="&gt;&gt;Label25.Name" xml:space="preserve">
-    <value>Label25</value>
-  </data>
-  <data name="&gt;&gt;Label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label25.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label25.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="UserTimelineTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="UserTimelineTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 294</value>
-  </data>
-  <data name="UserTimelineTextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="UserTimelineTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="UserTimelineTextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;UserTimelineTextCountApi.Name" xml:space="preserve">
-    <value>UserTimelineTextCountApi</value>
-  </data>
-  <data name="&gt;&gt;UserTimelineTextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;UserTimelineTextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;UserTimelineTextCountApi.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="Label17.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label17.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 296</value>
-  </data>
-  <data name="Label17.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label17.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 15</value>
-  </data>
-  <data name="Label17.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="Label17.Text" xml:space="preserve">
-    <value>UserTimelineの取得数</value>
-  </data>
-  <data name="&gt;&gt;Label17.Name" xml:space="preserve">
-    <value>Label17</value>
-  </data>
-  <data name="&gt;&gt;Label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label17.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label17.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Label30.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label30.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 262</value>
-  </data>
-  <data name="Label30.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label30.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 15</value>
-  </data>
-  <data name="Label30.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="Label30.Text" xml:space="preserve">
-    <value>PublicSearchの取得数</value>
-  </data>
-  <data name="&gt;&gt;Label30.Name" xml:space="preserve">
-    <value>Label30</value>
-  </data>
-  <data name="&gt;&gt;Label30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label30.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label30.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label28.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label28.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 170</value>
-  </data>
-  <data name="Label28.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label28.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 15</value>
-  </data>
-  <data name="Label28.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="Label28.Text" xml:space="preserve">
-    <value>初回の更新</value>
-  </data>
-  <data name="&gt;&gt;Label28.Name" xml:space="preserve">
-    <value>Label28</value>
-  </data>
-  <data name="&gt;&gt;Label28.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label28.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label28.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Label19.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label19.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 68</value>
-  </data>
-  <data name="Label19.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 15</value>
-  </data>
-  <data name="Label19.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="Label19.Text" xml:space="preserve">
-    <value>Mentions取得数</value>
-  </data>
-  <data name="&gt;&gt;Label19.Name" xml:space="preserve">
-    <value>Label19</value>
-  </data>
-  <data name="&gt;&gt;Label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label19.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label19.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="FavoritesTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="FavoritesTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 199</value>
-  </data>
-  <data name="FavoritesTextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="FavoritesTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="FavoritesTextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;FavoritesTextCountApi.Name" xml:space="preserve">
-    <value>FavoritesTextCountApi</value>
-  </data>
-  <data name="&gt;&gt;FavoritesTextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FavoritesTextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;FavoritesTextCountApi.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="SearchTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="SearchTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 261</value>
-  </data>
-  <data name="SearchTextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="SearchTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="SearchTextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;SearchTextCountApi.Name" xml:space="preserve">
-    <value>SearchTextCountApi</value>
-  </data>
-  <data name="&gt;&gt;SearchTextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SearchTextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;SearchTextCountApi.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Label66.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label66.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label66.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 200</value>
-  </data>
-  <data name="Label66.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label66.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 15</value>
-  </data>
-  <data name="Label66.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="Label66.Text" xml:space="preserve">
-    <value>Favoritesの取得数</value>
-  </data>
-  <data name="&gt;&gt;Label66.Name" xml:space="preserve">
-    <value>Label66</value>
-  </data>
-  <data name="&gt;&gt;Label66.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label66.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label66.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="FirstTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="FirstTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 169</value>
-  </data>
-  <data name="FirstTextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="FirstTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="FirstTextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;FirstTextCountApi.Name" xml:space="preserve">
-    <value>FirstTextCountApi</value>
-  </data>
-  <data name="&gt;&gt;FirstTextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FirstTextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;FirstTextCountApi.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="GetMoreTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="GetMoreTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 140</value>
-  </data>
-  <data name="GetMoreTextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GetMoreTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="GetMoreTextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;GetMoreTextCountApi.Name" xml:space="preserve">
-    <value>GetMoreTextCountApi</value>
-  </data>
-  <data name="&gt;&gt;GetMoreTextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GetMoreTextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;GetMoreTextCountApi.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="Label53.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label53.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label53.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 140</value>
-  </data>
-  <data name="Label53.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label53.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 15</value>
-  </data>
-  <data name="Label53.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="Label53.Text" xml:space="preserve">
-    <value>前データの更新</value>
-  </data>
-  <data name="&gt;&gt;Label53.Name" xml:space="preserve">
-    <value>Label53</value>
-  </data>
-  <data name="&gt;&gt;Label53.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label53.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label53.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="UseChangeGetCount.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="UseChangeGetCount.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="UseChangeGetCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 108</value>
-  </data>
-  <data name="UseChangeGetCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="UseChangeGetCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 19</value>
-  </data>
-  <data name="UseChangeGetCount.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="UseChangeGetCount.Text" xml:space="preserve">
-    <value>次の項目の更新時の取得数を個別に設定する</value>
-  </data>
-  <data name="&gt;&gt;UseChangeGetCount.Name" xml:space="preserve">
-    <value>UseChangeGetCount</value>
-  </data>
-  <data name="&gt;&gt;UseChangeGetCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;UseChangeGetCount.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;UseChangeGetCount.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="TextCountApiReply.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="TextCountApiReply.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 64</value>
-  </data>
-  <data name="TextCountApiReply.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextCountApiReply.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="TextCountApiReply.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;TextCountApiReply.Name" xml:space="preserve">
-    <value>TextCountApiReply</value>
-  </data>
-  <data name="&gt;&gt;TextCountApiReply.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextCountApiReply.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;TextCountApiReply.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="Label67.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label67.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label67.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 30</value>
-  </data>
-  <data name="Label67.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label67.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 15</value>
-  </data>
-  <data name="Label67.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label67.Text" xml:space="preserve">
-    <value>標準取得件数</value>
-  </data>
-  <data name="&gt;&gt;Label67.Name" xml:space="preserve">
-    <value>Label67</value>
-  </data>
-  <data name="&gt;&gt;Label67.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label67.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;Label67.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="TextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="TextCountApi.Location" type="System.Drawing.Point, System.Drawing">
-    <value>411, 26</value>
-  </data>
-  <data name="TextCountApi.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextCountApi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 22</value>
-  </data>
-  <data name="TextCountApi.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;TextCountApi.Name" xml:space="preserve">
-    <value>TextCountApi</value>
-  </data>
-  <data name="&gt;&gt;TextCountApi.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextCountApi.Parent" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;TextCountApi.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="GetCountPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="GetCountPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="GetCountPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="GetCountPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GetCountPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="GetCountPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="GetCountPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;GetCountPanel.Name" xml:space="preserve">
-    <value>GetCountPanel</value>
-  </data>
-  <data name="&gt;&gt;GetCountPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GetCountPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;GetCountPanel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ShortenTcoCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="ShortenTcoCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ShortenTcoCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 112</value>
-  </data>
-  <data name="ShortenTcoCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ShortenTcoCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 19</value>
-  </data>
-  <data name="ShortenTcoCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="ShortenTcoCheck.Text" xml:space="preserve">
-    <value>t.coで短縮する</value>
-  </data>
-  <data name="ShortenTcoCheck.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;ShortenTcoCheck.Name" xml:space="preserve">
-    <value>ShortenTcoCheck</value>
-  </data>
-  <data name="&gt;&gt;ShortenTcoCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ShortenTcoCheck.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;ShortenTcoCheck.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CheckForceResolve.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckForceResolve.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckForceResolve.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 56</value>
-  </data>
-  <data name="CheckForceResolve.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckForceResolve.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 19</value>
-  </data>
-  <data name="CheckForceResolve.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="CheckForceResolve.Text" xml:space="preserve">
-    <value>すべてのURLについて解決を試みる</value>
-  </data>
-  <data name="&gt;&gt;CheckForceResolve.Name" xml:space="preserve">
-    <value>CheckForceResolve</value>
-  </data>
-  <data name="&gt;&gt;CheckForceResolve.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckForceResolve.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckForceResolve.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="CheckTinyURL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckTinyURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckTinyURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 28</value>
-  </data>
-  <data name="CheckTinyURL.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckTinyURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 19</value>
-  </data>
-  <data name="CheckTinyURL.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CheckTinyURL.Text" xml:space="preserve">
-    <value>短縮URLを解決する</value>
-  </data>
-  <data name="&gt;&gt;CheckTinyURL.Name" xml:space="preserve">
-    <value>CheckTinyURL</value>
-  </data>
-  <data name="&gt;&gt;CheckTinyURL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckTinyURL.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckTinyURL.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="TextBitlyPw.Location" type="System.Drawing.Point, System.Drawing">
-    <value>551, 201</value>
-  </data>
-  <data name="TextBitlyPw.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextBitlyPw.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 22</value>
-  </data>
-  <data name="TextBitlyPw.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyPw.Name" xml:space="preserve">
-    <value>TextBitlyPw</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyPw.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyPw.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyPw.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="CheckAutoConvertUrl.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckAutoConvertUrl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckAutoConvertUrl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 85</value>
-  </data>
-  <data name="CheckAutoConvertUrl.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckAutoConvertUrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>301, 19</value>
-  </data>
-  <data name="CheckAutoConvertUrl.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="CheckAutoConvertUrl.Text" xml:space="preserve">
-    <value>入力欄のURLを投稿する際に自動で短縮する</value>
-  </data>
-  <data name="CheckAutoConvertUrl.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;CheckAutoConvertUrl.Name" xml:space="preserve">
-    <value>CheckAutoConvertUrl</value>
-  </data>
-  <data name="&gt;&gt;CheckAutoConvertUrl.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckAutoConvertUrl.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckAutoConvertUrl.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label71.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label71.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label71.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 176</value>
-  </data>
-  <data name="Label71.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label71.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 15</value>
-  </data>
-  <data name="Label71.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Label71.Text" xml:space="preserve">
-    <value>URL自動短縮で優先的に使用</value>
-  </data>
-  <data name="&gt;&gt;Label71.Name" xml:space="preserve">
-    <value>Label71</value>
-  </data>
-  <data name="&gt;&gt;Label71.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label71.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;Label71.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Items" xml:space="preserve">
-    <value>tinyurl</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Items1" xml:space="preserve">
-    <value>is.gd</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Items2" xml:space="preserve">
-    <value>twurl.nl</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Items3" xml:space="preserve">
-    <value>bit.ly</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Items4" xml:space="preserve">
-    <value>j.mp</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Items5" xml:space="preserve">
-    <value>ux.nu</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>335, 172</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>327, 23</value>
-  </data>
-  <data name="ComboBoxAutoShortUrlFirst.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.Name" xml:space="preserve">
-    <value>ComboBoxAutoShortUrlFirst</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Label76.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label76.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label76.Location" type="System.Drawing.Point, System.Drawing">
-    <value>333, 205</value>
-  </data>
-  <data name="Label76.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label76.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 15</value>
-  </data>
-  <data name="Label76.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="Label76.Text" xml:space="preserve">
-    <value>ID</value>
-  </data>
-  <data name="&gt;&gt;Label76.Name" xml:space="preserve">
-    <value>Label76</value>
-  </data>
-  <data name="&gt;&gt;Label76.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label76.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;Label76.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="Label77.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label77.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label77.Location" type="System.Drawing.Point, System.Drawing">
-    <value>488, 205</value>
-  </data>
-  <data name="Label77.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label77.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 15</value>
-  </data>
-  <data name="Label77.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="Label77.Text" xml:space="preserve">
-    <value>APIKey</value>
-  </data>
-  <data name="&gt;&gt;Label77.Name" xml:space="preserve">
-    <value>Label77</value>
-  </data>
-  <data name="&gt;&gt;Label77.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label77.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;Label77.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="TextBitlyId.Location" type="System.Drawing.Point, System.Drawing">
-    <value>361, 201</value>
-  </data>
-  <data name="TextBitlyId.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextBitlyId.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 22</value>
-  </data>
-  <data name="TextBitlyId.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyId.Name" xml:space="preserve">
-    <value>TextBitlyId</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyId.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyId.Parent" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;TextBitlyId.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="ShortUrlPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="ShortUrlPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="ShortUrlPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="ShortUrlPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ShortUrlPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="ShortUrlPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="ShortUrlPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;ShortUrlPanel.Name" xml:space="preserve">
-    <value>ShortUrlPanel</value>
-  </data>
-  <data name="&gt;&gt;ShortUrlPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ShortUrlPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;ShortUrlPanel.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="AuthUserCombo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>145, 32</value>
-  </data>
-  <data name="AuthUserCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="AuthUserCombo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 23</value>
-  </data>
-  <data name="AuthUserCombo.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;AuthUserCombo.Name" xml:space="preserve">
-    <value>AuthUserCombo</value>
-  </data>
-  <data name="&gt;&gt;AuthUserCombo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AuthUserCombo.Parent" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;AuthUserCombo.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 21</value>
-  </data>
-  <data name="Label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>617, 32</value>
-  </data>
-  <data name="Label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label1.Text" xml:space="preserve">
-    <value>サポート用アカウントのフォローをお勧めしています。</value>
-  </data>
-  <data name="&gt;&gt;Label1.Name" xml:space="preserve">
-    <value>Label1</value>
-  </data>
-  <data name="&gt;&gt;Label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label1.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;Label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="EmailText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>191, 85</value>
-  </data>
-  <data name="EmailText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="EmailText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>433, 22</value>
-  </data>
-  <data name="EmailText.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="EmailText.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;EmailText.Name" xml:space="preserve">
-    <value>EmailText</value>
-  </data>
-  <data name="&gt;&gt;EmailText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;EmailText.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;EmailText.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label6.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>45, 89</value>
-  </data>
-  <data name="Label6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 15</value>
-  </data>
-  <data name="Label6.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="Label6.Text" xml:space="preserve">
-    <value>メールアドレスの登録</value>
-  </data>
-  <data name="Label6.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;Label6.Name" xml:space="preserve">
-    <value>Label6</value>
-  </data>
-  <data name="&gt;&gt;Label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label6.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;Label6.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="FollowCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="FollowCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="FollowCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 70</value>
-  </data>
-  <data name="FollowCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="FollowCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>171, 24</value>
-  </data>
-  <data name="FollowCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="FollowCheckBox.Text" xml:space="preserve">
-    <value>{0} をフォローする</value>
-  </data>
-  <data name="&gt;&gt;FollowCheckBox.Name" xml:space="preserve">
-    <value>FollowCheckBox</value>
-  </data>
-  <data name="&gt;&gt;FollowCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FollowCheckBox.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;FollowCheckBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Label43.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label43.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 126</value>
-  </data>
-  <data name="Label43.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label43.Size" type="System.Drawing.Size, System.Drawing">
-    <value>613, 61</value>
-  </data>
-  <data name="Label43.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="Label43.Text" xml:space="preserve">
-    <value>バージョンアップやお役立ち情報をお伝えするほか、要望やお問い合わせの受付、回答をいたします。</value>
-  </data>
-  <data name="&gt;&gt;Label43.Name" xml:space="preserve">
-    <value>Label43</value>
-  </data>
-  <data name="&gt;&gt;Label43.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label43.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;Label43.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="GroupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 201</value>
-  </data>
-  <data name="GroupBox2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>635, 202</value>
-  </data>
-  <data name="GroupBox2.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="GroupBox2.Text" xml:space="preserve">
-    <value>Tweenサポート</value>
-  </data>
-  <data name="&gt;&gt;GroupBox2.Name" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;GroupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GroupBox2.Parent" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;GroupBox2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="CreateAccountButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CreateAccountButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 414</value>
-  </data>
-  <data name="CreateAccountButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CreateAccountButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 29</value>
-  </data>
-  <data name="CreateAccountButton.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="CreateAccountButton.Text" xml:space="preserve">
-    <value>Twitter アカウントを作成する</value>
-  </data>
-  <data name="&gt;&gt;CreateAccountButton.Name" xml:space="preserve">
-    <value>CreateAccountButton</value>
-  </data>
-  <data name="&gt;&gt;CreateAccountButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CreateAccountButton.Parent" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;CreateAccountButton.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="StartAuthButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="StartAuthButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>132, 85</value>
-  </data>
-  <data name="StartAuthButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="StartAuthButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>428, 56</value>
-  </data>
-  <data name="StartAuthButton.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="StartAuthButton.Text" xml:space="preserve">
-    <value>認証開始</value>
-  </data>
-  <data name="&gt;&gt;StartAuthButton.Name" xml:space="preserve">
-    <value>StartAuthButton</value>
-  </data>
-  <data name="&gt;&gt;StartAuthButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;StartAuthButton.Parent" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;StartAuthButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="AuthClearButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="AuthClearButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>404, 30</value>
-  </data>
-  <data name="AuthClearButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="AuthClearButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 29</value>
-  </data>
-  <data name="AuthClearButton.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="AuthClearButton.Text" xml:space="preserve">
-    <value>削除</value>
-  </data>
-  <data name="&gt;&gt;AuthClearButton.Name" xml:space="preserve">
-    <value>AuthClearButton</value>
-  </data>
-  <data name="&gt;&gt;AuthClearButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AuthClearButton.Parent" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;AuthClearButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 36</value>
-  </data>
-  <data name="Label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 15</value>
-  </data>
-  <data name="Label4.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label4.Text" xml:space="preserve">
-    <value>アカウント</value>
-  </data>
-  <data name="&gt;&gt;Label4.Name" xml:space="preserve">
-    <value>Label4</value>
-  </data>
-  <data name="&gt;&gt;Label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label4.Parent" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;Label4.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="BasedPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="BasedPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="BasedPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="BasedPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="BasedPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="BasedPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="BasedPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;BasedPanel.Name" xml:space="preserve">
-    <value>BasedPanel</value>
-  </data>
-  <data name="&gt;&gt;BasedPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BasedPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;BasedPanel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 106</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 19</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="IsListsIncludeRtsCheckBox.Text" xml:space="preserve">
-    <value>Listの発言取得に公式RTを含める</value>
-  </data>
-  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.Name" xml:space="preserve">
-    <value>IsListsIncludeRtsCheckBox</value>
-  </data>
-  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 54</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>207, 19</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="HideDuplicatedRetweetsCheck.Text" xml:space="preserve">
-    <value>重複した公式RTを表示しない</value>
-  </data>
-  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.Name" xml:space="preserve">
-    <value>HideDuplicatedRetweetsCheck</value>
-  </data>
-  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label47.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label47.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label47.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 222</value>
-  </data>
-  <data name="Label47.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label47.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 15</value>
-  </data>
-  <data name="Label47.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="Label47.Text" xml:space="preserve">
-    <value>再起動後有効になります。</value>
-  </data>
-  <data name="&gt;&gt;Label47.Name" xml:space="preserve">
-    <value>Label47</value>
-  </data>
-  <data name="&gt;&gt;Label47.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label47.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;Label47.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.Location" type="System.Drawing.Point, System.Drawing">
-    <value>352, 168</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 15</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="LabelDateTimeFormatApplied.Text" xml:space="preserve">
-    <value>Label63</value>
-  </data>
-  <data name="&gt;&gt;LabelDateTimeFormatApplied.Name" xml:space="preserve">
-    <value>LabelDateTimeFormatApplied</value>
-  </data>
-  <data name="&gt;&gt;LabelDateTimeFormatApplied.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelDateTimeFormatApplied.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelDateTimeFormatApplied.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Label62.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label62.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label62.Location" type="System.Drawing.Point, System.Drawing">
-    <value>289, 168</value>
-  </data>
-  <data name="Label62.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label62.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 15</value>
-  </data>
-  <data name="Label62.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="Label62.Text" xml:space="preserve">
-    <value>Sample:</value>
-  </data>
-  <data name="&gt;&gt;Label62.Name" xml:space="preserve">
-    <value>Label62</value>
-  </data>
-  <data name="&gt;&gt;Label62.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label62.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;Label62.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="CmbDateTimeFormat.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items" xml:space="preserve">
-    <value>yyyy/MM/dd H:mm:ss</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items1" xml:space="preserve">
-    <value>yy/M/d H:mm:ss</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items2" xml:space="preserve">
-    <value>H:mm:ss yy/M/d</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items3" xml:space="preserve">
-    <value>M/d H:mm:ss</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items4" xml:space="preserve">
-    <value>M/d H:mm</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items5" xml:space="preserve">
-    <value>H:mm:ss M/d</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items6" xml:space="preserve">
-    <value>H:mm:ss</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items7" xml:space="preserve">
-    <value>H:mm</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items8" xml:space="preserve">
-    <value>tt h:mm</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items9" xml:space="preserve">
-    <value>M/d tt h:mm:ss</value>
-  </data>
-  <data name="CmbDateTimeFormat.Items10" xml:space="preserve">
-    <value>M/d tt h:mm</value>
-  </data>
-  <data name="CmbDateTimeFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 139</value>
-  </data>
-  <data name="CmbDateTimeFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CmbDateTimeFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 23</value>
-  </data>
-  <data name="CmbDateTimeFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;CmbDateTimeFormat.Name" xml:space="preserve">
-    <value>CmbDateTimeFormat</value>
-  </data>
-  <data name="&gt;&gt;CmbDateTimeFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CmbDateTimeFormat.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;CmbDateTimeFormat.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Label23.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label23.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label23.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 142</value>
-  </data>
-  <data name="Label23.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 15</value>
-  </data>
-  <data name="Label23.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Label23.Text" xml:space="preserve">
-    <value>リストの日時フォーマット</value>
-  </data>
-  <data name="&gt;&gt;Label23.Name" xml:space="preserve">
-    <value>Label23</value>
-  </data>
-  <data name="&gt;&gt;Label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label23.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;Label23.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Label11.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 190</value>
-  </data>
-  <data name="Label11.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 15</value>
-  </data>
-  <data name="Label11.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="Label11.Text" xml:space="preserve">
-    <value>リストのアイコンサイズ（初期値16）</value>
-  </data>
-  <data name="&gt;&gt;Label11.Name" xml:space="preserve">
-    <value>Label11</value>
-  </data>
-  <data name="&gt;&gt;Label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label11.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;Label11.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="IconSize.Items" xml:space="preserve">
     <value>none</value>
   </data>
+  <data name="lblUnread.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="PreviewPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;TextCountApi.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="UReadMng.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 16</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 25</value>
+  </data>
+  <data name="Label57.Text" xml:space="preserve">
+    <value>発言を再取得してFav結果を検証します。通信量が増えるのでOff推奨</value>
+  </data>
+  <data name="&gt;&gt;lblAtTo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckDispUsername.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="Label39.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Save.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="LabelDateTimeFormatApplied.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="IconSize.Items1" xml:space="preserve">
     <value>16*16</value>
   </data>
-  <data name="IconSize.Items2" xml:space="preserve">
-    <value>24*24</value>
+  <data name="Label80.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="IconSize.Items3" xml:space="preserve">
-    <value>48*48</value>
+  <data name="&gt;&gt;StartupUserstreamCheck.ZOrder" xml:space="preserve">
+    <value>21</value>
   </data>
-  <data name="IconSize.Items4" xml:space="preserve">
-    <value>48*48(2Column)</value>
-  </data>
-  <data name="IconSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>336, 186</value>
-  </data>
-  <data name="IconSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="IconSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 23</value>
-  </data>
-  <data name="IconSize.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;IconSize.Name" xml:space="preserve">
-    <value>IconSize</value>
-  </data>
-  <data name="&gt;&gt;IconSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;IconSize.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;IconSize.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="TextBox3.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="TextBox3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 188</value>
-  </data>
-  <data name="TextBox3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 22</value>
-  </data>
-  <data name="TextBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;TextBox3.Name" xml:space="preserve">
-    <value>TextBox3</value>
-  </data>
-  <data name="&gt;&gt;TextBox3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextBox3.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;TextBox3.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="CheckSortOrderLock.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckSortOrderLock.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckSortOrderLock.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 309</value>
-  </data>
-  <data name="CheckSortOrderLock.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckSortOrderLock.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 19</value>
-  </data>
-  <data name="CheckSortOrderLock.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="CheckSortOrderLock.Text" xml:space="preserve">
-    <value>ソート順を変更できないようにロックする</value>
-  </data>
-  <data name="&gt;&gt;CheckSortOrderLock.Name" xml:space="preserve">
-    <value>CheckSortOrderLock</value>
-  </data>
-  <data name="&gt;&gt;CheckSortOrderLock.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckSortOrderLock.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckSortOrderLock.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="CheckShowGrid.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckShowGrid.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckShowGrid.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 278</value>
-  </data>
-  <data name="CheckShowGrid.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckShowGrid.Size" type="System.Drawing.Size, System.Drawing">
-    <value>191, 19</value>
-  </data>
-  <data name="CheckShowGrid.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="CheckShowGrid.Text" xml:space="preserve">
-    <value>リストの区切り線を表示する</value>
-  </data>
-  <data name="&gt;&gt;CheckShowGrid.Name" xml:space="preserve">
-    <value>CheckShowGrid</value>
-  </data>
-  <data name="&gt;&gt;CheckShowGrid.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckShowGrid.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckShowGrid.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="chkUnreadStyle.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkUnreadStyle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkUnreadStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 81</value>
-  </data>
-  <data name="chkUnreadStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="chkUnreadStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>282, 19</value>
-  </data>
-  <data name="chkUnreadStyle.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="chkUnreadStyle.Text" xml:space="preserve">
-    <value>未読ポストのフォントと色を変更する（低速）</value>
-  </data>
-  <data name="&gt;&gt;chkUnreadStyle.Name" xml:space="preserve">
-    <value>chkUnreadStyle</value>
-  </data>
-  <data name="&gt;&gt;chkUnreadStyle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkUnreadStyle.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;chkUnreadStyle.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="OneWayLv.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="OneWayLv.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="OneWayLv.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 26</value>
-  </data>
-  <data name="OneWayLv.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="OneWayLv.Size" type="System.Drawing.Size, System.Drawing">
-    <value>201, 19</value>
-  </data>
-  <data name="OneWayLv.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;GroupBox5.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="OneWayLv.Text" xml:space="preserve">
-    <value>片思いを色分けして表示する</value>
+  <data name="SplitContainer1.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="&gt;&gt;OneWayLv.Name" xml:space="preserve">
-    <value>OneWayLv</value>
+  <data name="AuthUserCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>109, 26</value>
+  </data>
+  <data name="RadioProxyNone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 16</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ReplyIconStateCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>215, 142</value>
+  </data>
+  <data name="&gt;&gt;Label9.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;UserstreamPeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items22" xml:space="preserve">
+    <value>Chinese (Taiwan)</value>
+  </data>
+  <data name="Label67.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;RadioProxyNone.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="CheckAtIdSupple.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TimelinePeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;Label15.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;SearchTextCountApi.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;StartAuthButton.Name" xml:space="preserve">
+    <value>StartAuthButton</value>
+  </data>
+  <data name="Label81.Location" type="System.Drawing.Point, System.Drawing">
+    <value>83, 290</value>
+  </data>
+  <data name="&gt;&gt;Label4.Name" xml:space="preserve">
+    <value>Label4</value>
+  </data>
+  <data name="Label33.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;Label6.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="&gt;&gt;TextProxyPort.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;ListTextCountApi.Name" xml:space="preserve">
+    <value>ListTextCountApi</value>
+  </data>
+  <data name="CheckShowGrid.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 16</value>
+  </data>
+  <data name="TweetActPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnDetailBack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 196</value>
+  </data>
+  <data name="Label36.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ConnectionTimeOut.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="Label34.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 45</value>
+  </data>
+  <data name="btnDetail.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnAtTo.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="Label9.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="CheckForceEventNotify.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 16</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items90" xml:space="preserve">
+    <value>Sorbian</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyId.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="TextBitlyId.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;LanguageCombo.Name" xml:space="preserve">
+    <value>LanguageCombo</value>
+  </data>
+  <data name="&gt;&gt;btnAtSelf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="IsListsIncludeRtsCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TwitterSearchAPIText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 19</value>
+  </data>
+  <data name="&gt;&gt;btnAtSelf.Name" xml:space="preserve">
+    <value>btnAtSelf</value>
+  </data>
+  <data name="&gt;&gt;btnOWL.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="CheckCloseToExit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>171, 16</value>
+  </data>
+  <data name="CreateAccountButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>315, 331</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items49" xml:space="preserve">
+    <value>French (Canada)</value>
+  </data>
+  <data name="&gt;&gt;ConnectionTimeOut.Name" xml:space="preserve">
+    <value>ConnectionTimeOut</value>
+  </data>
+  <data name="&gt;&gt;btnDetailBack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items40" xml:space="preserve">
+    <value>English (Caribbean)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items41" xml:space="preserve">
+    <value>English (Belize)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items42" xml:space="preserve">
+    <value>English (Trinidad)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items43" xml:space="preserve">
+    <value>Estonian</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items44" xml:space="preserve">
+    <value>Faeroese</value>
+  </data>
+  <data name="CmbDateTimeFormat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 20</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items46" xml:space="preserve">
+    <value>Finnish</value>
+  </data>
+  <data name="&gt;&gt;AuthClearButton.Name" xml:space="preserve">
+    <value>AuthClearButton</value>
+  </data>
+  <data name="MapThumbnailProviderComboBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;ComboBoxTranslateLanguage.Name" xml:space="preserve">
+    <value>ComboBoxTranslateLanguage</value>
+  </data>
+  <data name="&gt;&gt;CheckDispUsername.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items106" xml:space="preserve">
+    <value>Spanish (El Salvador)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items116" xml:space="preserve">
+    <value>Turkish</value>
+  </data>
+  <data name="CooperatePanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CheckStartupFollowers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 16</value>
+  </data>
+  <data name="Label77.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;btnDetail.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;EmailText.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnDetailBack.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="Label12.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblRetweet.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Save.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;CheckNicoms.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;CheckSortOrderLock.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;CheckPostAndGet.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items23" xml:space="preserve">
+    <value>Chinese (PRC)</value>
+  </data>
+  <data name="CheckPeriodAdjust.Text" xml:space="preserve">
+    <value>自動調整する</value>
+  </data>
+  <data name="Label80.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 12</value>
+  </data>
+  <data name="&gt;&gt;StartupPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Label10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CreateAccountButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ShortUrlPanel.Name" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="Label38.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 12</value>
+  </data>
+  <data name="ShortenTcoCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label67.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GetPeriodPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="btnDetail.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label53.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="btnListBack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 165</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Items" xml:space="preserve">
+    <value>tinyurl</value>
+  </data>
+  <data name="&gt;&gt;CheckForceEventNotify.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="GroupBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="Label64.Text" xml:space="preserve">
+    <value>※タイムアウトが頻発する場合に調整してください。初期設定は20秒です。</value>
+  </data>
+  <data name="CheckStartupFollowers.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="UserAppointUrlText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>205, 220</value>
+  </data>
+  <data name="CheckDispUsername.Size" type="System.Drawing.Size, System.Drawing">
+    <value>235, 16</value>
+  </data>
+  <data name="&gt;&gt;lblOWL.Name" xml:space="preserve">
+    <value>lblOWL</value>
+  </data>
+  <data name="Label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>103, 12</value>
+  </data>
+  <data name="Label72.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;Label13.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="Label71.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 12</value>
+  </data>
+  <data name="&gt;&gt;Label76.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;Label11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="BasedPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;CheckMonospace.Name" xml:space="preserve">
+    <value>CheckMonospace</value>
+  </data>
+  <data name="&gt;&gt;UseChangeGetCount.Name" xml:space="preserve">
+    <value>UseChangeGetCount</value>
+  </data>
+  <data name="&gt;&gt;chkReadOwnPost.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label42.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="TextBoxOutputzKey.Size" type="System.Drawing.Size, System.Drawing">
+    <value>182, 19</value>
+  </data>
+  <data name="CheckFollowEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>87, 16</value>
+  </data>
+  <data name="Label33.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label36.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;OneWayLv.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;OneWayLv.Parent" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;OneWayLv.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="TweetPrvPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="TweetPrvPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="TweetPrvPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="TweetPrvPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TweetPrvPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="TweetPrvPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="TweetPrvPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;TweetPrvPanel.Name" xml:space="preserve">
-    <value>TweetPrvPanel</value>
-  </data>
-  <data name="&gt;&gt;TweetPrvPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TweetPrvPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;TweetPrvPanel.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 321</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>321, 19</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="IsRemoveSameFavEventCheckBox.Text" xml:space="preserve">
-    <value>重複するFav追加、Fav削除のイベントは無視する</value>
-  </data>
-  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.Name" xml:space="preserve">
-    <value>IsRemoveSameFavEventCheckBox</value>
-  </data>
-  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CheckUserUpdateEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckUserUpdateEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 181</value>
-  </data>
-  <data name="CheckUserUpdateEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckUserUpdateEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>230, 19</value>
-  </data>
-  <data name="CheckUserUpdateEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="CheckUserUpdateEvent.Text" xml:space="preserve">
-    <value>ユーザーのプロフィールが更新された</value>
-  </data>
-  <data name="CheckUserUpdateEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
-  </data>
-  <data name="&gt;&gt;CheckUserUpdateEvent.Name" xml:space="preserve">
-    <value>CheckUserUpdateEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckUserUpdateEvent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckUserUpdateEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckUserUpdateEvent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label35.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label35.Location" type="System.Drawing.Point, System.Drawing">
-    <value>31, 351</value>
-  </data>
-  <data name="Label35.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label35.Size" type="System.Drawing.Size, System.Drawing">
-    <value>220, 15</value>
-  </data>
-  <data name="Label35.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="Label35.Text" xml:space="preserve">
-    <value>イベント通知の際に再生するサウンド</value>
-  </data>
-  <data name="&gt;&gt;Label35.Name" xml:space="preserve">
-    <value>Label35</value>
-  </data>
-  <data name="&gt;&gt;Label35.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label35.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;Label35.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ComboBoxEventNotifySound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>381, 348</value>
-  </data>
-  <data name="ComboBoxEventNotifySound.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ComboBoxEventNotifySound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>249, 23</value>
-  </data>
-  <data name="ComboBoxEventNotifySound.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxEventNotifySound.Name" xml:space="preserve">
-    <value>ComboBoxEventNotifySound</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxEventNotifySound.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxEventNotifySound.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxEventNotifySound.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="CheckFavEventUnread.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckFavEventUnread.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 300</value>
-  </data>
-  <data name="CheckFavEventUnread.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckFavEventUnread.Size" type="System.Drawing.Size, System.Drawing">
-    <value>336, 19</value>
-  </data>
-  <data name="CheckFavEventUnread.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="CheckFavEventUnread.Text" xml:space="preserve">
-    <value>Favoritesイベント受信の際に書き込みを未読に戻す</value>
-  </data>
-  <data name="&gt;&gt;CheckFavEventUnread.Name" xml:space="preserve">
-    <value>CheckFavEventUnread</value>
+  <data name="ComboBoxTranslateLanguage.Items31" xml:space="preserve">
+    <value>English</value>
   </data>
   <data name="&gt;&gt;CheckFavEventUnread.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;CheckFavEventUnread.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
+  <data name="lblListFont.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;CheckFavEventUnread.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="IconSize.Items3" xml:space="preserve">
+    <value>48*48</value>
   </data>
-  <data name="CheckListCreatedEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;GroupBox3.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
   </data>
-  <data name="CheckListCreatedEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 202</value>
+  <data name="&gt;&gt;LabelApiUsing.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
   </data>
-  <data name="CheckListCreatedEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;CheckPeriodAdjust.ZOrder" xml:space="preserve">
+    <value>18</value>
   </data>
-  <data name="CheckListCreatedEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 19</value>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
-  <data name="CheckListCreatedEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="CheckPreviewEnable.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 191</value>
   </data>
-  <data name="CheckListCreatedEvent.Text" xml:space="preserve">
-    <value>Listsの作成に成功した</value>
+  <data name="&gt;&gt;Label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="CheckListCreatedEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
-  </data>
-  <data name="&gt;&gt;CheckListCreatedEvent.Name" xml:space="preserve">
-    <value>CheckListCreatedEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckListCreatedEvent.Type" xml:space="preserve">
+  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;CheckListCreatedEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
+  <data name="&gt;&gt;Label77.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;CheckListCreatedEvent.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="lblListFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="CheckBlockEvent.AutoSize" type="System.Boolean, mscorlib">
+  <data name="Label27.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="CheckBlockEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 160</value>
+  <data name="&gt;&gt;CmbDateTimeFormat.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="CheckBlockEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="StartupReaded.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="CheckBlockEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>261, 19</value>
+  <data name="IsNotifyUseGrowlCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 16</value>
   </data>
-  <data name="CheckBlockEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="ReplyPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="CheckBlockEvent.Text" xml:space="preserve">
-    <value>他のユーザーに対するブロックが成功した</value>
+  <data name="CheckBalloonLimit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 66</value>
   </data>
-  <data name="CheckBlockEvent.ToolTip" xml:space="preserve">
+  <data name="&gt;&gt;ToolTip1.Name" xml:space="preserve">
+    <value>ToolTip1</value>
+  </data>
+  <data name="Label59.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckTinyURL.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 22</value>
+  </data>
+  <data name="CheckUnfavoritesEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label44.Name" xml:space="preserve">
+    <value>Label44</value>
+  </data>
+  <data name="&gt;&gt;TextBox3.Name" xml:space="preserve">
+    <value>TextBox3</value>
+  </data>
+  <data name="&gt;&gt;CheckForceResolve.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="HotkeyWin.Text" xml:space="preserve">
+    <value>Win</value>
+  </data>
+  <data name="&gt;&gt;CheckCloseToExit.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;UserAppointUrlText.Name" xml:space="preserve">
+    <value>UserAppointUrlText</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items1" xml:space="preserve">
+    <value>yy/M/d H:mm:ss</value>
+  </data>
+  <data name="&gt;&gt;Label17.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="TextBoxOutputzKey.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="OneWayLv.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 21</value>
+  </data>
+  <data name="Label10.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 20</value>
+  </data>
+  <data name="&gt;&gt;CheckListMemberAddedEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="lblTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;UserTimelinePeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="BasedPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="btnAtTo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label45.Name" xml:space="preserve">
+    <value>Label45</value>
+  </data>
+  <data name="CheckUserUpdateEvent.ToolTip" xml:space="preserve">
     <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
   </data>
   <data name="&gt;&gt;CheckBlockEvent.Name" xml:space="preserve">
     <value>CheckBlockEvent</value>
   </data>
-  <data name="&gt;&gt;CheckBlockEvent.Type" xml:space="preserve">
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items3" xml:space="preserve">
+    <value>M/d H:mm:ss</value>
+  </data>
+  <data name="TreeViewSetting.Nodes1" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQoAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wAQEBAAABAAEABAEICAgdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5v
+        ZGUCAAAAAgAAAAYDAAAABuWLleS9nAYEAAAAAAYFAAAACkFjdGlvbk5vZGUA/////wkEAAAA/////wkE
+        AAAAAQAAAAkHAAAABQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUJAAAABFRleHQLVG9v
+        bFRpcFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5k
+        ZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIAAAAGCAAAAAbmipXnqL8J
+        BAAAAAYKAAAADFR3ZWV0QWN0Tm9kZQD/////CQQAAAD/////CQQAAAAAAAAACw==
+</value>
+  </data>
+  <data name="&gt;&gt;StatusText.Name" xml:space="preserve">
+    <value>StatusText</value>
+  </data>
+  <data name="&gt;&gt;Label8.Name" xml:space="preserve">
+    <value>Label8</value>
+  </data>
+  <data name="&gt;&gt;lblUnread.Name" xml:space="preserve">
+    <value>lblUnread</value>
+  </data>
+  <data name="StartupReaded.Text" xml:space="preserve">
+    <value>読み込んだポストを既読にする</value>
+  </data>
+  <data name="ReplyIconStateCombo.Items" xml:space="preserve">
+    <value>通知なし</value>
+  </data>
+  <data name="&gt;&gt;ChkNewMentionsBlink.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;CheckBlockEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
+  <data name="&gt;&gt;Label76.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
   </data>
-  <data name="&gt;&gt;CheckBlockEvent.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;HotkeyShift.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
   </data>
-  <data name="CheckForceEventNotify.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="Label37.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 198</value>
   </data>
-  <data name="CheckForceEventNotify.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 278</value>
+  <data name="&gt;&gt;StartupUserstreamCheck.Name" xml:space="preserve">
+    <value>StartupUserstreamCheck</value>
   </data>
-  <data name="CheckForceEventNotify.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckForceEventNotify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 19</value>
-  </data>
-  <data name="CheckForceEventNotify.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="CheckForceEventNotify.Text" xml:space="preserve">
-    <value>新着通知が無効でもイベントを通知する</value>
-  </data>
-  <data name="&gt;&gt;CheckForceEventNotify.Name" xml:space="preserve">
-    <value>CheckForceEventNotify</value>
-  </data>
-  <data name="&gt;&gt;CheckForceEventNotify.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckForceEventNotify.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckForceEventNotify.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 139</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 19</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.Text" xml:space="preserve">
-    <value>Listsから削除された</value>
-  </data>
-  <data name="CheckListMemberRemovedEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberRemovedEvent.Name" xml:space="preserve">
-    <value>CheckListMemberRemovedEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberRemovedEvent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberRemovedEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberRemovedEvent.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 118</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 19</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.Text" xml:space="preserve">
-    <value>Listsに追加された</value>
-  </data>
-  <data name="CheckListMemberAddedEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberAddedEvent.Name" xml:space="preserve">
-    <value>CheckListMemberAddedEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberAddedEvent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberAddedEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckListMemberAddedEvent.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;Label20.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="CheckFollowEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;ButtonApiCalc.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
-  <data name="CheckFollowEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 96</value>
+  <data name="Label21.Text" xml:space="preserve">
+    <value>UserTimeline更新間隔（秒）</value>
   </data>
-  <data name="CheckFollowEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="ButtonBackToDefaultFontColor2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>191, 252</value>
   </data>
-  <data name="CheckFollowEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 19</value>
+  <data name="CooperatePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
   </data>
-  <data name="CheckFollowEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
   </data>
-  <data name="CheckFollowEvent.Text" xml:space="preserve">
-    <value>フォローされた</value>
+  <data name="ListDoubleClickActionComboBox.Items4" xml:space="preserve">
+    <value>関連発言表示</value>
   </data>
-  <data name="CheckFollowEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  <data name="ComboBoxTranslateLanguage.Items32" xml:space="preserve">
+    <value>English (United States)</value>
   </data>
-  <data name="&gt;&gt;CheckFollowEvent.Name" xml:space="preserve">
-    <value>CheckFollowEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckFollowEvent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckFollowEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckFollowEvent.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 75</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>237, 19</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.Text" xml:space="preserve">
-    <value>Fav削除した、またはFav削除された</value>
-  </data>
-  <data name="CheckUnfavoritesEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
-  </data>
-  <data name="&gt;&gt;CheckUnfavoritesEvent.Name" xml:space="preserve">
-    <value>CheckUnfavoritesEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckUnfavoritesEvent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckUnfavoritesEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckUnfavoritesEvent.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="CheckFavoritesEvent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckFavoritesEvent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 54</value>
-  </data>
-  <data name="CheckFavoritesEvent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckFavoritesEvent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>237, 19</value>
-  </data>
-  <data name="CheckFavoritesEvent.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="CheckFavoritesEvent.Text" xml:space="preserve">
-    <value>Fav追加した、またはFav追加された</value>
-  </data>
-  <data name="CheckFavoritesEvent.ToolTip" xml:space="preserve">
-    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
-  </data>
-  <data name="&gt;&gt;CheckFavoritesEvent.Name" xml:space="preserve">
-    <value>CheckFavoritesEvent</value>
-  </data>
-  <data name="&gt;&gt;CheckFavoritesEvent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckFavoritesEvent.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckFavoritesEvent.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="CheckEventNotify.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckEventNotify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="Label16.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="CheckEventNotify.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 28</value>
+  <data name="ListDoubleClickActionComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
   </data>
-  <data name="CheckEventNotify.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckEventNotify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>466, 19</value>
-  </data>
-  <data name="CheckEventNotify.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="CheckEventNotify.Text" xml:space="preserve">
-    <value>次のイベントを受信したときにバルーンで通知する(UserStream有効時のみ)</value>
-  </data>
-  <data name="&gt;&gt;CheckEventNotify.Name" xml:space="preserve">
-    <value>CheckEventNotify</value>
-  </data>
-  <data name="&gt;&gt;CheckEventNotify.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckEventNotify.Parent" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckEventNotify.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="NotifyPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="NotifyPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="NotifyPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="NotifyPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="NotifyPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="NotifyPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="NotifyPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;NotifyPanel.Name" xml:space="preserve">
-    <value>NotifyPanel</value>
-  </data>
-  <data name="&gt;&gt;NotifyPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;NotifyPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;NotifyPanel.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 318</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>408, 19</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="IsPreviewFoursquareCheckBox.Text" xml:space="preserve">
-    <value>FoursquareのURLからプレビューを表示する（非常に重くなります）</value>
-  </data>
-  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.Name" xml:space="preserve">
-    <value>IsPreviewFoursquareCheckBox</value>
-  </data>
-  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="MapThumbnailProviderComboBox.Items" xml:space="preserve">
-    <value>OpenStreetMap</value>
-  </data>
-  <data name="MapThumbnailProviderComboBox.Items1" xml:space="preserve">
-    <value>Google Maps</value>
-  </data>
-  <data name="MapThumbnailProviderComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="MapThumbnailProviderComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="MapThumbnailProviderComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 23</value>
-  </data>
-  <data name="MapThumbnailProviderComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailProviderComboBox.Name" xml:space="preserve">
-    <value>MapThumbnailProviderComboBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailProviderComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailProviderComboBox.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailProviderComboBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="label48.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label48.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 28</value>
-  </data>
-  <data name="label48.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 15</value>
-  </data>
-  <data name="label48.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="label48.Text" xml:space="preserve">
-    <value>地図サービス</value>
-  </data>
-  <data name="&gt;&gt;label48.Name" xml:space="preserve">
-    <value>label48</value>
-  </data>
-  <data name="&gt;&gt;label48.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label48.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label48.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label42.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label42.Location" type="System.Drawing.Point, System.Drawing">
-    <value>213, 64</value>
-  </data>
-  <data name="Label42.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>7, 0, 7, 0</value>
-  </data>
-  <data name="Label42.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 15</value>
-  </data>
-  <data name="Label42.TabIndex" type="System.Int32, mscorlib">
+  <data name="btnAtSelf.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="Label42.Text" xml:space="preserve">
-    <value>x</value>
-  </data>
-  <data name="&gt;&gt;Label42.Name" xml:space="preserve">
-    <value>Label42</value>
-  </data>
-  <data name="&gt;&gt;Label42.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label42.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;Label42.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="MapThumbnailWidthTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>136, 58</value>
-  </data>
-  <data name="MapThumbnailWidthTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="MapThumbnailWidthTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 22</value>
-  </data>
-  <data name="MapThumbnailWidthTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailWidthTextBox.Name" xml:space="preserve">
-    <value>MapThumbnailWidthTextBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailWidthTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailWidthTextBox.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailWidthTextBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="MapThumbnailZoomTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>461, 58</value>
-  </data>
-  <data name="MapThumbnailZoomTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="MapThumbnailZoomTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 22</value>
-  </data>
-  <data name="MapThumbnailZoomTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailZoomTextBox.Name" xml:space="preserve">
-    <value>MapThumbnailZoomTextBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailZoomTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailZoomTextBox.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailZoomTextBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="MapThumbnailHeightTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>239, 58</value>
-  </data>
-  <data name="MapThumbnailHeightTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="MapThumbnailHeightTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 22</value>
-  </data>
-  <data name="MapThumbnailHeightTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailHeightTextBox.Name" xml:space="preserve">
-    <value>MapThumbnailHeightTextBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailHeightTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailHeightTextBox.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;MapThumbnailHeightTextBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Label41.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label41.Location" type="System.Drawing.Point, System.Drawing">
-    <value>360, 61</value>
-  </data>
-  <data name="Label41.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label41.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 15</value>
-  </data>
-  <data name="Label41.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="Label41.Text" xml:space="preserve">
-    <value>ズームレベル</value>
-  </data>
-  <data name="&gt;&gt;Label41.Name" xml:space="preserve">
-    <value>Label41</value>
-  </data>
-  <data name="&gt;&gt;Label41.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label41.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
-  </data>
-  <data name="&gt;&gt;Label41.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Label40.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label40.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 61</value>
-  </data>
-  <data name="Label40.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 15</value>
-  </data>
-  <data name="Label40.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;SplitContainer1.Panel1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="Label40.Text" xml:space="preserve">
-    <value>サムネイルサイズ</value>
+  <data name="chkGetFav.Text" xml:space="preserve">
+    <value>Favoritesを取得する</value>
+  </data>
+  <data name="&gt;&gt;TextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="Label18.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 173</value>
+  </data>
+  <data name="&gt;&gt;Label77.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.Name" xml:space="preserve">
+    <value>ComboBoxAutoShortUrlFirst</value>
+  </data>
+  <data name="&gt;&gt;Label57.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;HotkeyText.Name" xml:space="preserve">
+    <value>HotkeyText</value>
+  </data>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="Label45.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 12</value>
+  </data>
+  <data name="&gt;&gt;Label72.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="CheckStartupFollowers.Text" xml:space="preserve">
+    <value>片思いユーザーリストを取得する</value>
+  </data>
+  <data name="GetCountPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="Label43.Text" xml:space="preserve">
+    <value>バージョンアップやお役立ち情報をお伝えするほか、要望やお問い合わせの受付、回答をいたします。</value>
+  </data>
+  <data name="AuthClearButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label55.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TwitterAPIText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 100</value>
+  </data>
+  <data name="&gt;&gt;BrowserPathText.Name" xml:space="preserve">
+    <value>BrowserPathText</value>
+  </data>
+  <data name="FollowCheckBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TextProxyPassword.Size" type="System.Drawing.Size, System.Drawing">
+    <value>96, 19</value>
+  </data>
+  <data name="TextCountApiReply.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 51</value>
+  </data>
+  <data name="&gt;&gt;RadioProxyIE.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="OneWayLv.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ShortenTcoCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 16</value>
+  </data>
+  <data name="&gt;&gt;Label18.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="OneWayLv.Text" xml:space="preserve">
+    <value>片思いを色分けして表示する</value>
+  </data>
+  <data name="Label77.Location" type="System.Drawing.Point, System.Drawing">
+    <value>366, 164</value>
+  </data>
+  <data name="FirstTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 135</value>
+  </data>
+  <data name="chkGetFav.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 93</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxPostKeySelect.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="lblInputFont.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;LabelProxyPort.Name" xml:space="preserve">
+    <value>LabelProxyPort</value>
+  </data>
+  <data name="&gt;&gt;Label52.Name" xml:space="preserve">
+    <value>Label52</value>
+  </data>
+  <data name="Label34.Text" xml:space="preserve">
+    <value>自分への@返信</value>
+  </data>
+  <data name="TextCountApiReply.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
   <data name="&gt;&gt;Label40.Name" xml:space="preserve">
     <value>Label40</value>
   </data>
-  <data name="&gt;&gt;Label40.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="CheckBlockEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>211, 16</value>
   </data>
-  <data name="&gt;&gt;Label40.Parent" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
+  <data name="CheckEventNotify.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="&gt;&gt;Label40.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;CheckUserUpdateEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label30.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckRetweetNoConfirm.Text" xml:space="preserve">
+    <value>公式RTする際に確認をしない</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Items1" xml:space="preserve">
+    <value>is.gd</value>
+  </data>
+  <data name="Label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 40</value>
+  </data>
+  <data name="&gt;&gt;chkTabIconDisp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label37.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label28.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="MapThumbnailGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>28, 356</value>
+  <data name="Label40.Text" xml:space="preserve">
+    <value>サムネイルサイズ</value>
   </data>
-  <data name="MapThumbnailGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="CheckHashSupple.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 16</value>
   </data>
-  <data name="MapThumbnailGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="btnRetweet.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="MapThumbnailGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>647, 89</value>
+  <data name="lblOWL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;FontPanel.Name" xml:space="preserve">
+    <value>FontPanel</value>
+  </data>
+  <data name="&gt;&gt;LabelDateTimeFormatApplied.Name" xml:space="preserve">
+    <value>LabelDateTimeFormatApplied</value>
+  </data>
+  <data name="&gt;&gt;Label13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckUserUpdateEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 16</value>
+  </data>
+  <data name="CheckPostAndGet.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GroupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 18</value>
+  </data>
+  <data name="&gt;&gt;Label41.Name" xml:space="preserve">
+    <value>Label41</value>
+  </data>
+  <data name="LabelPostAndGet.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;Label34.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckFavoritesEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label33.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckForceEventNotify.Text" xml:space="preserve">
+    <value>新着通知が無効でもイベントを通知する</value>
+  </data>
+  <data name="Label25.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;HotkeyText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ShortenTcoCheck.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;GroupBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="SplitContainer1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="LabelApiUsingUserStreamEnabled.Text" xml:space="preserve">
+    <value>999</value>
+  </data>
+  <data name="StartupPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="lblAtSelf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 43</value>
+  </data>
+  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;UReadMng.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;chkUnreadStyle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ChkNewMentionsBlink.Name" xml:space="preserve">
+    <value>ChkNewMentionsBlink</value>
+  </data>
+  <data name="&gt;&gt;Label13.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;CheckAlwaysTop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LanguageCombo.Items2" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="&gt;&gt;chkGetFav.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;CheckOutputz.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label18.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Button3.Text" xml:space="preserve">
+    <value>参照</value>
+  </data>
+  <data name="lblDetail.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items6" xml:space="preserve">
+    <value>H:mm:ss</value>
+  </data>
+  <data name="&gt;&gt;NotifyPanel.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="PlaySnd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="SearchTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 209</value>
+  </data>
+  <data name="&gt;&gt;PubSearchPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="PubSearchPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 127</value>
+  </data>
+  <data name="Label32.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 12</value>
+  </data>
+  <data name="Label64.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label33.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 158</value>
+  </data>
+  <data name="Label57.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label64.Size" type="System.Drawing.Size, System.Drawing">
+    <value>349, 12</value>
+  </data>
+  <data name="Label55.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 134</value>
+  </data>
+  <data name="CheckListCreatedEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;GroupBox2.Name" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="TwitterAPIText.Text" xml:space="preserve">
+    <value>api.twitter.com</value>
+  </data>
+  <data name="Label65.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="MapThumbnailProviderComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 20</value>
+  </data>
+  <data name="&gt;&gt;CheckUnfavoritesEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckListCreatedEvent.Name" xml:space="preserve">
+    <value>CheckListCreatedEvent</value>
+  </data>
+  <data name="&gt;&gt;Label19.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items" xml:space="preserve">
+    <value>yyyy/MM/dd H:mm:ss</value>
+  </data>
+  <data name="&gt;&gt;Label64.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="&gt;&gt;TwitterSearchAPIText.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="HotkeyWin.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="StartAuthButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label21.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 12</value>
+  </data>
+  <data name="Label63.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BasedPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="MapThumbnailGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
   </data>
-  <data name="MapThumbnailGroupBox.Text" xml:space="preserve">
-    <value>地図サムネイル</value>
+  <data name="&gt;&gt;FontPanel.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
-  <data name="&gt;&gt;MapThumbnailGroupBox.Name" xml:space="preserve">
-    <value>MapThumbnailGroupBox</value>
+  <data name="LabelProxyAddress.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 12</value>
   </data>
-  <data name="&gt;&gt;MapThumbnailGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lblListBackcolor.ZOrder" xml:space="preserve">
+    <value>21</value>
   </data>
-  <data name="&gt;&gt;MapThumbnailGroupBox.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
+  <data name="SplitContainer1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>691, 368</value>
   </data>
-  <data name="&gt;&gt;MapThumbnailGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label39.AutoSize" type="System.Boolean, mscorlib">
+  <data name="Label41.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="Label39.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 254</value>
+  <data name="MapThumbnailProviderComboBox.Items1" xml:space="preserve">
+    <value>Google Maps</value>
   </data>
-  <data name="Label39.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="&gt;&gt;LabelProxyPort.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
   </data>
-  <data name="Label39.Size" type="System.Drawing.Size, System.Drawing">
-    <value>503, 15</value>
+  <data name="IsListsIncludeRtsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 85</value>
   </data>
-  <data name="Label39.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+  <data name="&gt;&gt;Label65.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="Label39.Text" xml:space="preserve">
-    <value>ユーザー指定のURL({ID}をScreenNameに、{STATUS}をステータスIDに置き換えます)</value>
+  <data name="CheckDispUsername.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;Label39.Name" xml:space="preserve">
-    <value>Label39</value>
+  <data name="&gt;&gt;TextBitlyPw.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
   </data>
-  <data name="&gt;&gt;Label39.Type" xml:space="preserve">
+  <data name="lblInputFont.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;HotkeyText.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="&gt;&gt;Label12.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label39.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
+  <data name="lblDetail.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
   </data>
-  <data name="&gt;&gt;Label39.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="CheckUseRecommendStatus.Text" xml:space="preserve">
+    <value>推奨フッターを使用する[TWNv○○]</value>
   </data>
-  <data name="UserAppointUrlText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 275</value>
+  <data name="CheckAtIdSupple.Text" xml:space="preserve">
+    <value>@IDの入力補助を使用する</value>
   </data>
-  <data name="UserAppointUrlText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;Label3.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="UserAppointUrlText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>400, 22</value>
-  </data>
-  <data name="UserAppointUrlText.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;UserAppointUrlText.Name" xml:space="preserve">
-    <value>UserAppointUrlText</value>
-  </data>
-  <data name="&gt;&gt;UserAppointUrlText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;UserAppointUrlText.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;UserAppointUrlText.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items" xml:space="preserve">
-    <value>Afrikaans</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items1" xml:space="preserve">
-    <value>Albanian</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items2" xml:space="preserve">
-    <value>Arabic (Saudi Arabia)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items3" xml:space="preserve">
-    <value>Arabic (Iraq)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items4" xml:space="preserve">
-    <value>Arabic (Egypt)</value>
+  <data name="CheckStartupFollowers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="ComboBoxTranslateLanguage.Items5" xml:space="preserve">
     <value>Arabic (Libya)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items6" xml:space="preserve">
-    <value>Arabic (Algeria)</value>
+  <data name="lblAtTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items7" xml:space="preserve">
-    <value>Arabic (Morocco)</value>
+  <data name="&gt;&gt;Label69.ZOrder" xml:space="preserve">
+    <value>15</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items8" xml:space="preserve">
-    <value>Arabic (Tunisia)</value>
+  <data name="&gt;&gt;btnInputBackcolor.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items9" xml:space="preserve">
-    <value>Arabic (Oman)</value>
+  <data name="&gt;&gt;CmbDateTimeFormat.Name" xml:space="preserve">
+    <value>CmbDateTimeFormat</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items10" xml:space="preserve">
-    <value>Arabic (Yemen)</value>
+  <data name="lblAtTo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 143</value>
+  </data>
+  <data name="btnOWL.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ActionPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CheckSortOrderLock.Name" xml:space="preserve">
+    <value>CheckSortOrderLock</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Items4" xml:space="preserve">
+    <value>j.mp</value>
+  </data>
+  <data name="ComboBoxEventNotifySound.Size" type="System.Drawing.Size, System.Drawing">
+    <value>188, 20</value>
+  </data>
+  <data name="&gt;&gt;Label80.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;btnTarget.Name" xml:space="preserve">
+    <value>btnTarget</value>
+  </data>
+  <data name="Label38.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="FontPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CheckPreviewEnable.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;lblListFont.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;Label30.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="StatusText.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="BasedPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="Label57.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.Name" xml:space="preserve">
+    <value>IsNotifyUseGrowlCheckBox</value>
+  </data>
+  <data name="Label16.Text" xml:space="preserve">
+    <value>その人への@返信</value>
+  </data>
+  <data name="lblDetailLink.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="Label36.Text" xml:space="preserve">
+    <value>自分の発言</value>
+  </data>
+  <data name="BrowserPathText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label8.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;CheckBalloonLimit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckBalloonLimit.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;ReplyIconStateCombo.Name" xml:space="preserve">
+    <value>ReplyIconStateCombo</value>
+  </data>
+  <data name="&gt;&gt;Label42.Name" xml:space="preserve">
+    <value>Label42</value>
+  </data>
+  <data name="CheckHashSupple.Location" type="System.Drawing.Point, System.Drawing">
+    <value>24, 170</value>
+  </data>
+  <data name="lblRetweet.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;Label81.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="HotkeyShift.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Label31.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label52.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 12</value>
+  </data>
+  <data name="Label17.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 237</value>
+  </data>
+  <data name="MapThumbnailZoomTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 19</value>
+  </data>
+  <data name="&gt;&gt;OneWayLv.Name" xml:space="preserve">
+    <value>OneWayLv</value>
+  </data>
+  <data name="btnSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckDispUsername.Text" xml:space="preserve">
+    <value>タイトルバーとツールチップにユーザー名を表示</value>
+  </data>
+  <data name="TreeViewSetting.Nodes4" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQwAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIBAQEAAAEAAQAEBAQBCAgIHVN5c3Rl
+        bS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIA
+        AAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUCAAAAAgAAAAYDAAAABumAmuS/oQYEAAAAAAYF
+        AAAADkNvbm5lY3Rpb25Ob2RlAP////8JBAAAAP////8JBAAAAAMAAAAJBwAAAAkIAAAACQkAAAAFBwAA
+        AB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQkAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlz
+        Q2hlY2tlZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdl
+        S2V5CkNoaWxkQ291bnQBAQEAAAEAAQABCAgIAgAAAAYKAAAADOODl+ODreOCreOCtwkEAAAABgwAAAAJ
+        UHJveHlOb2RlAP////8JBAAAAP////8JBAAAAAAAAAAFCAAAAB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5U
+        cmVlTm9kZQkAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tlZApJbWFnZUluZGV4CEltYWdl
+        S2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNoaWxkQ291bnQBAQEAAAEAAQAB
+        CAgIAgAAAAYOAAAAEumAo+aQuuOCteODvOODk+OCuQkEAAAABhAAAAANQ29vcGVyYXRlTm9kZQD/////
+        CQQAAAD/////CQQAAAAAAAAABQkAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUJAAAABFRl
+        eHQLVG9vbFRpcFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZElt
+        YWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIAAAAGEgAAAAnn
+        n63nuK5VUkwJBAAAAAYUAAAADFNob3J0VXJsTm9kZQD/////CQQAAAD/////CQQAAAAAAAAACw==
+</value>
+  </data>
+  <data name="CheckUnfavoritesEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 60</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyPw.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyId.Name" xml:space="preserve">
+    <value>TextBitlyId</value>
+  </data>
+  <data name="Label53.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 112</value>
+  </data>
+  <data name="CheckAtIdSupple.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;GroupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckNicoms.Name" xml:space="preserve">
+    <value>CheckNicoms</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items2" xml:space="preserve">
+    <value>H:mm:ss yy/M/d</value>
+  </data>
+  <data name="lblDetailBackcolor.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="UserAppointUrlText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>301, 19</value>
+  </data>
+  <data name="GetPeriodPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;TextProxyPassword.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="&gt;&gt;Label36.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckForceResolve.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GroupBox5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 18</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items100" xml:space="preserve">
+    <value>Spanish (Argentina)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items110" xml:space="preserve">
+    <value>Sutu</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items120" xml:space="preserve">
+    <value>Vietnamese</value>
+  </data>
+  <data name="StartupUserstreamCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 16</value>
+  </data>
+  <data name="&gt;&gt;TreeViewSetting.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel1</value>
+  </data>
+  <data name="CheckEventNotify.Size" type="System.Drawing.Size, System.Drawing">
+    <value>376, 16</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 25</value>
+  </data>
+  <data name="ComboDispTitle.Items" xml:space="preserve">
+    <value>（なし）</value>
+  </data>
+  <data name="&gt;&gt;CheckTinyURL.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="TimelinePeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
+  </data>
+  <data name="&gt;&gt;ListDoubleClickActionComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyPassword.Name" xml:space="preserve">
+    <value>LabelProxyPassword</value>
+  </data>
+  <data name="&gt;&gt;Label9.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;CheckSortOrderLock.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PreviewPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FavoritesTextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckAutoConvertUrl.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="IsNotifyUseGrowlCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 314</value>
+  </data>
+  <data name="&gt;&gt;AuthUserCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FirstTextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="Label17.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label37.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 138</value>
+  </data>
+  <data name="CheckListCreatedEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 162</value>
+  </data>
+  <data name="&gt;&gt;Label61.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel2.Parent" xml:space="preserve">
+    <value>SplitContainer1</value>
+  </data>
+  <data name="Label15.Size" type="System.Drawing.Size, System.Drawing">
+    <value>408, 22</value>
+  </data>
+  <data name="LabelProxyPort.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="LabelProxyPassword.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="LabelApiUsingUserStreamEnabled.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="UserTimelinePeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnInputFont.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;Label49.Name" xml:space="preserve">
+    <value>Label49</value>
+  </data>
+  <data name="btnDetail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 25</value>
+  </data>
+  <data name="&gt;&gt;Label45.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxPostKeySelect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GetCountPanel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Label47.Name" xml:space="preserve">
+    <value>Label47</value>
+  </data>
+  <data name="FirstTextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="RadioProxyIE.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckSortOrderLock.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="SearchTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="MapThumbnailProviderComboBox.Items" xml:space="preserve">
+    <value>OpenStreetMap</value>
+  </data>
+  <data name="CheckListMemberRemovedEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label12.Text" xml:space="preserve">
+    <value>フッター（文末に付加）</value>
+  </data>
+  <data name="Label27.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label66.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;TextBoxOutputzKey.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="CheckAtIdSupple.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckAlwaysTop.Size" type="System.Drawing.Size, System.Drawing">
+    <value>133, 16</value>
+  </data>
+  <data name="Label52.Text" xml:space="preserve">
+    <value>入力欄アクティブ時背景色</value>
+  </data>
+  <data name="&gt;&gt;Label67.Name" xml:space="preserve">
+    <value>Label67</value>
+  </data>
+  <data name="Label76.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="&gt;&gt;ListDoubleClickActionComboBox.Name" xml:space="preserve">
+    <value>ListDoubleClickActionComboBox</value>
+  </data>
+  <data name="Label14.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TreeViewSetting.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="CheckPeriodAdjust.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnInputBackcolor.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="CreateAccountButton.Text" xml:space="preserve">
+    <value>Twitter アカウントを作成する</value>
+  </data>
+  <data name="CheckFavEventUnread.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnInputBackcolor.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label59.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;CheckShowGrid.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="CheckTinyURL.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="Button3.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label44.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 12</value>
+  </data>
+  <data name="Label37.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckAlwaysTop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;CheckMinimizeToTray.Name" xml:space="preserve">
+    <value>CheckMinimizeToTray</value>
+  </data>
+  <data name="TreeViewSetting.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="TabMouseLockCheck.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;GroupBox3.Name" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="&gt;&gt;CheckAtIdSupple.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkGetFav.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ConnectionPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;ProxyPanel.Name" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="CheckHashSupple.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="HotkeyWin.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="chkTabIconDisp.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;MapThumbnailHeightTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label12.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblListBackcolor.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="Label10.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;TwitterAPIText.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="CheckFavRestrict.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label32.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAtTo.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="ShortUrlPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="TextBitlyPw.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 19</value>
+  </data>
+  <data name="Label59.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="Label60.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items56" xml:space="preserve">
+    <value>German (Austria)</value>
+  </data>
+  <data name="GetMoreTextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;lblRetweet.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;CheckOpenUserTimeline.Name" xml:space="preserve">
+    <value>CheckOpenUserTimeline</value>
+  </data>
+  <data name="SplitContainer1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Cancel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="btnListBack.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label40.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="HotkeyShift.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 15</value>
+  </data>
+  <data name="StartupPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="HotkeyShift.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckFollowEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="CheckViewTabBottom.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 16</value>
+  </data>
+  <data name="&gt;&gt;Label33.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GroupBox2.Parent" xml:space="preserve">
+    <value>BasedPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckPreviewEnable.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="&gt;&gt;LabelApiUsingUserStreamEnabled.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblInputFont.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="Label72.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;chkTabIconDisp.Name" xml:space="preserve">
+    <value>chkTabIconDisp</value>
+  </data>
+  <data name="CheckUserUpdateEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 145</value>
+  </data>
+  <data name="TweetActPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="CheckOpenUserTimeline.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 16</value>
+  </data>
+  <data name="FavoritesTextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;Label18.Name" xml:space="preserve">
+    <value>Label18</value>
+  </data>
+  <data name="TextBitlyPw.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;lblTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="FollowCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Cancel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Label41.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="HotkeyCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 16</value>
+  </data>
+  <data name="&gt;&gt;LabelPostAndGet.Name" xml:space="preserve">
+    <value>LabelPostAndGet</value>
+  </data>
+  <data name="Label72.Text" xml:space="preserve">
+    <value>未読Mentions通知アイコン</value>
+  </data>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label32.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnSelf.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxTranslateLanguage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>205, 156</value>
+  </data>
+  <data name="&gt;&gt;CheckShowGrid.Name" xml:space="preserve">
+    <value>CheckShowGrid</value>
+  </data>
+  <data name="ShortenTcoCheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="BasedPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnAtSelf.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;Label38.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckFavEventUnread.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="UserTimelineTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 235</value>
+  </data>
+  <data name="NotifyPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;UserTimelineTextCountApi.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblDetail.Name" xml:space="preserve">
+    <value>lblDetail</value>
+  </data>
+  <data name="&gt;&gt;Label5.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="Label61.Text" xml:space="preserve">
+    <value>リストフォント</value>
+  </data>
+  <data name="Label30.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 12</value>
+  </data>
+  <data name="EmailText.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="Cancel.Text" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="Label39.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;CheckFollowEvent.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="NotifyPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CheckOutputz.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label64.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;ActionPanel.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;btnAtTo.Name" xml:space="preserve">
+    <value>btnAtTo</value>
+  </data>
+  <data name="&gt;&gt;chkReadOwnPost.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="HotkeyCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 15</value>
+  </data>
+  <data name="lblAtTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 93</value>
+  </data>
+  <data name="&gt;&gt;lblUnread.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="btnUnread.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label39.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="TextProxyPort.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TweetActPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label26.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="ComboBoxEventNotifySound.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="Label81.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 12</value>
+  </data>
+  <data name="&gt;&gt;TimelinePeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckForceEventNotify.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="lblFav.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;lblAtFromTarget.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;lblDetailLink.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;Label71.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="Label62.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 12</value>
+  </data>
+  <data name="&gt;&gt;LabelUserStreamActive.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="TextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="&gt;&gt;Label63.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btnInputFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="TweetPrvPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="Label8.Text" xml:space="preserve">
+    <value>Twitter API URL (api.twitter.com)</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailZoomTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblOWL.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnRetweet.Text" xml:space="preserve">
+    <value>文字色</value>
+  </data>
+  <data name="IsRemoveSameFavEventCheckBox.Text" xml:space="preserve">
+    <value>重複するFav追加、Fav削除のイベントは無視する</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items2" xml:space="preserve">
+    <value>Arabic (Saudi Arabia)</value>
+  </data>
+  <data name="TextBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>34, 19</value>
+  </data>
+  <data name="ComboBoxOutputzUrlmode.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Label1.Text" xml:space="preserve">
+    <value>サポート用アカウントのフォローをお勧めしています。</value>
+  </data>
+  <data name="PubSearchPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="FontPanel2.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;ColorDialog1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColorDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label53.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="HotkeyCheck.Text" xml:space="preserve">
+    <value>有効</value>
+  </data>
+  <data name="&gt;&gt;UserstreamPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblAtSelf.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;ActionPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="StartupReaded.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label69.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckForceResolve.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="lblDetail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 146</value>
+  </data>
+  <data name="HotkeyText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="CheckAlwaysTop.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 263</value>
+  </data>
+  <data name="Label15.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblOWL.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 96</value>
+  </data>
+  <data name="TweetPrvPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailWidthTextBox.Name" xml:space="preserve">
+    <value>MapThumbnailWidthTextBox</value>
+  </data>
+  <data name="Label29.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyAddress.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="&gt;&gt;FirstTextCountApi.Name" xml:space="preserve">
+    <value>FirstTextCountApi</value>
+  </data>
+  <data name="ComboBoxEventNotifySound.Location" type="System.Drawing.Point, System.Drawing">
+    <value>286, 278</value>
+  </data>
+  <data name="Label14.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckMonospace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>343, 16</value>
+  </data>
+  <data name="Label8.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label25.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;TweetActPanel.Name" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="CheckTinyURL.Size" type="System.Drawing.Size, System.Drawing">
+    <value>122, 16</value>
+  </data>
+  <data name="Label47.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 178</value>
+  </data>
+  <data name="Label24.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnAtTarget.Name" xml:space="preserve">
+    <value>btnAtTarget</value>
+  </data>
+  <data name="ProxyPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CheckListMemberAddedEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;TreeViewSetting.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnSelf.Name" xml:space="preserve">
+    <value>btnSelf</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items18" xml:space="preserve">
+    <value>Basque</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items19" xml:space="preserve">
+    <value>Bulgarian</value>
+  </data>
+  <data name="&gt;&gt;CheckBox3.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="FontPanel2.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CheckUserUpdateEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="Label47.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TwitterAPIText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label62.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
   <data name="ComboBoxTranslateLanguage.Items11" xml:space="preserve">
     <value>Arabic (Syria)</value>
@@ -4038,101 +2014,326 @@ Growl.CoreLibrary.DLL</value>
   <data name="ComboBoxTranslateLanguage.Items17" xml:space="preserve">
     <value>Arabic (Qatar)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items18" xml:space="preserve">
-    <value>Basque</value>
+  <data name="&gt;&gt;Label53.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items19" xml:space="preserve">
-    <value>Bulgarian</value>
+  <data name="CheckUseSsl.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="ComboBoxTranslateLanguage.Items20" xml:space="preserve">
-    <value>Belarusian</value>
+  <data name="ComboBoxTranslateLanguage.Items81" xml:space="preserve">
+    <value>Romanian</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items21" xml:space="preserve">
-    <value>Catalan</value>
+  <data name="TextBox3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 150</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items22" xml:space="preserve">
-    <value>Chinese (Taiwan)</value>
+  <data name="&gt;&gt;btnUnread.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items23" xml:space="preserve">
-    <value>Chinese (PRC)</value>
+  <data name="ComboBoxTranslateLanguage.Items84" xml:space="preserve">
+    <value>Russian (Republic of Moldova)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items24" xml:space="preserve">
-    <value>Chinese (Hong Kong SAR)</value>
+  <data name="ComboBoxTranslateLanguage.Items85" xml:space="preserve">
+    <value>Sami (Lappish)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items25" xml:space="preserve">
-    <value>Chinese (Singapore)</value>
+  <data name="ComboBoxTranslateLanguage.Items86" xml:space="preserve">
+    <value>Serbian (Cyrillic)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items26" xml:space="preserve">
-    <value>Croatian</value>
+  <data name="ComboBoxTranslateLanguage.Items87" xml:space="preserve">
+    <value>Serbian (Latin)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items27" xml:space="preserve">
-    <value>Czech</value>
+  <data name="&gt;&gt;Label26.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items28" xml:space="preserve">
-    <value>Danish</value>
+  <data name="CheckPostAndGet.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items29" xml:space="preserve">
-    <value>Dutch (Standard)</value>
+  <data name="lblSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items30" xml:space="preserve">
-    <value>Dutch (Belgium)</value>
+  <data name="TextBitlyPw.Location" type="System.Drawing.Point, System.Drawing">
+    <value>413, 161</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items31" xml:space="preserve">
-    <value>English</value>
+  <data name="&gt;&gt;Label43.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items32" xml:space="preserve">
-    <value>English (United States)</value>
+  <data name="&gt;&gt;Label47.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items33" xml:space="preserve">
-    <value>English (United Kingdom)</value>
+  <data name="Label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items34" xml:space="preserve">
-    <value>English (Australia)</value>
+  <data name="PreviewPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items35" xml:space="preserve">
-    <value>English (Canada)</value>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items36" xml:space="preserve">
-    <value>English (New Zealand)</value>
+  <data name="Label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 108</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items37" xml:space="preserve">
-    <value>English (Ireland)</value>
+  <data name="StartupPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items38" xml:space="preserve">
-    <value>English (South Africa)</value>
+  <data name="btnDetailBack.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items39" xml:space="preserve">
-    <value>English (Jamaica)</value>
+  <data name="btnDetail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items40" xml:space="preserve">
-    <value>English (Caribbean)</value>
+  <data name="&gt;&gt;ActionPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items41" xml:space="preserve">
-    <value>English (Belize)</value>
+  <data name="&gt;&gt;Label55.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items42" xml:space="preserve">
-    <value>English (Trinidad)</value>
+  <data name="&gt;&gt;Label77.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items43" xml:space="preserve">
-    <value>Estonian</value>
+  <data name="CheckAutoConvertUrl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 68</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items44" xml:space="preserve">
-    <value>Faeroese</value>
+  <data name="lblAtTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items45" xml:space="preserve">
-    <value>Farsi</value>
+  <data name="Cancel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>604, 374</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items46" xml:space="preserve">
-    <value>Finnish</value>
+  <data name="&gt;&gt;LabelPostAndGet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items47" xml:space="preserve">
-    <value>French (Standard)</value>
+  <data name="HotkeyShift.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="ComboBoxTranslateLanguage.Items48" xml:space="preserve">
-    <value>French (Belgium)</value>
+  <data name="LabelProxyUser.Location" type="System.Drawing.Point, System.Drawing">
+    <value>74, 110</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items49" xml:space="preserve">
-    <value>French (Canada)</value>
+  <data name="btnDetailLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 171</value>
+  </data>
+  <data name="&gt;&gt;Label25.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;Label7.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;GroupBox2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;TwitterAPIText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="FollowCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="Label7.Text" xml:space="preserve">
+    <value>Twitter検索更新間隔（秒）</value>
+  </data>
+  <data name="&gt;&gt;FirstTextCountApi.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="CheckUseRecommendStatus.Location" type="System.Drawing.Point, System.Drawing">
+    <value>185, 94</value>
+  </data>
+  <data name="&gt;&gt;btnTarget.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items" xml:space="preserve">
+    <value>Afrikaans</value>
+  </data>
+  <data name="Label23.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;btnDetailLink.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="Label9.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LabelDateTimeFormatApplied.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;lblFav.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="chkUnreadStyle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>226, 16</value>
+  </data>
+  <data name="Cancel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="CheckUnfavoritesEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  </data>
+  <data name="&gt;&gt;DMPeriod.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyPassword.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="LabelProxyPassword.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckFavRestrict.Size" type="System.Drawing.Size, System.Drawing">
+    <value>183, 16</value>
+  </data>
+  <data name="&gt;&gt;ReplyPeriod.Name" xml:space="preserve">
+    <value>ReplyPeriod</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items6" xml:space="preserve">
+    <value>Arabic (Algeria)</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCtrl.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="&gt;&gt;lblAtSelf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnAtTo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkGetFav.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label12.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 94</value>
+  </data>
+  <data name="Label25.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 12</value>
+  </data>
+  <data name="BrowserPathText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>184, 160</value>
+  </data>
+  <data name="CheckCloseToExit.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="DMPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="Label61.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckPeriodAdjust.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 59</value>
+  </data>
+  <data name="Label33.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="TextBitlyPw.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckFavEventUnread.Text" xml:space="preserve">
+    <value>Favoritesイベント受信の際に書き込みを未読に戻す</value>
+  </data>
+  <data name="&gt;&gt;UseChangeGetCount.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="FontPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;btnOWL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LabelApiUsing.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="Label46.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckPostAndGet.Name" xml:space="preserve">
+    <value>CheckPostAndGet</value>
+  </data>
+  <data name="LabelPostAndGet.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckHashSupple.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CheckPeriodAdjust.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 16</value>
+  </data>
+  <data name="lblListFont.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 21</value>
+  </data>
+  <data name="CheckUseSsl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 16</value>
+  </data>
+  <data name="&gt;&gt;CheckPreviewEnable.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="Label40.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TweetPrvPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyId.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="&gt;&gt;ProxyPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label5.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>230, 315</value>
+  </data>
+  <data name="&gt;&gt;FontPanel2.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="CheckReadOldPosts.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="btnDetail.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="Label46.Text" xml:space="preserve">
+    <value>UserStream反映間隔（秒）</value>
+  </data>
+  <data name="Label42.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ProxyPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="btnAtTo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 140</value>
+  </data>
+  <data name="Label30.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;CheckBox3.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="CheckFavoritesEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  </data>
+  <data name="ButtonApiCalc.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="LabelPostAndGet.Text" xml:space="preserve">
+    <value>投稿時取得が有効のため、投稿のたびにAPIを消費します。</value>
+  </data>
+  <data name="chkTabIconDisp.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label72.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label65.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;TextBox3.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyUser.Name" xml:space="preserve">
+    <value>LabelProxyUser</value>
+  </data>
+  <data name="&gt;&gt;CheckViewTabBottom.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="&gt;&gt;Label20.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
   <data name="ComboBoxTranslateLanguage.Items50" xml:space="preserve">
     <value>French (Switzerland)</value>
@@ -4152,110 +2353,1736 @@ Growl.CoreLibrary.DLL</value>
   <data name="ComboBoxTranslateLanguage.Items55" xml:space="preserve">
     <value>German (Switzerland)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items56" xml:space="preserve">
-    <value>German (Austria)</value>
+  <data name="&gt;&gt;CheckListMemberAddedEvent.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
   <data name="ComboBoxTranslateLanguage.Items57" xml:space="preserve">
     <value>German (Luxembourg)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items58" xml:space="preserve">
-    <value>German (Liechtenstein)</value>
+  <data name="Label30.Text" xml:space="preserve">
+    <value>PublicSearchの取得数</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items59" xml:space="preserve">
-    <value>Greek</value>
+  <data name="&gt;&gt;btnAtFromTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items60" xml:space="preserve">
-    <value>Hebrew</value>
+  <data name="TextBitlyId.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 19</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items61" xml:space="preserve">
-    <value>Hindi</value>
+  <data name="Label17.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 12</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items62" xml:space="preserve">
-    <value>Hungarian</value>
+  <data name="&gt;&gt;CheckUserUpdateEvent.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items63" xml:space="preserve">
-    <value>Icelandic</value>
+  <data name="&gt;&gt;NotifyPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items64" xml:space="preserve">
-    <value>Indonesian</value>
+  <data name="GetCountPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items65" xml:space="preserve">
-    <value>Italian (Standard)</value>
+  <data name="LabelProxyAddress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items66" xml:space="preserve">
-    <value>Italian (Switzerland)</value>
+  <data name="CheckPreviewEnable.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items67" xml:space="preserve">
-    <value>Japanese</value>
+  <data name="&gt;&gt;CheckStartupVersion.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items68" xml:space="preserve">
-    <value>Korean</value>
+  <data name="CheckUserUpdateEvent.Text" xml:space="preserve">
+    <value>ユーザーのプロフィールが更新された</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items69" xml:space="preserve">
-    <value>Korean (Johab)</value>
+  <data name="label48.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items70" xml:space="preserve">
-    <value>Latvian</value>
+  <data name="&gt;&gt;CheckBlockEvent.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items71" xml:space="preserve">
-    <value>Lithuanian</value>
+  <data name="LabelDateTimeFormatApplied.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items72" xml:space="preserve">
-    <value>Macedonian (FYROM)</value>
+  <data name="&gt;&gt;Label21.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items73" xml:space="preserve">
-    <value>Malaysian</value>
+  <data name="GroupBox3.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnSelf.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="Label11.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="ChkNewMentionsBlink.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;TwitterSearchAPIText.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="lblDetailBackcolor.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="CheckAlwaysTop.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="LabelProxyPort.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LabelApiUsing.Text" xml:space="preserve">
+    <value>999</value>
+  </data>
+  <data name="UserAppointUrlText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnFav.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckEventNotify.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnTarget.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblAtTo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckFavEventUnread.Size" type="System.Drawing.Size, System.Drawing">
+    <value>271, 16</value>
+  </data>
+  <data name="&gt;&gt;AuthClearButton.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;TextProxyPassword.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Label35.Name" xml:space="preserve">
+    <value>Label35</value>
+  </data>
+  <data name="Label28.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TweetPrvPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="chkReadOwnPost.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblInputBackcolor.Name" xml:space="preserve">
+    <value>lblInputBackcolor</value>
+  </data>
+  <data name="CheckMonospace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAtFromTarget.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;CheckRetweetNoConfirm.Name" xml:space="preserve">
+    <value>CheckRetweetNoConfirm</value>
+  </data>
+  <data name="ConnectionTimeOut.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Items3" xml:space="preserve">
+    <value>ユーザーのタイムラインを表示</value>
+  </data>
+  <data name="SearchTextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ShortUrlPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;CheckBalloonLimit.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="CheckShowGrid.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 222</value>
+  </data>
+  <data name="&gt;&gt;Label57.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="TwitterSearchAPIText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;UserTimelinePeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="FavoritesTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="CheckEventNotify.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 22</value>
   </data>
   <data name="ComboBoxTranslateLanguage.Items74" xml:space="preserve">
     <value>Maltese</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items75" xml:space="preserve">
-    <value>Norwegian (Bokmal)</value>
+  <data name="CheckMinimizeToTray.Size" type="System.Drawing.Size, System.Drawing">
+    <value>170, 16</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items76" xml:space="preserve">
-    <value>Norwegian (Nynorsk)</value>
+  <data name="Label15.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items77" xml:space="preserve">
-    <value>Polish</value>
+  <data name="&gt;&gt;ReplyIconStateCombo.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items78" xml:space="preserve">
-    <value>Portuguese (Brazil)</value>
+  <data name="&gt;&gt;cmbNameBalloon.Name" xml:space="preserve">
+    <value>cmbNameBalloon</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items79" xml:space="preserve">
-    <value>Portuguese (Portugal)</value>
+  <data name="&gt;&gt;Label27.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items80" xml:space="preserve">
-    <value>Rhaeto-Romanic</value>
+  <data name="&gt;&gt;CheckStartupVersion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items81" xml:space="preserve">
-    <value>Romanian</value>
+  <data name="Label42.Text" xml:space="preserve">
+    <value>x</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items82" xml:space="preserve">
-    <value>Romanian (Republic of Moldova)</value>
+  <data name="&gt;&gt;LabelApiUsingUserStreamEnabled.Name" xml:space="preserve">
+    <value>LabelApiUsingUserStreamEnabled</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items83" xml:space="preserve">
-    <value>Russian</value>
+  <data name="PlaySnd.Text" xml:space="preserve">
+    <value>サウンドを再生する</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items84" xml:space="preserve">
-    <value>Russian (Republic of Moldova)</value>
+  <data name="&gt;&gt;lblTarget.ZOrder" xml:space="preserve">
+    <value>24</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items85" xml:space="preserve">
-    <value>Sami (Lappish)</value>
+  <data name="&gt;&gt;Label36.Name" xml:space="preserve">
+    <value>Label36</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items86" xml:space="preserve">
-    <value>Serbian (Cyrillic)</value>
+  <data name="ComboBoxTranslateLanguage.Items122" xml:space="preserve">
+    <value>Yiddish</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items87" xml:space="preserve">
-    <value>Serbian (Latin)</value>
+  <data name="chkTabIconDisp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>161, 16</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items88" xml:space="preserve">
-    <value>Slovak</value>
+  <data name="MapThumbnailGroupBox.Text" xml:space="preserve">
+    <value>地図サムネイル</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items89" xml:space="preserve">
-    <value>Slovenian</value>
+  <data name="ProxyPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items90" xml:space="preserve">
-    <value>Sorbian</value>
+  <data name="&gt;&gt;FollowCheckBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="GetPeriodPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="Label60.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 12</value>
+  </data>
+  <data name="CheckFollowEvent.Text" xml:space="preserve">
+    <value>フォローされた</value>
+  </data>
+  <data name="Label8.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ChkNewMentionsBlink.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnAtTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxOutputzUrlmode.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="CheckEventNotify.Text" xml:space="preserve">
+    <value>次のイベントを受信したときにバルーンで通知する(UserStream有効時のみ)</value>
+  </data>
+  <data name="&gt;&gt;CheckUserUpdateEvent.Name" xml:space="preserve">
+    <value>CheckUserUpdateEvent</value>
+  </data>
+  <data name="&gt;&gt;CheckTinyURL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckPostAndGet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label24.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="GroupBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 161</value>
+  </data>
+  <data name="HotkeyCheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label13.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 12</value>
+  </data>
+  <data name="FirstTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="&gt;&gt;CooperatePanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="UReadMng.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnAtTo.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="Label43.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label77.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 12</value>
+  </data>
+  <data name="Label26.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 148</value>
+  </data>
+  <data name="CheckListMemberRemovedEvent.Text" xml:space="preserve">
+    <value>Listsから削除された</value>
+  </data>
+  <data name="FavoritesTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 159</value>
+  </data>
+  <data name="&gt;&gt;BasedPanel.Name" xml:space="preserve">
+    <value>BasedPanel</value>
+  </data>
+  <data name="&gt;&gt;ColorDialog1.Name" xml:space="preserve">
+    <value>ColorDialog1</value>
+  </data>
+  <data name="Label25.Text" xml:space="preserve">
+    <value>Listsの取得数</value>
+  </data>
+  <data name="CheckPreviewEnable.Text" xml:space="preserve">
+    <value>画像リンクがあった場合にサムネイルを表示する</value>
+  </data>
+  <data name="lblAtTarget.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;StartupUserstreamCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckNicoms.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 120</value>
+  </data>
+  <data name="UserTimelineTextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items9" xml:space="preserve">
+    <value>Arabic (Oman)</value>
+  </data>
+  <data name="chkGetFav.Size" type="System.Drawing.Size, System.Drawing">
+    <value>124, 16</value>
+  </data>
+  <data name="&gt;&gt;HideDuplicatedRetweetsCheck.Name" xml:space="preserve">
+    <value>HideDuplicatedRetweetsCheck</value>
+  </data>
+  <data name="&gt;&gt;CheckCloseToExit.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="chkUnreadStyle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 65</value>
+  </data>
+  <data name="UserTimelinePeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="GroupBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>476, 162</value>
+  </data>
+  <data name="&gt;&gt;CheckStartupFollowers.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ButtonApiCalc.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="TextBox3.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label60.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyUser.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;lblAtTo.Name" xml:space="preserve">
+    <value>lblAtTo</value>
+  </data>
+  <data name="btnInputBackcolor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="UseChangeGetCount.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 86</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Items5" xml:space="preserve">
+    <value>ユーザーのHomeを開く</value>
+  </data>
+  <data name="MapThumbnailHeightTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 19</value>
+  </data>
+  <data name="DMPeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckForceEventNotify.Name" xml:space="preserve">
+    <value>CheckForceEventNotify</value>
+  </data>
+  <data name="CheckOpenUserTimeline.Text" xml:space="preserve">
+    <value>ユーザーのホームURLをタブで開く</value>
+  </data>
+  <data name="&gt;&gt;CheckListCreatedEvent.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;Label22.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 12</value>
+  </data>
+  <data name="CheckFavEventUnread.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 240</value>
+  </data>
+  <data name="Label66.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 160</value>
+  </data>
+  <data name="CheckViewTabBottom.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblAtFromTarget.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LabelProxyPort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblRetweet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 121</value>
+  </data>
+  <data name="&gt;&gt;Label53.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;RadioProxyIE.Name" xml:space="preserve">
+    <value>RadioProxyIE</value>
+  </data>
+  <data name="TextProxyAddress.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="Label28.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;TextBoxOutputzKey.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="CheckUseRecommendStatus.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="MapThumbnailGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 285</value>
+  </data>
+  <data name="MapThumbnailZoomTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnDetailLink.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;Label23.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="&gt;&gt;UReadMng.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="StartupPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckPostAndGet.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckPeriodAdjust.Name" xml:space="preserve">
+    <value>CheckPeriodAdjust</value>
+  </data>
+  <data name="&gt;&gt;ShortUrlPanel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="RadioProxySpecified.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxOutputzUrlmode.Items" xml:space="preserve">
+    <value>twitter.com</value>
+  </data>
+  <data name="TextProxyPort.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Label66.Name" xml:space="preserve">
+    <value>Label66</value>
+  </data>
+  <data name="CheckViewTabBottom.Text" xml:space="preserve">
+    <value>タブを一覧の下に表示する</value>
+  </data>
+  <data name="CheckUserUpdateEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;TextProxyAddress.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="&gt;&gt;LabelApiUsing.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;GetPeriodPanel.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;ShortenTcoCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckRetweetNoConfirm.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;GroupBox5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label29.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 12</value>
+  </data>
+  <data name="&gt;&gt;btnFav.Name" xml:space="preserve">
+    <value>btnFav</value>
+  </data>
+  <data name="ConnectionPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="FollowCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>36, 56</value>
+  </data>
+  <data name="FollowCheckBox.Text" xml:space="preserve">
+    <value>{0} をフォローする</value>
+  </data>
+  <data name="Label22.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items101" xml:space="preserve">
+    <value>Spanish (Ecuador)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items111" xml:space="preserve">
+    <value>Swedish</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items121" xml:space="preserve">
+    <value>Xhosa</value>
+  </data>
+  <data name="HotkeyCode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>340, 16</value>
+  </data>
+  <data name="&gt;&gt;Label28.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckListMemberRemovedEvent.Name" xml:space="preserve">
+    <value>CheckListMemberRemovedEvent</value>
+  </data>
+  <data name="Label42.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 51</value>
+  </data>
+  <data name="&gt;&gt;lblDetailBackcolor.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;StatusText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckListMemberRemovedEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 16</value>
+  </data>
+  <data name="btnListFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;lblDetailLink.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="ButtonApiCalc.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckSortOrderLock.Size" type="System.Drawing.Size, System.Drawing">
+    <value>203, 16</value>
+  </data>
+  <data name="&gt;&gt;ReplyIconStateCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TextProxyAddress.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;Label6.Name" xml:space="preserve">
+    <value>Label6</value>
+  </data>
+  <data name="&gt;&gt;CheckViewTabBottom.Name" xml:space="preserve">
+    <value>CheckViewTabBottom</value>
+  </data>
+  <data name="&gt;&gt;Label59.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblListBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="MapThumbnailWidthTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="LabelDateTimeFormatApplied.Text" xml:space="preserve">
+    <value>Label63</value>
+  </data>
+  <data name="LanguageCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>136, 20</value>
+  </data>
+  <data name="&gt;&gt;CheckStartupFollowers.Parent" xml:space="preserve">
+    <value>StartupPanel</value>
+  </data>
+  <data name="CmbDateTimeFormat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 111</value>
+  </data>
+  <data name="&gt;&gt;UserTimelineTextCountApi.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items28" xml:space="preserve">
+    <value>Danish</value>
+  </data>
+  <data name="&gt;&gt;btnRetweet.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="btnAtTo.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckReadOldPosts.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 92</value>
+  </data>
+  <data name="&gt;&gt;btnInputBackcolor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LanguageCombo.Items3" xml:space="preserve">
+    <value>Simplified Chinese</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCheck.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CheckStartupVersion.Text" xml:space="preserve">
+    <value>最新版のチェックをする</value>
+  </data>
+  <data name="&gt;&gt;CheckReadOldPosts.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="TweetActPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;label48.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Label80.Name" xml:space="preserve">
+    <value>Label80</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items9" xml:space="preserve">
+    <value>M/d tt h:mm:ss</value>
+  </data>
+  <data name="Label44.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;UseChangeGetCount.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 43</value>
+  </data>
+  <data name="chkTabIconDisp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 118</value>
+  </data>
+  <data name="CheckShowGrid.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;lblDetailBackcolor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkGetFav.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ProxyPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="btnSelf.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckBlockEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  </data>
+  <data name="btnAtFromTarget.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="PreviewPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;Label61.ZOrder" xml:space="preserve">
+    <value>24</value>
+  </data>
+  <data name="chkUnreadStyle.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SearchTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="&gt;&gt;Label81.Name" xml:space="preserve">
+    <value>Label81</value>
+  </data>
+  <data name="Label21.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 183</value>
+  </data>
+  <data name="CheckForceEventNotify.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label36.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 20</value>
+  </data>
+  <data name="HotkeyCode.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;ComboBoxOutputzUrlmode.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;lblDetailLink.Name" xml:space="preserve">
+    <value>lblDetailLink</value>
+  </data>
+  <data name="CheckEventNotify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 68</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxPostKeySelect.Name" xml:space="preserve">
+    <value>ComboBoxPostKeySelect</value>
+  </data>
+  <data name="&gt;&gt;Label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckUseSsl.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="PlaySnd.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label65.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 220</value>
+  </data>
+  <data name="&gt;&gt;Label30.Name" xml:space="preserve">
+    <value>Label30</value>
+  </data>
+  <data name="HotkeyCtrl.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;lblDetailLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label26.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="ComboDispTitle.Items7" xml:space="preserve">
+    <value>発言数/フォロー数/フォロワー数</value>
+  </data>
+  <data name="CheckOutputz.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ListTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="HotkeyCtrl.Text" xml:space="preserve">
+    <value>Ctrl</value>
+  </data>
+  <data name="lblDetailLink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 171</value>
+  </data>
+  <data name="Label8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 12</value>
+  </data>
+  <data name="StartupUserstreamCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>334, 14</value>
+  </data>
+  <data name="CheckAtIdSupple.Location" type="System.Drawing.Point, System.Drawing">
+    <value>24, 146</value>
+  </data>
+  <data name="CheckListCreatedEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  </data>
+  <data name="ChkNewMentionsBlink.Text" xml:space="preserve">
+    <value>Mentionsの新着があるときにウインドウを点滅する</value>
+  </data>
+  <data name="Label11.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label24.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="CheckSortOrderLock.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 247</value>
+  </data>
+  <data name="GetPeriodPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="ComboDispTitle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>215, 88</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LabelDateTimeFormatApplied.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PlaySnd.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CheckFollowEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnRetweet.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="Label61.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 23</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Items5" xml:space="preserve">
+    <value>ux.nu</value>
+  </data>
+  <data name="lblAtFromTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="lblListBackcolor.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="StartupReaded.Size" type="System.Drawing.Size, System.Drawing">
+    <value>166, 16</value>
+  </data>
+  <data name="Label77.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RadioProxySpecified.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckFollowEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="Label8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 103</value>
+  </data>
+  <data name="btnOWL.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 12</value>
+  </data>
+  <data name="UserTimelineTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="&gt;&gt;Label64.Name" xml:space="preserve">
+    <value>Label64</value>
+  </data>
+  <data name="LabelProxyUser.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GetMoreTextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Label25.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="MapThumbnailProviderComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="&gt;&gt;Label40.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="PreviewPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;GroupBox3.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckForceResolve.Name" xml:space="preserve">
+    <value>CheckForceResolve</value>
+  </data>
+  <data name="chkTabIconDisp.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;NotifyPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;GroupBox1.Name" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;Label10.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="chkUnreadStyle.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;PlaySnd.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ConnectionTimeOut.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="UserstreamPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items3" xml:space="preserve">
+    <value>Arabic (Iraq)</value>
+  </data>
+  <data name="btnDetailLink.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ReplyIconStateCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>136, 20</value>
+  </data>
+  <data name="&gt;&gt;Label5.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="&gt;&gt;lblAtTo.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;Label33.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="btnInputFont.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 215</value>
+  </data>
+  <data name="&gt;&gt;CheckMinimizeToTray.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;btnRetweet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor2.Text" xml:space="preserve">
+    <value>デフォルトに戻す</value>
+  </data>
+  <data name="&gt;&gt;Label41.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblInputBackcolor.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="CheckUseRecommendStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>195, 16</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items10" xml:space="preserve">
+    <value>M/d tt h:mm</value>
+  </data>
+  <data name="Label42.Size" type="System.Drawing.Size, System.Drawing">
+    <value>11, 12</value>
+  </data>
+  <data name="Label49.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckHashSupple.Name" xml:space="preserve">
+    <value>CheckHashSupple</value>
+  </data>
+  <data name="&gt;&gt;BasedPanel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="CheckForceEventNotify.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TextProxyUser.Location" type="System.Drawing.Point, System.Drawing">
+    <value>143, 107</value>
+  </data>
+  <data name="Label6.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;lblAtTarget.Name" xml:space="preserve">
+    <value>lblAtTarget</value>
+  </data>
+  <data name="CheckPeriodAdjust.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ReplyIconStateCombo.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;PubSearchPeriod.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;ShortenTcoCheck.Name" xml:space="preserve">
+    <value>ShortenTcoCheck</value>
+  </data>
+  <data name="&gt;&gt;Label24.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="btnOWL.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 96</value>
+  </data>
+  <data name="&gt;&gt;lblAtTarget.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;Label46.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="Label66.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 12</value>
+  </data>
+  <data name="&gt;&gt;ConnectionPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label66.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ChkNewMentionsBlink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>256, 16</value>
+  </data>
+  <data name="&gt;&gt;Label24.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label71.Name" xml:space="preserve">
+    <value>Label71</value>
+  </data>
+  <data name="PubSearchPeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblFav.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 71</value>
+  </data>
+  <data name="HotkeyText.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;Label30.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;lblAtSelf.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="UReadMng.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 71</value>
+  </data>
+  <data name="&gt;&gt;Label67.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;Label47.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label29.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 160</value>
+  </data>
+  <data name="lblDetailLink.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;SearchTextCountApi.Name" xml:space="preserve">
+    <value>SearchTextCountApi</value>
+  </data>
+  <data name="Label14.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TextProxyAddress.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblAtTo.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckNicoms.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label25.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 12</value>
+  </data>
+  <data name="UseChangeGetCount.Size" type="System.Drawing.Size, System.Drawing">
+    <value>247, 16</value>
+  </data>
+  <data name="&gt;&gt;btnAtTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label14.Text" xml:space="preserve">
+    <value>その発言の@先の人の発言</value>
+  </data>
+  <data name="&gt;&gt;GroupBox5.Name" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;RadioProxySpecified.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CheckMonospace.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;CheckUseRecommendStatus.Name" xml:space="preserve">
+    <value>CheckUseRecommendStatus</value>
+  </data>
+  <data name="CheckCloseToExit.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ListsPeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckFollowEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items104" xml:space="preserve">
+    <value>Spanish (Paraguay)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items114" xml:space="preserve">
+    <value>Tsonga</value>
+  </data>
+  <data name="lblDetailLink.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnDetailBack.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;Cancel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckUseSsl.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label32.Name" xml:space="preserve">
+    <value>Label32</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailProviderComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label21.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="btnRetweet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chkUnreadStyle.Text" xml:space="preserve">
+    <value>未読ポストのフォントと色を変更する（低速）</value>
+  </data>
+  <data name="&gt;&gt;FontDialog1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FontDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyUser.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="&gt;&gt;Button3.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckFavoritesEvent.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;btnInputBackcolor.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;Label31.Name" xml:space="preserve">
+    <value>Label31</value>
+  </data>
+  <data name="Label18.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;FavoritesTextCountApi.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btnDetailLink.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;btnFav.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="CheckBalloonLimit.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.Name" xml:space="preserve">
+    <value>IsListsIncludeRtsCheckBox</value>
+  </data>
+  <data name="TextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 21</value>
+  </data>
+  <data name="Label69.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 83</value>
+  </data>
+  <data name="TabMouseLockCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>164, 16</value>
+  </data>
+  <data name="LabelApiUsing.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailHeightTextBox.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="&gt;&gt;UserTimelinePeriod.Name" xml:space="preserve">
+    <value>UserTimelinePeriod</value>
+  </data>
+  <data name="LabelProxyAddress.Location" type="System.Drawing.Point, System.Drawing">
+    <value>50, 85</value>
+  </data>
+  <data name="StartupReaded.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label69.Text" xml:space="preserve">
+    <value>Mentions更新間隔（秒）</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxEventNotifySound.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="CheckMonospace.Text" xml:space="preserve">
+    <value>発言詳細を等幅フォントで表示（AA対応、フォント適用不具合あり）</value>
+  </data>
+  <data name="IsNotifyUseGrowlCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;Label33.Name" xml:space="preserve">
+    <value>Label33</value>
+  </data>
+  <data name="NotifyPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Label30.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;UReadMng.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyPort.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;label48.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="GetMoreTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 112</value>
+  </data>
+  <data name="&gt;&gt;lblAtFromTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label24.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 98</value>
+  </data>
+  <data name="CheckListMemberRemovedEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  </data>
+  <data name="Label66.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblAtTo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="CheckReadOldPosts.Text" xml:space="preserve">
+    <value>新着時に未読をクリアする</value>
+  </data>
+  <data name="&gt;&gt;Label34.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="TextProxyPassword.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="Label77.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ShortenTcoCheck.Text" xml:space="preserve">
+    <value>t.coで短縮する</value>
+  </data>
+  <data name="Label17.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;CheckFavoritesEvent.Name" xml:space="preserve">
+    <value>CheckFavoritesEvent</value>
+  </data>
+  <data name="&gt;&gt;Label27.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="HotkeyCtrl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 15</value>
+  </data>
+  <data name="IsRemoveSameFavEventCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;OneWayLv.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="btnDetailLink.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblDetail.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="StartAuthButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>99, 68</value>
+  </data>
+  <data name="Label67.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Label43.Name" xml:space="preserve">
+    <value>Label43</value>
+  </data>
+  <data name="&gt;&gt;CheckUseRecommendStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckPostAndGet.Text" xml:space="preserve">
+    <value>投稿時取得</value>
+  </data>
+  <data name="TextProxyUser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 19</value>
+  </data>
+  <data name="HotkeyAlt.Text" xml:space="preserve">
+    <value>Alt</value>
+  </data>
+  <data name="&gt;&gt;chkGetFav.Name" xml:space="preserve">
+    <value>chkGetFav</value>
+  </data>
+  <data name="&gt;&gt;CheckStartupVersion.Parent" xml:space="preserve">
+    <value>StartupPanel</value>
+  </data>
+  <data name="btnDetail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 146</value>
+  </data>
+  <data name="&gt;&gt;chkTabIconDisp.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="&gt;&gt;Label1.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="&gt;&gt;Label35.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="Label76.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckAutoConvertUrl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckFavRestrict.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 188</value>
+  </data>
+  <data name="&gt;&gt;Label39.Name" xml:space="preserve">
+    <value>Label39</value>
+  </data>
+  <data name="Label16.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 95</value>
+  </data>
+  <data name="&gt;&gt;btnListFont.Name" xml:space="preserve">
+    <value>btnListFont</value>
+  </data>
+  <data name="&gt;&gt;HotkeyShift.Name" xml:space="preserve">
+    <value>HotkeyShift</value>
+  </data>
+  <data name="btnFav.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label43.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label12.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;IconSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PreviewPanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="Label32.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 70</value>
+  </data>
+  <data name="Label35.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="CheckReadOldPosts.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckFollowEvent.Name" xml:space="preserve">
+    <value>CheckFollowEvent</value>
+  </data>
+  <data name="Label64.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 51</value>
+  </data>
+  <data name="&gt;&gt;AuthClearButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="IsRemoveSameFavEventCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 257</value>
+  </data>
+  <data name="Label47.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="HotkeyCtrl.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="CheckPostAndGet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label80.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 123</value>
+  </data>
+  <data name="Label24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 12</value>
+  </data>
+  <data name="TextProxyPassword.Location" type="System.Drawing.Point, System.Drawing">
+    <value>286, 107</value>
+  </data>
+  <data name="TimelinePeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 37</value>
+  </data>
+  <data name="Label6.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ComboBoxOutputzUrlmode.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;LabelPostAndGet.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="chkTabIconDisp.Text" xml:space="preserve">
+    <value>タブに未読アイコンを表示する</value>
+  </data>
+  <data name="TweetActPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;lblAtTarget.ZOrder" xml:space="preserve">
+    <value>23</value>
+  </data>
+  <data name="MapThumbnailWidthTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 19</value>
+  </data>
+  <data name="Label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="UReadMng.Text" xml:space="preserve">
+    <value>未読管理を行う</value>
+  </data>
+  <data name="&gt;&gt;CheckStartupFollowers.Name" xml:space="preserve">
+    <value>CheckStartupFollowers</value>
+  </data>
+  <data name="Label62.Location" type="System.Drawing.Point, System.Drawing">
+    <value>217, 134</value>
+  </data>
+  <data name="CheckUseSsl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxPostKeySelect.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="GetCountPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="ProxyPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="Label72.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Button3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;IconSize.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="&gt;&gt;Label66.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="ComboDispTitle.Items6" xml:space="preserve">
+    <value>全未読/全発言数</value>
+  </data>
+  <data name="Label32.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;ConnectionPanel.Name" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="&gt;&gt;Label45.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RadioProxyNone.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ActionPanel.Name" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="Label36.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LabelUserStreamActive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>348, 36</value>
+  </data>
+  <data name="Label26.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnListFont.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="Label72.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 145</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Items3" xml:space="preserve">
+    <value>bit.ly</value>
+  </data>
+  <data name="&gt;&gt;Label22.ZOrder" xml:space="preserve">
+    <value>21</value>
+  </data>
+  <data name="CreateAccountButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label49.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LabelProxyPassword.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label27.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label15.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 42</value>
+  </data>
+  <data name="&gt;&gt;Label35.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LanguageCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>215, 285</value>
+  </data>
+  <data name="Label40.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 49</value>
+  </data>
+  <data name="EmailText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;TweetPrvPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblListBackcolor.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Label8.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckStartupVersion.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label34.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label30.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;PlaySnd.Name" xml:space="preserve">
+    <value>PlaySnd</value>
+  </data>
+  <data name="&gt;&gt;TimelinePeriod.Name" xml:space="preserve">
+    <value>TimelinePeriod</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCode.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ConnectionPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;LabelProxyPassword.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label23.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="GroupBox3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 328</value>
+  </data>
+  <data name="ConnectionTimeOut.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="&gt;&gt;ShortenTcoCheck.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="TextCountApiReply.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="&gt;&gt;ChkNewMentionsBlink.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckUseRecommendStatus.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ComboDispTitle.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ConnectionPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="&gt;&gt;ShortUrlPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="ChkNewMentionsBlink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;CheckBlockEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label71.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="UserstreamPeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label49.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>34, 71</value>
+  </data>
+  <data name="Label6.Text" xml:space="preserve">
+    <value>メールアドレスの登録</value>
+  </data>
+  <data name="Label41.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="Label66.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CooperatePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;Label31.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CheckAlwaysTop.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;CheckUseSsl.Name" xml:space="preserve">
+    <value>CheckUseSsl</value>
+  </data>
+  <data name="&gt;&gt;Label17.Name" xml:space="preserve">
+    <value>Label17</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyPw.Name" xml:space="preserve">
+    <value>TextBitlyPw</value>
+  </data>
+  <data name="&gt;&gt;CmbDateTimeFormat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label48.Name" xml:space="preserve">
+    <value>label48</value>
+  </data>
+  <data name="&gt;&gt;Label28.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="btnUnread.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label4.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnAtFromTarget.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;chkUnreadStyle.Name" xml:space="preserve">
+    <value>chkUnreadStyle</value>
+  </data>
+  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label80.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cmbNameBalloon.Location" type="System.Drawing.Point, System.Drawing">
+    <value>215, 15</value>
+  </data>
+  <data name="&gt;&gt;CheckMonospace.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="CheckForceResolve.Size" type="System.Drawing.Size, System.Drawing">
+    <value>187, 16</value>
+  </data>
+  <data name="&gt;&gt;CheckFavRestrict.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="btnUnread.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckOutputz.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;lblInputFont.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;ListsPeriod.Name" xml:space="preserve">
+    <value>ListsPeriod</value>
+  </data>
+  <data name="&gt;&gt;PubSearchPeriod.Name" xml:space="preserve">
+    <value>PubSearchPeriod</value>
+  </data>
+  <data name="btnFav.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 71</value>
+  </data>
+  <data name="Label62.Text" xml:space="preserve">
+    <value>Sample:</value>
+  </data>
+  <data name="CheckBlockEvent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label8.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="BasedPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;GetCountPanel.Name" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckPeriodAdjust.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckPeriodAdjust.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items29" xml:space="preserve">
+    <value>Dutch (Standard)</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Label46.Name" xml:space="preserve">
+    <value>Label46</value>
+  </data>
+  <data name="&gt;&gt;Label29.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="StartupUserstreamCheck.Text" xml:space="preserve">
+    <value>起動時に自動接続</value>
+  </data>
+  <data name="&gt;&gt;TextCountApiReply.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items20" xml:space="preserve">
+    <value>Belarusian</value>
+  </data>
+  <data name="&gt;&gt;CheckOutputz.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="SplitContainer1.Panel1.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items99" xml:space="preserve">
+    <value>Spanish (Peru)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items24" xml:space="preserve">
+    <value>Chinese (Hong Kong SAR)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items25" xml:space="preserve">
+    <value>Chinese (Singapore)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items26" xml:space="preserve">
+    <value>Croatian</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items27" xml:space="preserve">
+    <value>Czech</value>
+  </data>
+  <data name="&gt;&gt;Label3.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="CheckBox3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckListMemberAddedEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 94</value>
   </data>
   <data name="ComboBoxTranslateLanguage.Items91" xml:space="preserve">
     <value>Spanish (Spain)</value>
@@ -4278,4587 +4105,4761 @@ Growl.CoreLibrary.DLL</value>
   <data name="ComboBoxTranslateLanguage.Items97" xml:space="preserve">
     <value>Spanish (Venezuela)</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items98" xml:space="preserve">
-    <value>Spanish (Colombia)</value>
+  <data name="StartAuthButton.Text" xml:space="preserve">
+    <value>認証開始</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items99" xml:space="preserve">
-    <value>Spanish (Peru)</value>
+  <data name="&gt;&gt;Label69.Name" xml:space="preserve">
+    <value>Label69</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items100" xml:space="preserve">
-    <value>Spanish (Argentina)</value>
+  <data name="ChkNewMentionsBlink.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 166</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items101" xml:space="preserve">
-    <value>Spanish (Ecuador)</value>
+  <data name="&gt;&gt;btnTarget.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="ComboBoxTranslateLanguage.Items102" xml:space="preserve">
-    <value>Spanish (Chile)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items103" xml:space="preserve">
-    <value>Spanish (Uruguay)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items104" xml:space="preserve">
-    <value>Spanish (Paraguay)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items105" xml:space="preserve">
-    <value>Spanish (Bolivia)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items106" xml:space="preserve">
-    <value>Spanish (El Salvador)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items107" xml:space="preserve">
-    <value>Spanish (Honduras)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items108" xml:space="preserve">
-    <value>Spanish (Nicaragua)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items109" xml:space="preserve">
-    <value>Spanish (Puerto Rico)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items110" xml:space="preserve">
-    <value>Sutu</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items111" xml:space="preserve">
-    <value>Swedish</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items112" xml:space="preserve">
-    <value>Swedish (Finland)</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items113" xml:space="preserve">
-    <value>Thai</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items114" xml:space="preserve">
-    <value>Tsonga</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items115" xml:space="preserve">
-    <value>Tswana</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items116" xml:space="preserve">
-    <value>Turkish</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items117" xml:space="preserve">
-    <value>Ukrainian</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items118" xml:space="preserve">
-    <value>Urdu</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items119" xml:space="preserve">
-    <value>Venda</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items120" xml:space="preserve">
-    <value>Vietnamese</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items121" xml:space="preserve">
-    <value>Xhosa</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items122" xml:space="preserve">
-    <value>Yiddish</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Items123" xml:space="preserve">
-    <value>Zulu</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 195</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 23</value>
-  </data>
-  <data name="ComboBoxTranslateLanguage.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxTranslateLanguage.Name" xml:space="preserve">
-    <value>ComboBoxTranslateLanguage</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxTranslateLanguage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxTranslateLanguage.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxTranslateLanguage.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label29.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label29.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 200</value>
-  </data>
-  <data name="Label29.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 15</value>
-  </data>
-  <data name="Label29.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="Label29.Text" xml:space="preserve">
-    <value>発言翻訳先の言語</value>
-  </data>
-  <data name="&gt;&gt;Label29.Name" xml:space="preserve">
-    <value>Label29</value>
-  </data>
-  <data name="&gt;&gt;Label29.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label29.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;Label29.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CheckOutputz.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckOutputz.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckOutputz.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 28</value>
-  </data>
-  <data name="CheckOutputz.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckOutputz.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 19</value>
-  </data>
-  <data name="CheckOutputz.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="CheckOutputz.Text" xml:space="preserve">
-    <value>Outputzに対応する</value>
-  </data>
-  <data name="&gt;&gt;CheckOutputz.Name" xml:space="preserve">
-    <value>CheckOutputz</value>
-  </data>
-  <data name="&gt;&gt;CheckOutputz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckOutputz.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;CheckOutputz.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="CheckNicoms.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckNicoms.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckNicoms.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 150</value>
-  </data>
-  <data name="CheckNicoms.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckNicoms.Size" type="System.Drawing.Size, System.Drawing">
-    <value>294, 19</value>
-  </data>
-  <data name="CheckNicoms.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="CheckNicoms.Text" xml:space="preserve">
-    <value>ニコニコ動画のURLをnico.msで短縮して送信</value>
-  </data>
-  <data name="&gt;&gt;CheckNicoms.Name" xml:space="preserve">
-    <value>CheckNicoms</value>
-  </data>
-  <data name="&gt;&gt;CheckNicoms.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckNicoms.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;CheckNicoms.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="TextBoxOutputzKey.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 55</value>
-  </data>
-  <data name="TextBoxOutputzKey.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextBoxOutputzKey.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 22</value>
-  </data>
-  <data name="TextBoxOutputzKey.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;TextBoxOutputzKey.Name" xml:space="preserve">
-    <value>TextBoxOutputzKey</value>
-  </data>
-  <data name="&gt;&gt;TextBoxOutputzKey.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextBoxOutputzKey.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;TextBoxOutputzKey.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Label60.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label60.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label60.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 94</value>
-  </data>
-  <data name="Label60.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label60.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 15</value>
-  </data>
-  <data name="Label60.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="Label60.Text" xml:space="preserve">
-    <value>アウトプット先のURL</value>
-  </data>
-  <data name="&gt;&gt;Label60.Name" xml:space="preserve">
-    <value>Label60</value>
-  </data>
-  <data name="&gt;&gt;Label60.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label60.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;Label60.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="Label59.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label59.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label59.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 59</value>
-  </data>
-  <data name="Label59.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label59.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 15</value>
-  </data>
-  <data name="Label59.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="Label59.Text" xml:space="preserve">
-    <value>復活の呪文</value>
-  </data>
-  <data name="&gt;&gt;Label59.Name" xml:space="preserve">
-    <value>Label59</value>
-  </data>
-  <data name="&gt;&gt;Label59.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label59.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;Label59.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="ComboBoxOutputzUrlmode.Items" xml:space="preserve">
-    <value>twitter.com</value>
-  </data>
-  <data name="ComboBoxOutputzUrlmode.Items1" xml:space="preserve">
-    <value>twitter.com/username</value>
-  </data>
-  <data name="ComboBoxOutputzUrlmode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 90</value>
-  </data>
-  <data name="ComboBoxOutputzUrlmode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ComboBoxOutputzUrlmode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 23</value>
-  </data>
-  <data name="ComboBoxOutputzUrlmode.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxOutputzUrlmode.Name" xml:space="preserve">
-    <value>ComboBoxOutputzUrlmode</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxOutputzUrlmode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxOutputzUrlmode.Parent" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;ComboBoxOutputzUrlmode.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="CooperatePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="CooperatePanel.Enabled" type="System.Boolean, mscorlib">
+  <data name="ActionPanel.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="CooperatePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="Label11.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 152</value>
   </data>
-  <data name="CooperatePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="IconSize.Items2" xml:space="preserve">
+    <value>24*24</value>
   </data>
-  <data name="CooperatePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
+  <data name="ReplyIconStateCombo.Items2" xml:space="preserve">
+    <value>アイコン変更＆点滅</value>
   </data>
-  <data name="CooperatePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+  <data name="Label39.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="CooperatePanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
+  <data name="FontPanel.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="&gt;&gt;CooperatePanel.Name" xml:space="preserve">
-    <value>CooperatePanel</value>
-  </data>
-  <data name="&gt;&gt;CooperatePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CooperatePanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;CooperatePanel.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Label55.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label55.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label55.Location" type="System.Drawing.Point, System.Drawing">
-    <value>55, 168</value>
-  </data>
-  <data name="Label55.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label55.Size" type="System.Drawing.Size, System.Drawing">
-    <value>392, 15</value>
-  </data>
-  <data name="Label55.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="Label55.Text" xml:space="preserve">
-    <value>※認証が不要な場合は、ユーザ名とパスワードは空にしてください。</value>
-  </data>
-  <data name="&gt;&gt;Label55.Name" xml:space="preserve">
-    <value>Label55</value>
-  </data>
-  <data name="&gt;&gt;Label55.Type" xml:space="preserve">
+  <data name="&gt;&gt;Label21.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label55.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;Label55.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="TextProxyPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>381, 134</value>
-  </data>
-  <data name="TextProxyPassword.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextProxyPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 22</value>
-  </data>
-  <data name="TextProxyPassword.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPassword.Name" xml:space="preserve">
-    <value>TextProxyPassword</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPassword.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPassword.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPassword.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="RadioProxyNone.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RadioProxyNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="lblAtFromTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="RadioProxyNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 24</value>
-  </data>
-  <data name="RadioProxyNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="RadioProxyNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 19</value>
-  </data>
-  <data name="RadioProxyNone.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="RadioProxyNone.Text" xml:space="preserve">
-    <value>使用しない</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyNone.Name" xml:space="preserve">
-    <value>RadioProxyNone</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyNone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyNone.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyNone.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="LabelProxyPassword.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LabelProxyPassword.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelProxyPassword.Location" type="System.Drawing.Point, System.Drawing">
-    <value>289, 138</value>
-  </data>
-  <data name="LabelProxyPassword.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelProxyPassword.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 15</value>
-  </data>
-  <data name="LabelProxyPassword.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="LabelProxyPassword.Text" xml:space="preserve">
-    <value>パスワード(&amp;W)</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPassword.Name" xml:space="preserve">
-    <value>LabelProxyPassword</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPassword.Type" xml:space="preserve">
+  <data name="&gt;&gt;Label23.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;LabelProxyPassword.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPassword.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="RadioProxyIE.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RadioProxyIE.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RadioProxyIE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 51</value>
-  </data>
-  <data name="RadioProxyIE.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="RadioProxyIE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>237, 19</value>
-  </data>
-  <data name="RadioProxyIE.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="RadioProxyIE.Text" xml:space="preserve">
-    <value>InternetExplorerの設定を使用する</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyIE.Name" xml:space="preserve">
-    <value>RadioProxyIE</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyIE.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyIE.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;RadioProxyIE.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="TextProxyUser.Location" type="System.Drawing.Point, System.Drawing">
-    <value>191, 134</value>
-  </data>
-  <data name="TextProxyUser.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextProxyUser.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 22</value>
-  </data>
-  <data name="TextProxyUser.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;TextProxyUser.Name" xml:space="preserve">
-    <value>TextProxyUser</value>
-  </data>
-  <data name="&gt;&gt;TextProxyUser.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextProxyUser.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;TextProxyUser.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="RadioProxySpecified.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RadioProxySpecified.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RadioProxySpecified.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 78</value>
-  </data>
-  <data name="RadioProxySpecified.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="RadioProxySpecified.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 19</value>
-  </data>
-  <data name="RadioProxySpecified.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="RadioProxySpecified.Text" xml:space="preserve">
-    <value>指定する</value>
-  </data>
-  <data name="&gt;&gt;RadioProxySpecified.Name" xml:space="preserve">
-    <value>RadioProxySpecified</value>
-  </data>
-  <data name="&gt;&gt;RadioProxySpecified.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RadioProxySpecified.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;RadioProxySpecified.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="LabelProxyUser.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LabelProxyUser.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelProxyUser.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 138</value>
-  </data>
-  <data name="LabelProxyUser.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelProxyUser.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 15</value>
-  </data>
-  <data name="LabelProxyUser.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="LabelProxyUser.Text" xml:space="preserve">
-    <value>ユーザ名(&amp;U)</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyUser.Name" xml:space="preserve">
-    <value>LabelProxyUser</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyUser.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyUser.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyUser.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="LabelProxyAddress.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LabelProxyAddress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelProxyAddress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>67, 106</value>
-  </data>
-  <data name="LabelProxyAddress.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelProxyAddress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 15</value>
-  </data>
-  <data name="LabelProxyAddress.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="LabelProxyAddress.Text" xml:space="preserve">
-    <value>プロキシ(&amp;X)</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyAddress.Name" xml:space="preserve">
-    <value>LabelProxyAddress</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyAddress.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyAddress.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyAddress.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="TextProxyPort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="TextProxyPort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>412, 102</value>
-  </data>
-  <data name="TextProxyPort.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextProxyPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 22</value>
-  </data>
-  <data name="TextProxyPort.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPort.Name" xml:space="preserve">
-    <value>TextProxyPort</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPort.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;TextProxyPort.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="TextProxyAddress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>152, 102</value>
-  </data>
-  <data name="TextProxyAddress.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TextProxyAddress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>179, 22</value>
-  </data>
-  <data name="TextProxyAddress.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;TextProxyAddress.Name" xml:space="preserve">
-    <value>TextProxyAddress</value>
-  </data>
-  <data name="&gt;&gt;TextProxyAddress.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TextProxyAddress.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;TextProxyAddress.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="LabelProxyPort.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LabelProxyPort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelProxyPort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>340, 106</value>
-  </data>
-  <data name="LabelProxyPort.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelProxyPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 15</value>
-  </data>
-  <data name="LabelProxyPort.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="LabelProxyPort.Text" xml:space="preserve">
-    <value>ポート(&amp;P)</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPort.Name" xml:space="preserve">
-    <value>LabelProxyPort</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPort.Parent" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelProxyPort.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="ProxyPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="ProxyPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="ProxyPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="ProxyPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ProxyPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="ProxyPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="ProxyPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;ProxyPanel.Name" xml:space="preserve">
-    <value>ProxyPanel</value>
-  </data>
-  <data name="&gt;&gt;ProxyPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ProxyPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;ProxyPanel.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="TwitterSearchAPIText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>349, 156</value>
-  </data>
-  <data name="TwitterSearchAPIText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TwitterSearchAPIText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 22</value>
+  <data name="Label28.Text" xml:space="preserve">
+    <value>初回の更新</value>
   </data>
   <data name="TwitterSearchAPIText.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="TwitterSearchAPIText.Text" xml:space="preserve">
-    <value>search.twitter.com</value>
+  <data name="GroupBox2.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="TwitterSearchAPIText.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;TwitterSearchAPIText.Name" xml:space="preserve">
-    <value>TwitterSearchAPIText</value>
+  <data name="Label67.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 24</value>
   </data>
   <data name="&gt;&gt;TwitterSearchAPIText.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;TwitterSearchAPIText.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
+  <data name="lblTarget.Text" xml:space="preserve">
+    <value>This is sample.</value>
   </data>
-  <data name="&gt;&gt;TwitterSearchAPIText.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;btnListBack.Name" xml:space="preserve">
+    <value>btnListBack</value>
+  </data>
+  <data name="&gt;&gt;CheckTinyURL.Name" xml:space="preserve">
+    <value>CheckTinyURL</value>
+  </data>
+  <data name="Label47.Text" xml:space="preserve">
+    <value>再起動後有効になります。</value>
+  </data>
+  <data name="Label6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="StartupReaded.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="Label31.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label31.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label31.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 160</value>
-  </data>
-  <data name="Label31.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label31.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 15</value>
-  </data>
-  <data name="Label31.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="Label31.Text" xml:space="preserve">
-    <value>Twitter SearchAPI URL (search.twitter.com)</value>
-  </data>
-  <data name="Label31.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;Label31.Name" xml:space="preserve">
-    <value>Label31</value>
-  </data>
-  <data name="&gt;&gt;Label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label31.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label31.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="TwitterAPIText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>349, 125</value>
-  </data>
-  <data name="TwitterAPIText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TwitterAPIText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 22</value>
-  </data>
-  <data name="TwitterAPIText.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="TwitterAPIText.Text" xml:space="preserve">
-    <value>api.twitter.com</value>
-  </data>
-  <data name="TwitterAPIText.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;TwitterAPIText.Name" xml:space="preserve">
-    <value>TwitterAPIText</value>
-  </data>
-  <data name="&gt;&gt;TwitterAPIText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TwitterAPIText.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
-  </data>
-  <data name="&gt;&gt;TwitterAPIText.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="Label8.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 129</value>
-  </data>
-  <data name="Label8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>217, 15</value>
-  </data>
-  <data name="Label8.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="Label8.Text" xml:space="preserve">
-    <value>Twitter API URL (api.twitter.com)</value>
-  </data>
-  <data name="Label8.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;Label8.Name" xml:space="preserve">
-    <value>Label8</value>
-  </data>
-  <data name="&gt;&gt;Label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label8.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label8.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="CheckUseSsl.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckUseSsl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckUseSsl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 98</value>
-  </data>
-  <data name="CheckUseSsl.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckUseSsl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 19</value>
-  </data>
-  <data name="CheckUseSsl.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="CheckUseSsl.Text" xml:space="preserve">
-    <value>通信にHTTPSを使用する</value>
-  </data>
-  <data name="&gt;&gt;CheckUseSsl.Name" xml:space="preserve">
-    <value>CheckUseSsl</value>
-  </data>
-  <data name="&gt;&gt;CheckUseSsl.Type" xml:space="preserve">
+  <data name="&gt;&gt;CheckMonospace.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;CheckUseSsl.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
+  <data name="&gt;&gt;CreateAccountButton.Parent" xml:space="preserve">
+    <value>BasedPanel</value>
   </data>
-  <data name="&gt;&gt;CheckUseSsl.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="CheckUseRecommendStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
   </data>
-  <data name="Label64.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="IsPreviewFoursquareCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>327, 16</value>
   </data>
-  <data name="Label64.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;TweetPrvPanel.Name" xml:space="preserve">
+    <value>TweetPrvPanel</value>
   </data>
-  <data name="Label64.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 64</value>
+  <data name="&gt;&gt;FavoritesTextCountApi.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="Label64.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="ComboBoxTranslateLanguage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>182, 20</value>
   </data>
-  <data name="Label64.Size" type="System.Drawing.Size, System.Drawing">
-    <value>440, 15</value>
+  <data name="&gt;&gt;TreeViewSetting.Name" xml:space="preserve">
+    <value>TreeViewSetting</value>
   </data>
-  <data name="Label64.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="&gt;&gt;btnOWL.Name" xml:space="preserve">
+    <value>btnOWL</value>
   </data>
-  <data name="Label64.Text" xml:space="preserve">
-    <value>※タイムアウトが頻発する場合に調整してください。初期設定は20秒です。</value>
-  </data>
-  <data name="&gt;&gt;Label64.Name" xml:space="preserve">
-    <value>Label64</value>
-  </data>
-  <data name="&gt;&gt;Label64.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label64.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label64.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;TextProxyUser.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="ConnectionTimeOut.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
+  <data name="Label4.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="ConnectionTimeOut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>349, 22</value>
+  <data name="&gt;&gt;btnListBack.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="ConnectionTimeOut.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;Label28.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ConnectionTimeOut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 22</value>
+  <data name="Label36.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 12</value>
   </data>
-  <data name="ConnectionTimeOut.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="ListsPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 151</value>
   </data>
-  <data name="&gt;&gt;ConnectionTimeOut.Name" xml:space="preserve">
-    <value>ConnectionTimeOut</value>
+  <data name="&gt;&gt;btnOWL.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
-  <data name="&gt;&gt;ConnectionTimeOut.Type" xml:space="preserve">
+  <data name="&gt;&gt;HotkeyCtrl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GetMoreTextCountApi.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ConnectionTimeOut.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
+  <data name="&gt;&gt;SplitContainer1.Name" xml:space="preserve">
+    <value>SplitContainer1</value>
   </data>
-  <data name="&gt;&gt;ConnectionTimeOut.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;Label5.Name" xml:space="preserve">
+    <value>Label5</value>
   </data>
-  <data name="Label63.AutoSize" type="System.Boolean, mscorlib">
+  <data name="&gt;&gt;Label13.Name" xml:space="preserve">
+    <value>Label13</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel1.Name" xml:space="preserve">
+    <value>SplitContainer1.Panel1</value>
+  </data>
+  <data name="Label80.Text" xml:space="preserve">
+    <value>ReTweet</value>
+  </data>
+  <data name="Label4.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="Label63.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="&gt;&gt;StartupReaded.Name" xml:space="preserve">
+    <value>StartupReaded</value>
+  </data>
+  <data name="Label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Label63.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 25</value>
+  <data name="&gt;&gt;UserAppointUrlText.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
   </data>
-  <data name="Label63.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="Label38.Location" type="System.Drawing.Point, System.Drawing">
+    <value>24, 282</value>
   </data>
-  <data name="Label63.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 15</value>
+  <data name="&gt;&gt;HotkeyAlt.Name" xml:space="preserve">
+    <value>HotkeyAlt</value>
+  </data>
+  <data name="&gt;&gt;FontPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="RadioProxyIE.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor.Name" xml:space="preserve">
+    <value>ButtonBackToDefaultFontColor</value>
+  </data>
+  <data name="Label14.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 12</value>
+  </data>
+  <data name="btnSelf.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="IsRemoveSameFavEventCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;AuthUserCombo.Parent" xml:space="preserve">
+    <value>BasedPanel</value>
+  </data>
+  <data name="&gt;&gt;Label29.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblSelf.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="btnAtTarget.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="NotifyPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckDispUsername.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="IconSize.Items4" xml:space="preserve">
+    <value>48*48(2Column)</value>
+  </data>
+  <data name="&gt;&gt;GetMoreTextCountApi.Name" xml:space="preserve">
+    <value>GetMoreTextCountApi</value>
+  </data>
+  <data name="chkUnreadStyle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;TweetPrvPanel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Label32.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="CheckAutoConvertUrl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="cmbNameBalloon.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="AuthClearButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;CheckFavoritesEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckNicoms.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;StartupUserstreamCheck.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="&gt;&gt;Label55.Name" xml:space="preserve">
+    <value>Label55</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxEventNotifySound.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;LanguageCombo.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="&gt;&gt;Label16.Name" xml:space="preserve">
+    <value>Label16</value>
+  </data>
+  <data name="TreeViewSetting.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label17.Text" xml:space="preserve">
+    <value>UserTimelineの取得数</value>
+  </data>
+  <data name="Label71.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="StartAuthButton.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label23.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 114</value>
+  </data>
+  <data name="btnAtTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="HotkeyCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Label9.Name" xml:space="preserve">
+    <value>Label9</value>
+  </data>
+  <data name="&gt;&gt;Label19.Name" xml:space="preserve">
+    <value>Label19</value>
+  </data>
+  <data name="btnUnread.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnListFont.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;btnDetailBack.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="Label22.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Size" type="System.Drawing.Size, System.Drawing">
+    <value>246, 20</value>
+  </data>
+  <data name="&gt;&gt;Label33.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items48" xml:space="preserve">
+    <value>French (Belgium)</value>
+  </data>
+  <data name="TwitterSearchAPIText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 125</value>
+  </data>
+  <data name="&gt;&gt;ButtonApiCalc.Name" xml:space="preserve">
+    <value>ButtonApiCalc</value>
+  </data>
+  <data name="RadioProxySpecified.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label47.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items69" xml:space="preserve">
+    <value>Korean (Johab)</value>
+  </data>
+  <data name="Label45.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 91</value>
+  </data>
+  <data name="btnSelf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 15</value>
+  </data>
+  <data name="CheckMonospace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 238</value>
+  </data>
+  <data name="CheckFavRestrict.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;LabelPostAndGet.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblFav.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label13.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;Save.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items62" xml:space="preserve">
+    <value>Hungarian</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items63" xml:space="preserve">
+    <value>Icelandic</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items64" xml:space="preserve">
+    <value>Indonesian</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items65" xml:space="preserve">
+    <value>Italian (Standard)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items66" xml:space="preserve">
+    <value>Italian (Switzerland)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items67" xml:space="preserve">
+    <value>Japanese</value>
+  </data>
+  <data name="&gt;&gt;Label6.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="Label63.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="Label63.Text" xml:space="preserve">
-    <value>タイムアウトまでの時間(秒)</value>
+  <data name="CheckBlockEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 128</value>
   </data>
-  <data name="&gt;&gt;Label63.Name" xml:space="preserve">
-    <value>Label63</value>
+  <data name="CheckSortOrderLock.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;Label63.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="Label20.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="&gt;&gt;Label63.Parent" xml:space="preserve">
-    <value>ConnectionPanel</value>
+  <data name="ProxyPanel.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="&gt;&gt;Label63.ZOrder" xml:space="preserve">
-    <value>7</value>
+  <data name="ConnectionTimeOut.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 19</value>
   </data>
-  <data name="ConnectionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="ButtonApiCalc.Location" type="System.Drawing.Point, System.Drawing">
+    <value>205, 339</value>
   </data>
-  <data name="ConnectionPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="ConnectionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="ConnectionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ConnectionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="ConnectionPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="ConnectionPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;ConnectionPanel.Name" xml:space="preserve">
-    <value>ConnectionPanel</value>
-  </data>
-  <data name="&gt;&gt;ConnectionPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ConnectionPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;ConnectionPanel.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="UserstreamPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="TextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>Disable</value>
   </data>
-  <data name="UserstreamPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 15</value>
+  <data name="ComboBoxEventNotifySound.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="UserstreamPeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="UserstreamPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
-  </data>
-  <data name="UserstreamPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;UserstreamPeriod.Name" xml:space="preserve">
-    <value>UserstreamPeriod</value>
-  </data>
-  <data name="&gt;&gt;UserstreamPeriod.Type" xml:space="preserve">
+  <data name="&gt;&gt;TextCountApi.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;UserstreamPeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
+  <data name="&gt;&gt;CheckRetweetNoConfirm.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;UserstreamPeriod.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="Label66.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
   </data>
-  <data name="Label46.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label46.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label46.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 19</value>
-  </data>
-  <data name="Label46.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label46.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 15</value>
-  </data>
-  <data name="Label46.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label46.Text" xml:space="preserve">
-    <value>UserStream反映間隔（秒）</value>
-  </data>
-  <data name="&gt;&gt;Label46.Name" xml:space="preserve">
-    <value>Label46</value>
-  </data>
-  <data name="&gt;&gt;Label46.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label46.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;Label46.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;Label38.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="LabelApiUsingUserStreamEnabled.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="LabelApiUsingUserStreamEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 385</value>
+  <data name="Label4.Text" xml:space="preserve">
+    <value>アカウント</value>
   </data>
-  <data name="LabelApiUsingUserStreamEnabled.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.Name" xml:space="preserve">
+    <value>IsPreviewFoursquareCheckBox</value>
   </data>
-  <data name="LabelApiUsingUserStreamEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 15</value>
+  <data name="Label55.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
-  <data name="LabelApiUsingUserStreamEnabled.TabIndex" type="System.Int32, mscorlib">
+  <data name="btnFav.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="GroupBox3.Text" xml:space="preserve">
+    <value>ホットキー</value>
+  </data>
+  <data name="&gt;&gt;lblAtTo.ZOrder" xml:space="preserve">
     <value>20</value>
   </data>
-  <data name="LabelApiUsingUserStreamEnabled.Text" xml:space="preserve">
-    <value>999</value>
+  <data name="Label63.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 20</value>
   </data>
-  <data name="&gt;&gt;LabelApiUsingUserStreamEnabled.Name" xml:space="preserve">
-    <value>LabelApiUsingUserStreamEnabled</value>
+  <data name="ActionPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="Label45.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;cmbNameBalloon.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="RadioProxySpecified.Text" xml:space="preserve">
+    <value>指定する</value>
+  </data>
+  <data name="CheckStartupVersion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 47</value>
+  </data>
+  <data name="&gt;&gt;ReplyPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Items1" xml:space="preserve">
+    <value>Favorite</value>
+  </data>
+  <data name="Label27.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ActionPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailZoomTextBox.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="Label19.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 54</value>
   </data>
   <data name="&gt;&gt;LabelApiUsingUserStreamEnabled.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="LabelApiUsingUserStreamEnabled.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="StartupUserstreamCheck.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label1.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="SplitContainer1.Panel2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label43.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;CheckViewTabBottom.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label76.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblAtTo.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;ListDoubleClickActionComboBox.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;Label39.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ChkNewMentionsBlink.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;btnDetail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="TweetPrvPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;Label60.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="Label46.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnInputFont.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="&gt;&gt;chkGetFav.Parent" xml:space="preserve">
+    <value>StartupPanel</value>
+  </data>
+  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CheckHashSupple.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label60.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Button3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 21</value>
+  </data>
+  <data name="TwitterAPIText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 19</value>
+  </data>
+  <data name="Label16.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckRetweetNoConfirm.Size" type="System.Drawing.Size, System.Drawing">
+    <value>165, 16</value>
+  </data>
+  <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>223, 12</value>
+  </data>
+  <data name="&gt;&gt;lblAtTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckBalloonLimit.Text" xml:space="preserve">
+    <value>画面最小化・アイコン時のみバルーンを表示する</value>
+  </data>
+  <data name="Label31.Size" type="System.Drawing.Size, System.Drawing">
+    <value>228, 12</value>
+  </data>
+  <data name="Label46.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;btnDetail.Name" xml:space="preserve">
+    <value>btnDetail</value>
+  </data>
+  <data name="StartAuthButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>321, 45</value>
+  </data>
+  <data name="StartupPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;LabelDateTimeFormatApplied.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="CheckUserUpdateEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;ShortUrlPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkReadOwnPost.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label23.Text" xml:space="preserve">
+    <value>リストの日時フォーマット</value>
+  </data>
+  <data name="LabelProxyAddress.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="CheckFavEventUnread.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="FontPanel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="lblFav.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel1.Parent" xml:space="preserve">
+    <value>SplitContainer1</value>
+  </data>
+  <data name="ButtonApiCalc.Text" xml:space="preserve">
+    <value>再計算</value>
+  </data>
+  <data name="&gt;&gt;Label44.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckEventNotify.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;FontPanel2.Name" xml:space="preserve">
+    <value>FontPanel2</value>
+  </data>
+  <data name="&gt;&gt;lblDetail.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="NotifyPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CooperatePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;CheckOutputz.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="CheckFavoritesEvent.Text" xml:space="preserve">
+    <value>Fav追加した、またはFav追加された</value>
+  </data>
+  <data name="lblAtSelf.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;CheckTinyURL.Parent" xml:space="preserve">
+    <value>ShortUrlPanel</value>
+  </data>
+  <data name="chkReadOwnPost.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 255</value>
+  </data>
+  <data name="Label65.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblOWL.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyId.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;CheckPeriodAdjust.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="Label14.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 120</value>
+  </data>
+  <data name="TweetActPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="Label32.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="CheckEventNotify.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label45.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label30.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 210</value>
+  </data>
+  <data name="GetCountPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyAddress.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="AuthUserCombo.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;HotkeyText.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>463, 26</value>
+  </data>
+  <data name="&gt;&gt;HotkeyAlt.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="&gt;&gt;lblListFont.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="TabMouseLockCheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyPassword.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="&gt;&gt;Label15.Name" xml:space="preserve">
+    <value>Label15</value>
+  </data>
+  <data name="CheckDispUsername.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;FontPanel2.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="Label18.Text" xml:space="preserve">
+    <value>発言詳細リンク</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCheck.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="Label38.Text" xml:space="preserve">
+    <value>発言をダブルクリック時の動作</value>
+  </data>
+  <data name="Label60.Text" xml:space="preserve">
+    <value>アウトプット先のURL</value>
+  </data>
+  <data name="&gt;&gt;HotkeyWin.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="CheckTinyURL.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;FontPanel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label62.Name" xml:space="preserve">
+    <value>Label62</value>
+  </data>
+  <data name="CooperatePanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCode.Name" xml:space="preserve">
+    <value>HotkeyCode</value>
+  </data>
+  <data name="&gt;&gt;Label57.Name" xml:space="preserve">
+    <value>Label57</value>
+  </data>
+  <data name="CheckMinimizeToTray.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="Label32.Text" xml:space="preserve">
+    <value>その人の発言</value>
+  </data>
+  <data name="&gt;&gt;PlaySnd.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="chkReadOwnPost.Text" xml:space="preserve">
+    <value>自分の発言を既読にする</value>
+  </data>
+  <data name="SplitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="&gt;&gt;btnAtTarget.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="CheckListMemberAddedEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 16</value>
+  </data>
+  <data name="CheckReadOldPosts.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label71.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckCloseToExit.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="BasedPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label2.ToolTip" xml:space="preserve">
+    <value>Growl for Windowsの開発者向けに公開されている、
+Growl_NET_Connector_SDK.zipに同梱の次のDLLが必要です
+Growl.Connector.DLL
+Growl.CoreLibrary.DLL</value>
+  </data>
   <data name="&gt;&gt;LabelApiUsingUserStreamEnabled.Parent" xml:space="preserve">
     <value>GetPeriodPanel</value>
   </data>
-  <data name="&gt;&gt;LabelApiUsingUserStreamEnabled.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="Label64.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="LabelUserStreamActive.AutoSize" type="System.Boolean, mscorlib">
+  <data name="&gt;&gt;Label52.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;TextBox3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckPeriodAdjust.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblUnread.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 46</value>
+  </data>
+  <data name="&gt;&gt;Label46.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;chkReadOwnPost.Name" xml:space="preserve">
+    <value>chkReadOwnPost</value>
+  </data>
+  <data name="CheckForceResolve.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="LabelUserStreamActive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 326</value>
+  <data name="LabelProxyAddress.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="LabelUserStreamActive.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="CheckMinimizeToTray.Text" xml:space="preserve">
+    <value>最小化したときにアイコン化する</value>
   </data>
-  <data name="LabelUserStreamActive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>436, 45</value>
+  <data name="btnDetailLink.Text" xml:space="preserve">
+    <value>文字色</value>
   </data>
-  <data name="LabelUserStreamActive.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+  <data name="&gt;&gt;Label59.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="&gt;&gt;PlaySnd.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnAtTo.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckBlockEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="&gt;&gt;btnAtFromTarget.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items5" xml:space="preserve">
+    <value>H:mm:ss M/d</value>
+  </data>
+  <data name="GroupBox1.Text" xml:space="preserve">
+    <value>フォント＆色設定</value>
+  </data>
+  <data name="&gt;&gt;lblUnread.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="DMPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
+  </data>
+  <data name="ActionPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;Label53.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="UseChangeGetCount.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label16.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 12</value>
+  </data>
+  <data name="lblOWL.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="CheckStartupFollowers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 70</value>
+  </data>
+  <data name="Label15.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;LabelApiUsing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckHashSupple.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="Label52.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="AuthUserCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 20</value>
+  </data>
+  <data name="FontPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="TextBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="RadioProxyNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailHeightTextBox.Name" xml:space="preserve">
+    <value>MapThumbnailHeightTextBox</value>
+  </data>
+  <data name="&gt;&gt;Label44.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="Label16.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label40.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="&gt;&gt;TextBoxOutputzKey.Name" xml:space="preserve">
+    <value>TextBoxOutputzKey</value>
+  </data>
+  <data name="CheckStartupVersion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 16</value>
+  </data>
+  <data name="&gt;&gt;TabMouseLockCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnListFont.ZOrder" xml:space="preserve">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;btnInputBackcolor.Name" xml:space="preserve">
+    <value>btnInputBackcolor</value>
+  </data>
+  <data name="CheckOpenUserTimeline.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckListMemberAddedEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="ShortenTcoCheck.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ShortUrlPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ShortUrlPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="btnListFont.Text" xml:space="preserve">
+    <value>フォント&amp;&amp;色</value>
+  </data>
+  <data name="Label3.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="FontPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="CheckCloseToExit.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label18.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="HotkeyWin.Location" type="System.Drawing.Point, System.Drawing">
+    <value>211, 15</value>
   </data>
   <data name="LabelUserStreamActive.Text" xml:space="preserve">
     <value>UserStreamが有効です。
 タイムライン/Mentions/DMの定期更新、投稿時取得は停止しています。
 これらはUserStreamによりリアルタイム更新されます。</value>
   </data>
-  <data name="&gt;&gt;LabelUserStreamActive.Name" xml:space="preserve">
-    <value>LabelUserStreamActive</value>
-  </data>
-  <data name="&gt;&gt;LabelUserStreamActive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelUserStreamActive.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelUserStreamActive.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Label21.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label21.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 229</value>
-  </data>
-  <data name="Label21.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label21.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 15</value>
-  </data>
-  <data name="Label21.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="Label21.Text" xml:space="preserve">
-    <value>UserTimeline更新間隔（秒）</value>
-  </data>
-  <data name="&gt;&gt;Label21.Name" xml:space="preserve">
-    <value>Label21</value>
-  </data>
-  <data name="&gt;&gt;Label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label21.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;Label21.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="UserTimelinePeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="UserTimelinePeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 224</value>
-  </data>
-  <data name="UserTimelinePeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="UserTimelinePeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
-  </data>
-  <data name="UserTimelinePeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;UserTimelinePeriod.Name" xml:space="preserve">
-    <value>UserTimelinePeriod</value>
-  </data>
-  <data name="&gt;&gt;UserTimelinePeriod.Type" xml:space="preserve">
+  <data name="&gt;&gt;TextProxyPassword.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;UserTimelinePeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
+  <data name="Label57.Location" type="System.Drawing.Point, System.Drawing">
+    <value>26, 210</value>
   </data>
-  <data name="&gt;&gt;UserTimelinePeriod.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="RadioProxySpecified.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 16</value>
   </data>
-  <data name="TimelinePeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
+  <data name="&gt;&gt;Label41.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
   </data>
-  <data name="TimelinePeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 46</value>
+  <data name="&gt;&gt;lblListBackcolor.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="TimelinePeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="LabelProxyPassword.Location" type="System.Drawing.Point, System.Drawing">
+    <value>217, 110</value>
   </data>
-  <data name="TimelinePeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
-  </data>
-  <data name="TimelinePeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;TimelinePeriod.Name" xml:space="preserve">
-    <value>TimelinePeriod</value>
-  </data>
-  <data name="&gt;&gt;TimelinePeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TimelinePeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;TimelinePeriod.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
+  <data name="FollowCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="lblAtTarget.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
   </data>
-  <data name="Label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 50</value>
-  </data>
-  <data name="Label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 15</value>
-  </data>
-  <data name="Label3.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Label3.Text" xml:space="preserve">
-    <value>タイムライン更新間隔（秒）</value>
-  </data>
-  <data name="&gt;&gt;Label3.Name" xml:space="preserve">
-    <value>Label3</value>
-  </data>
-  <data name="&gt;&gt;Label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label3.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;Label3.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="ButtonApiCalc.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ButtonApiCalc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 424</value>
-  </data>
-  <data name="ButtonApiCalc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ButtonApiCalc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 29</value>
-  </data>
-  <data name="ButtonApiCalc.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="ButtonApiCalc.Text" xml:space="preserve">
-    <value>再計算</value>
-  </data>
-  <data name="&gt;&gt;ButtonApiCalc.Name" xml:space="preserve">
-    <value>ButtonApiCalc</value>
-  </data>
-  <data name="&gt;&gt;ButtonApiCalc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ButtonApiCalc.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;ButtonApiCalc.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="LabelPostAndGet.AutoSize" type="System.Boolean, mscorlib">
+  <data name="HotkeyAlt.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="LabelPostAndGet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelPostAndGet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 295</value>
-  </data>
-  <data name="LabelPostAndGet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelPostAndGet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>356, 15</value>
-  </data>
-  <data name="LabelPostAndGet.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="LabelPostAndGet.Text" xml:space="preserve">
-    <value>投稿時取得が有効のため、投稿のたびにAPIを消費します。</value>
-  </data>
-  <data name="&gt;&gt;LabelPostAndGet.Name" xml:space="preserve">
-    <value>LabelPostAndGet</value>
-  </data>
-  <data name="&gt;&gt;LabelPostAndGet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelPostAndGet.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelPostAndGet.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="LabelApiUsing.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LabelApiUsing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LabelApiUsing.Location" type="System.Drawing.Point, System.Drawing">
-    <value>36, 269</value>
-  </data>
-  <data name="LabelApiUsing.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="LabelApiUsing.Size" type="System.Drawing.Size, System.Drawing">
-    <value>31, 15</value>
-  </data>
-  <data name="LabelApiUsing.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="LabelApiUsing.Text" xml:space="preserve">
-    <value>999</value>
-  </data>
-  <data name="LabelApiUsing.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="&gt;&gt;LabelApiUsing.Name" xml:space="preserve">
-    <value>LabelApiUsing</value>
-  </data>
-  <data name="&gt;&gt;LabelApiUsing.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelApiUsing.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelApiUsing.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="Label33.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label33.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label33.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 198</value>
-  </data>
-  <data name="Label33.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label33.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 15</value>
-  </data>
-  <data name="Label33.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="Label33.Text" xml:space="preserve">
-    <value>Lists更新間隔（秒）</value>
-  </data>
-  <data name="&gt;&gt;Label33.Name" xml:space="preserve">
-    <value>Label33</value>
-  </data>
-  <data name="&gt;&gt;Label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label33.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;Label33.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="ListsPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="ListsPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 189</value>
-  </data>
-  <data name="ListsPeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ListsPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
-  </data>
-  <data name="ListsPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;ListsPeriod.Name" xml:space="preserve">
-    <value>ListsPeriod</value>
-  </data>
-  <data name="&gt;&gt;ListsPeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ListsPeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;ListsPeriod.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="Label7.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 166</value>
-  </data>
-  <data name="Label7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 15</value>
-  </data>
-  <data name="Label7.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="Label7.Text" xml:space="preserve">
-    <value>Twitter検索更新間隔（秒）</value>
-  </data>
-  <data name="&gt;&gt;Label7.Name" xml:space="preserve">
-    <value>Label7</value>
-  </data>
-  <data name="&gt;&gt;Label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label7.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;Label7.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="PubSearchPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="PubSearchPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 159</value>
-  </data>
-  <data name="PubSearchPeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="PubSearchPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
-  </data>
-  <data name="PubSearchPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;PubSearchPeriod.Name" xml:space="preserve">
-    <value>PubSearchPeriod</value>
-  </data>
-  <data name="&gt;&gt;PubSearchPeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PubSearchPeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;PubSearchPeriod.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="Label69.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label69.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label69.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 104</value>
-  </data>
-  <data name="Label69.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label69.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 15</value>
+  <data name="&gt;&gt;CheckUseSsl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Label69.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
-  <data name="Label69.Text" xml:space="preserve">
-    <value>Mentions更新間隔（秒）</value>
-  </data>
-  <data name="&gt;&gt;Label69.Name" xml:space="preserve">
-    <value>Label69</value>
-  </data>
-  <data name="&gt;&gt;Label69.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label69.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;Label69.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="ReplyPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="ReplyPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 99</value>
-  </data>
-  <data name="ReplyPeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ReplyPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
-  </data>
-  <data name="ReplyPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;ReplyPeriod.Name" xml:space="preserve">
-    <value>ReplyPeriod</value>
-  </data>
-  <data name="&gt;&gt;ReplyPeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ReplyPeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;ReplyPeriod.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="CheckPostAndGet.AutoSize" type="System.Boolean, mscorlib">
+  <data name="IsPreviewFoursquareCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="CheckPostAndGet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;CheckAutoConvertUrl.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="CheckPostAndGet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>44, 74</value>
+  <data name="lblInputFont.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
   </data>
-  <data name="CheckPostAndGet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;lblTarget.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="CheckPostAndGet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 19</value>
-  </data>
-  <data name="CheckPostAndGet.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="CheckPostAndGet.Text" xml:space="preserve">
-    <value>投稿時取得</value>
-  </data>
-  <data name="&gt;&gt;CheckPostAndGet.Name" xml:space="preserve">
-    <value>CheckPostAndGet</value>
-  </data>
-  <data name="&gt;&gt;CheckPostAndGet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckPostAndGet.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckPostAndGet.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="CheckPeriodAdjust.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckPeriodAdjust.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckPeriodAdjust.Location" type="System.Drawing.Point, System.Drawing">
-    <value>335, 74</value>
-  </data>
-  <data name="CheckPeriodAdjust.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckPeriodAdjust.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 19</value>
-  </data>
-  <data name="CheckPeriodAdjust.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="CheckPeriodAdjust.Text" xml:space="preserve">
-    <value>自動調整する</value>
-  </data>
-  <data name="CheckPeriodAdjust.Visible" type="System.Boolean, mscorlib">
+  <data name="CheckAutoConvertUrl.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="&gt;&gt;CheckPeriodAdjust.Name" xml:space="preserve">
-    <value>CheckPeriodAdjust</value>
+  <data name="Label11.Text" xml:space="preserve">
+    <value>リストのアイコンサイズ（初期値16）</value>
   </data>
-  <data name="&gt;&gt;CheckPeriodAdjust.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="Label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;CheckPeriodAdjust.Parent" xml:space="preserve">
+  <data name="&gt;&gt;LabelApiUsing.Name" xml:space="preserve">
+    <value>LabelApiUsing</value>
+  </data>
+  <data name="&gt;&gt;TextProxyPort.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="ListsPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
+  </data>
+  <data name="CooperatePanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnFav.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label46.Parent" xml:space="preserve">
     <value>GetPeriodPanel</value>
   </data>
-  <data name="&gt;&gt;CheckPeriodAdjust.ZOrder" xml:space="preserve">
-    <value>18</value>
+  <data name="&gt;&gt;RadioProxyIE.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items117" xml:space="preserve">
+    <value>Ukrainian</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items8" xml:space="preserve">
+    <value>tt h:mm</value>
+  </data>
+  <data name="CooperatePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;CheckMonospace.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="ComboDispTitle.Items1" xml:space="preserve">
+    <value>バージョン</value>
+  </data>
+  <data name="lblUnread.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;Label1.Name" xml:space="preserve">
+    <value>Label1</value>
+  </data>
+  <data name="AuthClearButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items105" xml:space="preserve">
+    <value>Spanish (Bolivia)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items115" xml:space="preserve">
+    <value>Tswana</value>
+  </data>
+  <data name="CheckRetweetNoConfirm.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;FontDialog1.Name" xml:space="preserve">
+    <value>FontDialog1</value>
+  </data>
+  <data name="CheckPostAndGet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 16</value>
   </data>
   <data name="Label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="Label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="MapThumbnailZoomTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="btnTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 135</value>
+  <data name="CheckHashSupple.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="Label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="Label52.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 15</value>
+  <data name="GetCountPanel.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="Label5.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="&gt;&gt;Label55.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
   </data>
-  <data name="Label5.Text" xml:space="preserve">
-    <value>DM更新間隔（秒）</value>
+  <data name="lblAtFromTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
   </data>
-  <data name="&gt;&gt;Label5.Name" xml:space="preserve">
-    <value>Label5</value>
-  </data>
-  <data name="&gt;&gt;Label5.Type" xml:space="preserve">
+  <data name="&gt;&gt;Label61.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label5.Parent" xml:space="preserve">
+  <data name="ComboBoxTranslateLanguage.Items47" xml:space="preserve">
+    <value>French (Standard)</value>
+  </data>
+  <data name="CheckViewTabBottom.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 272</value>
+  </data>
+  <data name="&gt;&gt;Label59.Name" xml:space="preserve">
+    <value>Label59</value>
+  </data>
+  <data name="Label31.Text" xml:space="preserve">
+    <value>Twitter SearchAPI URL (search.twitter.com)</value>
+  </data>
+  <data name="&gt;&gt;Label7.Parent" xml:space="preserve">
     <value>GetPeriodPanel</value>
   </data>
-  <data name="&gt;&gt;Label5.ZOrder" xml:space="preserve">
-    <value>19</value>
+  <data name="btnDetailBack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
   </data>
-  <data name="DMPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
+  <data name="ComboBoxTranslateLanguage.Items7" xml:space="preserve">
+    <value>Arabic (Morocco)</value>
   </data>
-  <data name="DMPeriod.Location" type="System.Drawing.Point, System.Drawing">
-    <value>344, 129</value>
+  <data name="TextCountApiReply.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="DMPeriod.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;StartupPanel.Name" xml:space="preserve">
+    <value>StartupPanel</value>
   </data>
-  <data name="DMPeriod.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 22</value>
+  <data name="Save.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
   </data>
-  <data name="DMPeriod.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;DMPeriod.Name" xml:space="preserve">
-    <value>DMPeriod</value>
-  </data>
-  <data name="&gt;&gt;DMPeriod.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;DMPeriod.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;DMPeriod.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="StartupUserstreamCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="StartupUserstreamCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="StartupUserstreamCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>445, 18</value>
-  </data>
-  <data name="StartupUserstreamCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="StartupUserstreamCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>146, 19</value>
-  </data>
-  <data name="StartupUserstreamCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="StartupUserstreamCheck.Text" xml:space="preserve">
-    <value>起動時に自動接続</value>
-  </data>
-  <data name="&gt;&gt;StartupUserstreamCheck.Name" xml:space="preserve">
-    <value>StartupUserstreamCheck</value>
-  </data>
-  <data name="&gt;&gt;StartupUserstreamCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;StartupUserstreamCheck.Parent" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;StartupUserstreamCheck.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="GetPeriodPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="GetPeriodPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="GetPeriodPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="GetPeriodPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GetPeriodPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="GetPeriodPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="GetPeriodPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;GetPeriodPanel.Name" xml:space="preserve">
-    <value>GetPeriodPanel</value>
-  </data>
-  <data name="&gt;&gt;GetPeriodPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GetPeriodPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;GetPeriodPanel.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="TabMouseLockCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="TabMouseLockCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="TabMouseLockCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 380</value>
-  </data>
-  <data name="TabMouseLockCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="TabMouseLockCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>202, 19</value>
-  </data>
-  <data name="TabMouseLockCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="TabMouseLockCheck.Text" xml:space="preserve">
-    <value>マウスでのタブ移動を禁止する</value>
-  </data>
-  <data name="&gt;&gt;TabMouseLockCheck.Name" xml:space="preserve">
-    <value>TabMouseLockCheck</value>
-  </data>
-  <data name="&gt;&gt;TabMouseLockCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabMouseLockCheck.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;TabMouseLockCheck.ZOrder" xml:space="preserve">
+  <data name="Label40.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="Label38.AutoSize" type="System.Boolean, mscorlib">
+  <data name="lblListFont.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="Label38.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 352</value>
+  <data name="FirstTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
   </data>
-  <data name="Label38.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="CheckListMemberAddedEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
   </data>
-  <data name="Label38.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 15</value>
+  <data name="&gt;&gt;Label14.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="Label38.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="Label38.Text" xml:space="preserve">
-    <value>発言をダブルクリック時の動作</value>
-  </data>
-  <data name="&gt;&gt;Label38.Name" xml:space="preserve">
-    <value>Label38</value>
-  </data>
-  <data name="&gt;&gt;Label38.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label38.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label38.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="HotkeyCode.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="ListDoubleClickActionComboBox.Items" xml:space="preserve">
     <value>Reply</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Items1" xml:space="preserve">
-    <value>Favorite</value>
+  <data name="NotifyPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Items2" xml:space="preserve">
-    <value>プロフィール表示</value>
+  <data name="&gt;&gt;IsListsIncludeRtsCheckBox.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Items3" xml:space="preserve">
-    <value>ユーザーのタイムラインを表示</value>
+  <data name="&gt;&gt;TextProxyAddress.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Items4" xml:space="preserve">
-    <value>関連発言表示</value>
+  <data name="CheckListMemberRemovedEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 111</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Items5" xml:space="preserve">
-    <value>ユーザーのHomeを開く</value>
+  <data name="CheckBox3.Text" xml:space="preserve">
+    <value>発言詳細部にアイコンを表示する</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Items6" xml:space="preserve">
-    <value>ステータスをWebで開く</value>
+  <data name="CheckBalloonLimit.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="ListDoubleClickActionComboBox.Items7" xml:space="preserve">
-    <value>なし</value>
+  <data name="&gt;&gt;CheckFavRestrict.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>351, 346</value>
+  <data name="CheckViewTabBottom.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="ListDoubleClickActionComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="UserTimelinePeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
   </data>
-  <data name="ListDoubleClickActionComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>308, 23</value>
+  <data name="Label62.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="ListDoubleClickActionComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+  <data name="Label44.Text" xml:space="preserve">
+    <value>ブラウザパス</value>
   </data>
-  <data name="&gt;&gt;ListDoubleClickActionComboBox.Name" xml:space="preserve">
-    <value>ListDoubleClickActionComboBox</value>
+  <data name="Label55.Size" type="System.Drawing.Size, System.Drawing">
+    <value>314, 12</value>
   </data>
-  <data name="&gt;&gt;ListDoubleClickActionComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="PubSearchPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
   </data>
-  <data name="&gt;&gt;ListDoubleClickActionComboBox.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
+  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="&gt;&gt;ListDoubleClickActionComboBox.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;LabelDateTimeFormatApplied.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
   </data>
-  <data name="CheckOpenUserTimeline.AutoSize" type="System.Boolean, mscorlib">
+  <data name="btnOWL.Text" xml:space="preserve">
+    <value>文字色</value>
+  </data>
+  <data name="&gt;&gt;Save.Name" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Label61.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="CheckOpenUserTimeline.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 290</value>
+  <data name="&gt;&gt;chkUnreadStyle.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
-  <data name="CheckOpenUserTimeline.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="TextProxyUser.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="CheckOpenUserTimeline.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 19</value>
+  <data name="IsListsIncludeRtsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 16</value>
   </data>
-  <data name="CheckOpenUserTimeline.TabIndex" type="System.Int32, mscorlib">
+  <data name="TimelinePeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 12</value>
+  </data>
+  <data name="HotkeyAlt.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="Label45.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckCloseToExit.Name" xml:space="preserve">
+    <value>CheckCloseToExit</value>
+  </data>
+  <data name="&gt;&gt;CheckUnfavoritesEvent.Name" xml:space="preserve">
+    <value>CheckUnfavoritesEvent</value>
+  </data>
+  <data name="lblListBackcolor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 168</value>
+  </data>
+  <data name="&gt;&gt;lblSelf.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;Label67.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSelf.ZOrder" xml:space="preserve">
+    <value>26</value>
+  </data>
+  <data name="lblDetail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label63.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="IsListsIncludeRtsCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="OneWayLv.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 16</value>
+  </data>
+  <data name="CheckStartupFollowers.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="LabelApiUsingUserStreamEnabled.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 308</value>
+  </data>
+  <data name="CheckNicoms.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="CheckBox3.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
-  <data name="CheckOpenUserTimeline.Text" xml:space="preserve">
-    <value>ユーザーのホームURLをタブで開く</value>
+  <data name="&gt;&gt;NotifyPanel.Name" xml:space="preserve">
+    <value>NotifyPanel</value>
   </data>
-  <data name="&gt;&gt;CheckOpenUserTimeline.Name" xml:space="preserve">
-    <value>CheckOpenUserTimeline</value>
+  <data name="LabelPostAndGet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>285, 12</value>
   </data>
-  <data name="&gt;&gt;CheckOpenUserTimeline.Type" xml:space="preserve">
+  <data name="&gt;&gt;btnUnread.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblFav.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="Label47.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;lblListFont.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;StartupPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label71.Text" xml:space="preserve">
+    <value>URL自動短縮で優先的に使用</value>
+  </data>
+  <data name="&gt;&gt;TextProxyUser.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="UReadMng.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="HotkeyShift.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 16</value>
+  </data>
+  <data name="Label63.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.Name" xml:space="preserve">
+    <value>IsRemoveSameFavEventCheckBox</value>
+  </data>
+  <data name="ComboBoxOutputzUrlmode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>182, 20</value>
+  </data>
+  <data name="MapThumbnailWidthTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ListsPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TweetActPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="UserAppointUrlText.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="HotkeyText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 19</value>
+  </data>
+  <data name="&gt;&gt;Label42.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="TweetPrvPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;LabelUserStreamActive.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyAddress.Name" xml:space="preserve">
+    <value>LabelProxyAddress</value>
+  </data>
+  <data name="CheckPeriodAdjust.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="Label77.Text" xml:space="preserve">
+    <value>APIKey</value>
+  </data>
+  <data name="lblDetailLink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;CooperatePanel.Name" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="CheckOpenUserTimeline.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;EmailText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label18.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="Label34.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 12</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items98" xml:space="preserve">
+    <value>Spanish (Colombia)</value>
+  </data>
+  <data name="LabelDateTimeFormatApplied.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 12</value>
+  </data>
+  <data name="LabelApiUsingUserStreamEnabled.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;Label24.Name" xml:space="preserve">
+    <value>Label24</value>
+  </data>
+  <data name="Label16.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items4" xml:space="preserve">
+    <value>M/d H:mm</value>
+  </data>
+  <data name="Label72.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 12</value>
+  </data>
+  <data name="RadioProxyNone.Text" xml:space="preserve">
+    <value>使用しない</value>
+  </data>
+  <data name="&gt;&gt;Label14.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="PlaySnd.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 20</value>
+  </data>
+  <data name="&gt;&gt;RadioProxySpecified.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="btnAtSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;ButtonApiCalc.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label12.Name" xml:space="preserve">
+    <value>Label12</value>
+  </data>
+  <data name="TextBitlyId.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="chkReadOwnPost.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 16</value>
+  </data>
+  <data name="EmailText.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="Label13.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 290</value>
+  </data>
+  <data name="&gt;&gt;lblAtSelf.Name" xml:space="preserve">
+    <value>lblAtSelf</value>
+  </data>
+  <data name="Label23.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="FontPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="Label61.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 12</value>
+  </data>
+  <data name="&gt;&gt;Label80.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label25.Name" xml:space="preserve">
+    <value>Label25</value>
+  </data>
+  <data name="UserstreamPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
+  </data>
+  <data name="&gt;&gt;Label76.Name" xml:space="preserve">
+    <value>Label76</value>
+  </data>
+  <data name="&gt;&gt;CheckFavoritesEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="Label81.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items108" xml:space="preserve">
+    <value>Spanish (Nicaragua)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items118" xml:space="preserve">
+    <value>Urdu</value>
+  </data>
+  <data name="Label63.Text" xml:space="preserve">
+    <value>タイムアウトまでの時間(秒)</value>
+  </data>
+  <data name="CheckMonospace.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;lblDetail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label67.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label15.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="lblTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="FontPanel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="&gt;&gt;CheckShowGrid.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label10.Text" xml:space="preserve">
+    <value>新着バルーンのユーザー名</value>
+  </data>
+  <data name="RadioProxyIE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 41</value>
+  </data>
+  <data name="lblAtFromTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 118</value>
+  </data>
+  <data name="TextBoxOutputzKey.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCode.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="Label81.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="RadioProxySpecified.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="EmailText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>326, 19</value>
+  </data>
+  <data name="CheckReadOldPosts.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 16</value>
+  </data>
+  <data name="&gt;&gt;Label81.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label10.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;EmailText.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="AuthClearButton.Text" xml:space="preserve">
+    <value>削除</value>
+  </data>
+  <data name="btnAtFromTarget.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnDetailBack.Name" xml:space="preserve">
+    <value>btnDetailBack</value>
+  </data>
+  <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>163, 12</value>
+  </data>
+  <data name="&gt;&gt;Label77.Name" xml:space="preserve">
+    <value>Label77</value>
+  </data>
+  <data name="Label29.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;lblRetweet.Name" xml:space="preserve">
+    <value>lblRetweet</value>
+  </data>
+  <data name="&gt;&gt;Label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label13.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;TextProxyPassword.Name" xml:space="preserve">
+    <value>TextProxyPassword</value>
+  </data>
+  <data name="HotkeyAlt.Location" type="System.Drawing.Point, System.Drawing">
+    <value>168, 15</value>
+  </data>
+  <data name="ComboBoxPostKeySelect.Items" xml:space="preserve">
+    <value>Enter</value>
+  </data>
+  <data name="HotkeyCtrl.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LanguageCombo.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailWidthTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label49.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="Label52.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;UserAppointUrlText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btnListFont.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;ComboDispTitle.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="CheckMinimizeToTray.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 137</value>
+  </data>
+  <data name="&gt;&gt;CheckPreviewEnable.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.Items2" xml:space="preserve">
+    <value>twurl.nl</value>
+  </data>
+  <data name="&gt;&gt;Label16.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="Label35.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 281</value>
+  </data>
+  <data name="Label19.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="Label20.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="ListsPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="CheckStartupVersion.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;UReadMng.Name" xml:space="preserve">
+    <value>UReadMng</value>
+  </data>
+  <data name="&gt;&gt;btnDetail.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="GroupBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>474, 40</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>263, 277</value>
+  </data>
+  <data name="ButtonApiCalc.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;CreateAccountButton.Name" xml:space="preserve">
+    <value>CreateAccountButton</value>
+  </data>
+  <data name="&gt;&gt;ComboDispTitle.Name" xml:space="preserve">
+    <value>ComboDispTitle</value>
+  </data>
+  <data name="&gt;&gt;StartAuthButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Label8.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="UserstreamPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="CheckRetweetNoConfirm.Location" type="System.Drawing.Point, System.Drawing">
+    <value>24, 50</value>
+  </data>
+  <data name="TextProxyPort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 19</value>
+  </data>
+  <data name="CheckRetweetNoConfirm.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label17.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;Label20.Name" xml:space="preserve">
+    <value>Label20</value>
+  </data>
+  <data name="CheckDispUsername.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="GroupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnInputFont.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnAtSelf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 40</value>
+  </data>
+  <data name="&gt;&gt;Label65.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CheckOpenUserTimeline.Parent" xml:space="preserve">
     <value>ActionPanel</value>
   </data>
-  <data name="&gt;&gt;CheckOpenUserTimeline.ZOrder" xml:space="preserve">
+  <data name="lblUnread.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="label48.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 12</value>
+  </data>
+  <data name="&gt;&gt;CheckUnfavoritesEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label7.Name" xml:space="preserve">
+    <value>Label7</value>
+  </data>
+  <data name="&gt;&gt;Label10.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="StartupPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;CheckFavRestrict.Name" xml:space="preserve">
+    <value>CheckFavRestrict</value>
+  </data>
+  <data name="Label61.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Label34.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="lblListBackcolor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="cmbNameBalloon.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="Label20.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="TabMouseLockCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label49.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;Label21.Name" xml:space="preserve">
+    <value>Label21</value>
+  </data>
+  <data name="&gt;&gt;CheckAtIdSupple.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="CheckForceResolve.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label72.Name" xml:space="preserve">
+    <value>Label72</value>
+  </data>
+  <data name="&gt;&gt;BasedPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;Label23.Name" xml:space="preserve">
+    <value>Label23</value>
+  </data>
+  <data name="btnInputFont.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 25</value>
+  </data>
+  <data name="CheckBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 16</value>
+  </data>
+  <data name="Label26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 12</value>
+  </data>
+  <data name="&gt;&gt;CheckAutoConvertUrl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label28.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 136</value>
+  </data>
+  <data name="lblAtSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblUnread.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="&gt;&gt;FavoritesTextCountApi.Name" xml:space="preserve">
+    <value>FavoritesTextCountApi</value>
+  </data>
+  <data name="LabelUserStreamActive.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="lblFav.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label11.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailHeightTextBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="IsPreviewFoursquareCheckBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;TextProxyPort.Name" xml:space="preserve">
+    <value>TextProxyPort</value>
+  </data>
+  <data name="CheckForceEventNotify.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;Label35.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="&gt;&gt;Label29.Name" xml:space="preserve">
+    <value>Label29</value>
+  </data>
+  <data name="CheckAlwaysTop.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label44.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="CheckHashSupple.Text" xml:space="preserve">
+    <value>#タグの入力補助を使用する</value>
+  </data>
+  <data name="CheckShowGrid.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Label26.Name" xml:space="preserve">
+    <value>Label26</value>
+  </data>
+  <data name="cmbNameBalloon.Items" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="Label77.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LabelProxyPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>255, 85</value>
+  </data>
+  <data name="Label80.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="FavoritesTextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label11.Name" xml:space="preserve">
+    <value>Label11</value>
+  </data>
+  <data name="&gt;&gt;Label76.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckStartupVersion.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="TreeViewSetting.Nodes2" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQsAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wCWNoaWxkcmVuMQEBAQAAAQABAAQEAQgICB1TeXN0ZW0uV2luZG93cy5G
+        b3Jtcy5UcmVlTm9kZQIAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUCAAAAAgAAAAYDAAAA
+        BuihqOekugYEAAAAAAYFAAAAC1ByZXZpZXdOb2RlAP////8JBAAAAP////8JBAAAAAIAAAAJBwAAAAkI
+        AAAABQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUJAAAABFRleHQLVG9vbFRpcFRleHQE
+        TmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0
+        ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIAAAAGCQAAAAznmbroqIDkuIDopqcJBAAA
+        AAYLAAAADFR3ZWV0UHJ2Tm9kZQD/////CQQAAAD/////CQQAAAAAAAAABQgAAAAdU3lzdGVtLldpbmRv
+        d3MuRm9ybXMuVHJlZU5vZGUJAAAABFRleHQLVG9vbFRpcFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJ
+        bmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50
+        AQEBAAABAAEAAQgICAIAAAAGDQAAABLjgqTjg5njg7Pjg4jpgJrnn6UJBAAAAAYPAAAACk5vdGlmeU5v
+        ZGUA/////wkEAAAA/////wkEAAAAAAAAAAs=
+</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxTranslateLanguage.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="CheckOpenUserTimeline.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;CheckReadOldPosts.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="&gt;&gt;Label16.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor2.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
+  </data>
+  <data name="&gt;&gt;TimelinePeriod.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="btnAtFromTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label53.Name" xml:space="preserve">
+    <value>Label53</value>
+  </data>
+  <data name="IconSize.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="IsRemoveSameFavEventCheckBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnInputFont.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="chkUnreadStyle.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;FontPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="CheckListCreatedEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="AuthUserCombo.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Label27.Name" xml:space="preserve">
+    <value>Label27</value>
+  </data>
+  <data name="Label22.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Cancel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="btnOWL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label12.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="CheckOutputz.Size" type="System.Drawing.Size, System.Drawing">
+    <value>115, 16</value>
+  </data>
+  <data name="btnAtFromTarget.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkGetFav.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="HotkeyCheck.AutoSize" type="System.Boolean, mscorlib">
+  <data name="CheckUnfavoritesEvent.Text" xml:space="preserve">
+    <value>Fav削除した、またはFav削除された</value>
+  </data>
+  <data name="&gt;&gt;CheckEventNotify.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="ComboBoxAutoShortUrlFirst.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnAtTo.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 12</value>
+  </data>
+  <data name="CheckForceResolve.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 45</value>
+  </data>
+  <data name="LabelPostAndGet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 236</value>
+  </data>
+  <data name="&gt;&gt;LabelDateTimeFormatApplied.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="RadioProxyIE.Text" xml:space="preserve">
+    <value>InternetExplorerの設定を使用する</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxEventNotifySound.Name" xml:space="preserve">
+    <value>ComboBoxEventNotifySound</value>
+  </data>
+  <data name="LabelProxyUser.Text" xml:space="preserve">
+    <value>ユーザ名(&amp;U)</value>
+  </data>
+  <data name="&gt;&gt;chkTabIconDisp.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;ListTextCountApi.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="FontPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="LabelProxyAddress.Text" xml:space="preserve">
+    <value>プロキシ(&amp;X)</value>
+  </data>
+  <data name="&gt;&gt;Label4.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="Label32.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;GroupBox5.Parent" xml:space="preserve">
+    <value>FontPanel2</value>
+  </data>
+  <data name="CheckAutoConvertUrl.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="MapThumbnailGroupBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckReadOldPosts.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="$this.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblAtTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="UserTimelineTextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblInputFont.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 218</value>
+  </data>
+  <data name="Label46.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 12</value>
+  </data>
+  <data name="&gt;&gt;CheckPreviewEnable.Name" xml:space="preserve">
+    <value>CheckPreviewEnable</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailProviderComboBox.Name" xml:space="preserve">
+    <value>MapThumbnailProviderComboBox</value>
+  </data>
+  <data name="TwitterAPIText.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="ButtonApiCalc.Size" type="System.Drawing.Size, System.Drawing">
+    <value>108, 23</value>
+  </data>
+  <data name="HotkeyCode.Text" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblInputBackcolor.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="HotkeyCtrl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>43, 16</value>
+  </data>
+  <data name="Label22.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 12</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items88" xml:space="preserve">
+    <value>Slovak</value>
+  </data>
+  <data name="&gt;&gt;StartupReaded.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label80.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Label43.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 101</value>
+  </data>
+  <data name="btnAtSelf.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblInputFont.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>429, 267</value>
+  </data>
+  <data name="&gt;&gt;GetCountPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
+    <value>87, 12</value>
+  </data>
+  <data name="&gt;&gt;Label18.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="CheckTinyURL.Text" xml:space="preserve">
+    <value>短縮URLを解決する</value>
+  </data>
+  <data name="TreeViewSetting.Nodes3" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQoAAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wAQEBAAABAAEABAEICAgdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5v
+        ZGUCAAAAAgAAAAYDAAAADOODleOCqeODs+ODiAYEAAAAAAYFAAAACEZvbnROb2RlAP////8JBAAAAP//
+        //8JBAAAAAEAAAAJBwAAAAUHAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlCQAAAARUZXh0
+        C1Rvb2xUaXBUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdlSW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFn
+        ZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3VudAEBAQAAAQABAAEICAgCAAAABggAAAAN44OV
+        44Kp44Oz44OIMgkEAAAABgoAAAAJRm9udE5vZGUyAP////8JBAAAAP////8JBAAAAAAAAAAL
+</value>
+  </data>
+  <data name="&gt;&gt;HotkeyAlt.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="GetPeriodPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;lblOWL.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label43.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;CheckUseRecommendStatus.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="CheckFavoritesEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="LabelProxyUser.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LanguageCombo.Items" xml:space="preserve">
+    <value>OS Default</value>
+  </data>
+  <data name="CheckMinimizeToTray.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label31.Parent" xml:space="preserve">
+    <value>ConnectionPanel</value>
+  </data>
+  <data name="&gt;&gt;Label62.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkGetFav.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="PubSearchPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="LabelProxyUser.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;ReplyPeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="Label35.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label57.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="HotkeyCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="HotkeyCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 19</value>
-  </data>
-  <data name="HotkeyCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="HotkeyCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 24</value>
-  </data>
-  <data name="HotkeyCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="HotkeyCheck.Text" xml:space="preserve">
-    <value>有効</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCheck.Name" xml:space="preserve">
-    <value>HotkeyCheck</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCheck.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCheck.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="HotkeyCode.AutoSize" type="System.Boolean, mscorlib">
+  <data name="Label65.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="HotkeyCode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;StartAuthButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="HotkeyCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>453, 20</value>
+  <data name="&gt;&gt;ListsPeriod.ZOrder" xml:space="preserve">
+    <value>12</value>
   </data>
-  <data name="HotkeyCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+  <data name="CreateAccountButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 23</value>
   </data>
-  <data name="HotkeyCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>17, 17</value>
+  <data name="&gt;&gt;CheckOutputz.Name" xml:space="preserve">
+    <value>CheckOutputz</value>
   </data>
-  <data name="HotkeyCode.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="&gt;&gt;lblFav.ZOrder" xml:space="preserve">
+    <value>20</value>
   </data>
-  <data name="HotkeyCode.Text" xml:space="preserve">
-    <value>0</value>
+  <data name="CheckBox3.ToolTip" xml:space="preserve">
+    <value />
   </data>
-  <data name="&gt;&gt;HotkeyCode.Name" xml:space="preserve">
-    <value>HotkeyCode</value>
+  <data name="&gt;&gt;RadioProxyNone.Name" xml:space="preserve">
+    <value>RadioProxyNone</value>
   </data>
-  <data name="&gt;&gt;HotkeyCode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCode.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCode.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="HotkeyText.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Disable</value>
-  </data>
-  <data name="HotkeyText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>343, 16</value>
-  </data>
-  <data name="HotkeyText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="HotkeyText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 22</value>
-  </data>
-  <data name="HotkeyText.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;Label12.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;HotkeyText.Name" xml:space="preserve">
-    <value>HotkeyText</value>
-  </data>
-  <data name="&gt;&gt;HotkeyText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HotkeyText.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;HotkeyText.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="HotkeyWin.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="HotkeyWin.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="ButtonBackToDefaultFontColor2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="HotkeyWin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>281, 19</value>
+  <data name="Label76.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="HotkeyWin.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;btnDetailLink.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="HotkeyWin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 24</value>
-  </data>
-  <data name="HotkeyWin.TabIndex" type="System.Int32, mscorlib">
+  <data name="StartAuthButton.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="HotkeyWin.Text" xml:space="preserve">
-    <value>Win</value>
+  <data name="&gt;&gt;Label36.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="Label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 17</value>
+  </data>
+  <data name="Label25.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="LabelProxyUser.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="LabelProxyPort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 12</value>
+  </data>
+  <data name="PreviewPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="Label9.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OneWayLv.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;TwitterAPIText.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="Label12.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items30" xml:space="preserve">
+    <value>Dutch (Belgium)</value>
+  </data>
+  <data name="&gt;&gt;lblListBackcolor.Name" xml:space="preserve">
+    <value>lblListBackcolor</value>
+  </data>
+  <data name="&gt;&gt;CheckBox3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items33" xml:space="preserve">
+    <value>English (United Kingdom)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items34" xml:space="preserve">
+    <value>English (Australia)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items35" xml:space="preserve">
+    <value>English (Canada)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items36" xml:space="preserve">
+    <value>English (New Zealand)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items37" xml:space="preserve">
+    <value>English (Ireland)</value>
+  </data>
+  <data name="Label9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 170</value>
+  </data>
+  <data name="&gt;&gt;Label28.Name" xml:space="preserve">
+    <value>Label28</value>
+  </data>
+  <data name="Label11.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxPostKeySelect.Items1" xml:space="preserve">
+    <value>Ctrl+Enter</value>
+  </data>
+  <data name="CheckFavRestrict.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RadioProxyIE.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label26.Text" xml:space="preserve">
+    <value>発言詳細文字</value>
+  </data>
+  <data name="btnDetailLink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmbNameBalloon.Items1" xml:space="preserve">
+    <value>ユーザーID</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items89" xml:space="preserve">
+    <value>Slovenian</value>
+  </data>
+  <data name="cmbNameBalloon.Items2" xml:space="preserve">
+    <value>ニックネーム</value>
+  </data>
+  <data name="Label13.Text" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Items6" xml:space="preserve">
+    <value>ステータスをWebで開く</value>
+  </data>
+  <data name="UseChangeGetCount.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;GroupBox1.Parent" xml:space="preserve">
+    <value>FontPanel</value>
+  </data>
+  <data name="&gt;&gt;CheckAtIdSupple.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyAddress.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="IsRemoveSameFavEventCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 16</value>
+  </data>
+  <data name="btnListFont.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 21</value>
+  </data>
+  <data name="btnAtSelf.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label53.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnAtTarget.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;TweetActPanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="LabelUserStreamActive.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label15.Text" xml:space="preserve">
+    <value>タブのサウンドを設定した上で、「再生する」を選ぶとサウンドが再生されます。</value>
+  </data>
+  <data name="CheckPreviewEnable.Size" type="System.Drawing.Size, System.Drawing">
+    <value>243, 16</value>
+  </data>
+  <data name="&gt;&gt;Label36.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="Label35.Text" xml:space="preserve">
+    <value>イベント通知の際に再生するサウンド</value>
+  </data>
+  <data name="Label49.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label55.Text" xml:space="preserve">
+    <value>※認証が不要な場合は、ユーザ名とパスワードは空にしてください。</value>
+  </data>
+  <data name="&gt;&gt;CheckDispUsername.Name" xml:space="preserve">
+    <value>CheckDispUsername</value>
+  </data>
+  <data name="&gt;&gt;IconSize.Name" xml:space="preserve">
+    <value>IconSize</value>
+  </data>
+  <data name="Label27.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 22</value>
+  </data>
+  <data name="ComboBoxPostKeySelect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>246, 20</value>
+  </data>
+  <data name="&gt;&gt;Label47.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="Label71.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="PlaySnd.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 16</value>
+  </data>
+  <data name="lblSelf.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 17</value>
+  </data>
+  <data name="chkReadOwnPost.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;StatusText.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="GroupBox5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>429, 290</value>
+  </data>
+  <data name="Label24.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnDetailLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="Label24.Text" xml:space="preserve">
+    <value>片思い発言</value>
+  </data>
+  <data name="lblDetailBackcolor.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="btnAtTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 90</value>
+  </data>
+  <data name="&gt;&gt;TweetPrvPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;CheckEventNotify.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblFav.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="Label34.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Label66.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label19.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="StatusText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>185, 116</value>
+  </data>
+  <data name="CmbDateTimeFormat.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="GroupBox5.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblSelf.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="StartupUserstreamCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckViewTabBottom.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnFav.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TwitterSearchAPIText.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="Label81.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;btnDetailLink.Name" xml:space="preserve">
+    <value>btnDetailLink</value>
+  </data>
+  <data name="&gt;&gt;btnSelf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label9.Text" xml:space="preserve">
+    <value>一般発言</value>
+  </data>
+  <data name="GetMoreTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="&gt;&gt;Label37.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;UserstreamPeriod.Name" xml:space="preserve">
+    <value>UserstreamPeriod</value>
+  </data>
+  <data name="lblInputBackcolor.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="OneWayLv.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label42.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
+  </data>
+  <data name="lblFav.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="&gt;&gt;Label71.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="btnListFont.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label32.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;CheckBalloonLimit.Name" xml:space="preserve">
+    <value>CheckBalloonLimit</value>
+  </data>
+  <data name="&gt;&gt;LabelUserStreamActive.Name" xml:space="preserve">
+    <value>LabelUserStreamActive</value>
+  </data>
+  <data name="&gt;&gt;TimelinePeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TextBoxOutputzKey.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PubSearchPeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="Label41.Text" xml:space="preserve">
+    <value>ズームレベル</value>
+  </data>
+  <data name="&gt;&gt;Label72.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items60" xml:space="preserve">
+    <value>Hebrew</value>
+  </data>
+  <data name="Label35.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="&gt;&gt;HotkeyWin.Name" xml:space="preserve">
     <value>HotkeyWin</value>
   </data>
-  <data name="&gt;&gt;HotkeyWin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="Label81.Text" xml:space="preserve">
+    <value>Apply after restarting</value>
   </data>
-  <data name="&gt;&gt;HotkeyWin.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
+  <data name="btnTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 65</value>
   </data>
-  <data name="&gt;&gt;HotkeyWin.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;CheckViewTabBottom.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
-  <data name="HotkeyAlt.AutoSize" type="System.Boolean, mscorlib">
+  <data name="Label76.Location" type="System.Drawing.Point, System.Drawing">
+    <value>250, 164</value>
+  </data>
+  <data name="SplitContainer1.IsSplitterFixed" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="HotkeyAlt.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="Label21.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="HotkeyWin.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblInputBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="HotkeyAlt.Location" type="System.Drawing.Point, System.Drawing">
-    <value>224, 19</value>
+  <data name="CheckFavoritesEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 43</value>
   </data>
-  <data name="HotkeyAlt.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="StartupUserstreamCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <data name="HotkeyAlt.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 24</value>
+  <data name="&gt;&gt;GetMoreTextCountApi.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
-  <data name="HotkeyAlt.TabIndex" type="System.Int32, mscorlib">
+  <data name="Label39.Size" type="System.Drawing.Size, System.Drawing">
+    <value>401, 12</value>
+  </data>
+  <data name="ComboBoxPostKeySelect.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckOpenUserTimeline.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 232</value>
+  </data>
+  <data name="AuthClearButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items78" xml:space="preserve">
+    <value>Portuguese (Brazil)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items79" xml:space="preserve">
+    <value>Portuguese (Portugal)</value>
+  </data>
+  <data name="Label41.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="IsNotifyUseGrowlCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 12</value>
+  </data>
+  <data name="ComboDispTitle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>197, 20</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items70" xml:space="preserve">
+    <value>Latvian</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items71" xml:space="preserve">
+    <value>Lithuanian</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items72" xml:space="preserve">
+    <value>Macedonian (FYROM)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items73" xml:space="preserve">
+    <value>Malaysian</value>
+  </data>
+  <data name="Label26.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items75" xml:space="preserve">
+    <value>Norwegian (Bokmal)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items76" xml:space="preserve">
+    <value>Norwegian (Nynorsk)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items77" xml:space="preserve">
+    <value>Polish</value>
+  </data>
+  <data name="HotkeyShift.Text" xml:space="preserve">
+    <value>Shift</value>
+  </data>
+  <data name="Label3.Text" xml:space="preserve">
+    <value>タイムライン更新間隔（秒）</value>
+  </data>
+  <data name="&gt;&gt;Label69.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="LabelProxyUser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 12</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>            </value>
+  </data>
+  <data name="&gt;&gt;TabMouseLockCheck.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="Label60.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TwitterAPIText.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CheckFavEventUnread.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckAtIdSupple.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="Label22.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;UserTimelineTextCountApi.Name" xml:space="preserve">
+    <value>UserTimelineTextCountApi</value>
+  </data>
+  <data name="SearchTextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="HotkeyCtrl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOWL.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="UseChangeGetCount.Text" xml:space="preserve">
+    <value>次の項目の更新時の取得数を個別に設定する</value>
+  </data>
+  <data name="lblSelf.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnDetail.Text" xml:space="preserve">
+    <value>フォント&amp;&amp;色</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnRetweet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="CheckForceResolve.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="Label5.Text" xml:space="preserve">
+    <value>DM更新間隔（秒）</value>
+  </data>
+  <data name="TabMouseLockCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;TabMouseLockCheck.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="Label22.Text" xml:space="preserve">
+    <value>Fav発言</value>
+  </data>
+  <data name="btnAtSelf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="ConnectionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="TextBitlyId.Location" type="System.Drawing.Point, System.Drawing">
+    <value>271, 161</value>
+  </data>
+  <data name="lblDetailBackcolor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="&gt;&gt;BrowserPathText.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="label48.Text" xml:space="preserve">
+    <value>地図サービス</value>
+  </data>
+  <data name="&gt;&gt;TextBox3.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="lblListFont.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="&gt;&gt;ListTextCountApi.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label48.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TextProxyUser.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label39.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="btnInputBackcolor.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;MapThumbnailGroupBox.Name" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="Save.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="FontPanel2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CheckAlwaysTop.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="chkTabIconDisp.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblInputFont.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="&gt;&gt;BrowserPathText.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label31.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Cancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label13.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label20.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckAtIdSupple.Size" type="System.Drawing.Size, System.Drawing">
+    <value>153, 16</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items4" xml:space="preserve">
+    <value>Arabic (Egypt)</value>
+  </data>
+  <data name="CheckUnfavoritesEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;IsRemoveSameFavEventCheckBox.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="btnUnread.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 46</value>
+  </data>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.ZOrder" xml:space="preserve">
+    <value>27</value>
+  </data>
+  <data name="CheckUseRecommendStatus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ConnectionTimeOut.Location" type="System.Drawing.Point, System.Drawing">
+    <value>262, 18</value>
+  </data>
+  <data name="&gt;&gt;ProxyPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;SplitContainer1.Panel2.Name" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="lblRetweet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;IsNotifyUseGrowlCheckBox.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="&gt;&gt;Label49.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;CheckListCreatedEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items102" xml:space="preserve">
+    <value>Spanish (Chile)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items112" xml:space="preserve">
+    <value>Swedish (Finland)</value>
+  </data>
+  <data name="&gt;&gt;Label37.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="Label59.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 12</value>
+  </data>
+  <data name="&gt;&gt;Label17.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="HotkeyAlt.Text" xml:space="preserve">
-    <value>Alt</value>
+  <data name="&gt;&gt;Label64.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;HotkeyAlt.Name" xml:space="preserve">
-    <value>HotkeyAlt</value>
+  <data name="btnAtTarget.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label34.Name" xml:space="preserve">
+    <value>Label34</value>
+  </data>
+  <data name="Cancel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckListMemberAddedEvent.Name" xml:space="preserve">
+    <value>CheckListMemberAddedEvent</value>
+  </data>
+  <data name="&gt;&gt;CheckMinimizeToTray.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="Label23.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>691, 403</value>
+  </data>
+  <data name="CheckBlockEvent.Text" xml:space="preserve">
+    <value>他のユーザーに対するブロックが成功した</value>
+  </data>
+  <data name="NotifyPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;CooperatePanel.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="Label20.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 12</value>
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.Text" xml:space="preserve">
+    <value>重複した公式RTを表示しない</value>
+  </data>
+  <data name="Label65.Text" xml:space="preserve">
+    <value>入力欄フォント</value>
+  </data>
+  <data name="CheckNicoms.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;Button3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GetPeriodPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;lblRetweet.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;HotkeyShift.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="Label69.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="DMPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="&gt;&gt;Button3.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;FollowCheckBox.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="Label31.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;TextProxyUser.Name" xml:space="preserve">
+    <value>TextProxyUser</value>
+  </data>
+  <data name="ListTextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;PreviewPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="CheckUnfavoritesEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 16</value>
+  </data>
+  <data name="UserTimelinePeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 179</value>
+  </data>
+  <data name="TweetPrvPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="CheckUseSsl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 78</value>
+  </data>
+  <data name="Label37.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 12</value>
+  </data>
+  <data name="LabelApiUsing.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="Label5.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="MapThumbnailGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>485, 71</value>
+  </data>
+  <data name="&gt;&gt;ListDoubleClickActionComboBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblSelf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="&gt;&gt;Label80.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="GetCountPanel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="CheckBalloonLimit.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label66.Text" xml:space="preserve">
+    <value>Favoritesの取得数</value>
+  </data>
+  <data name="btnListBack.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;btnFav.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items61" xml:space="preserve">
+    <value>Hindi</value>
+  </data>
+  <data name="&gt;&gt;lblAtSelf.ZOrder" xml:space="preserve">
+    <value>25</value>
+  </data>
+  <data name="Label23.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="GetPeriodPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;MapThumbnailGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="StartupPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>519, 368</value>
+  </data>
+  <data name="&gt;&gt;Label16.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="IsNotifyUseGrowlCheckBox.Text" xml:space="preserve">
+    <value>通知にGrowlを使用</value>
+  </data>
+  <data name="&gt;&gt;btnAtSelf.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="TreeViewSetting.Nodes" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAAB1TeXN0
+        ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQ0AAAAEVGV4dAtUb29sVGlwVGV4dAROYW1lCUlzQ2hlY2tl
+        ZApJbWFnZUluZGV4CEltYWdlS2V5ElNlbGVjdGVkSW1hZ2VJbmRleBBTZWxlY3RlZEltYWdlS2V5CkNo
+        aWxkQ291bnQJY2hpbGRyZW4wCWNoaWxkcmVuMQljaGlsZHJlbjIIVXNlckRhdGEBAQEAAAEAAQAEBAQB
+        AQgICB1TeXN0ZW0uV2luZG93cy5Gb3Jtcy5UcmVlTm9kZQIAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMu
+        VHJlZU5vZGUCAAAAHVN5c3RlbS5XaW5kb3dzLkZvcm1zLlRyZWVOb2RlAgAAAAIAAAAGAwAAAAbln7rm
+        nKwGBAAAAAAGBQAAAAlCYXNlZE5vZGUA/////wkEAAAA/////wkEAAAAAwAAAAkHAAAACQgAAAAJCQAA
+        AAkEAAAABQcAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5vZGUJAAAABFRleHQLVG9vbFRpcFRl
+        eHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJTZWxlY3RlZEltYWdlSW5kZXgQU2Vs
+        ZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIAAAAGCwAAAAzmm7TmlrDplpPpmpQJ
+        BAAAAAYNAAAAClBlcmlvZE5vZGUA/////wkEAAAA/////wkEAAAAAAAAAAUIAAAAHVN5c3RlbS5XaW5k
+        b3dzLkZvcm1zLlRyZWVOb2RlCQAAAARUZXh0C1Rvb2xUaXBUZXh0BE5hbWUJSXNDaGVja2VkCkltYWdl
+        SW5kZXgISW1hZ2VLZXkSU2VsZWN0ZWRJbWFnZUluZGV4EFNlbGVjdGVkSW1hZ2VLZXkKQ2hpbGRDb3Vu
+        dAEBAQAAAQABAAEICAgCAAAABg8AAAAS6LW35YuV5pmC44Gu5YuV5L2cCQQAAAAGEQAAAAtTdGFydFVw
+        Tm9kZQD/////CQQAAAD/////CQQAAAAAAAAABQkAAAAdU3lzdGVtLldpbmRvd3MuRm9ybXMuVHJlZU5v
+        ZGUJAAAABFRleHQLVG9vbFRpcFRleHQETmFtZQlJc0NoZWNrZWQKSW1hZ2VJbmRleAhJbWFnZUtleRJT
+        ZWxlY3RlZEltYWdlSW5kZXgQU2VsZWN0ZWRJbWFnZUtleQpDaGlsZENvdW50AQEBAAABAAEAAQgICAIA
+        AAAGEwAAAAzlj5blvpfku7bmlbAJBAAAAAYVAAAADEdldENvdW50Tm9kZQD/////CQQAAAD/////CQQA
+        AAAAAAAACw==
+</value>
+  </data>
+  <data name="&gt;&gt;lblSelf.Name" xml:space="preserve">
+    <value>lblSelf</value>
+  </data>
+  <data name="&gt;&gt;Label81.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Items2" xml:space="preserve">
+    <value>プロフィール表示</value>
+  </data>
+  <data name="Label26.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label19.Text" xml:space="preserve">
+    <value>Mentions取得数</value>
+  </data>
+  <data name="Label39.Text" xml:space="preserve">
+    <value>ユーザー指定のURL({ID}をScreenNameに、{STATUS}をステータスIDに置き換えます)</value>
+  </data>
+  <data name="Label59.Text" xml:space="preserve">
+    <value>復活の呪文</value>
+  </data>
+  <data name="Label7.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnSelf.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblInputBackcolor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>227, 193</value>
+  </data>
+  <data name="TextBoxOutputzKey.Location" type="System.Drawing.Point, System.Drawing">
+    <value>205, 44</value>
+  </data>
+  <data name="CheckOutputz.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 22</value>
+  </data>
+  <data name="&gt;&gt;CheckListMemberRemovedEvent.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;BrowserPathText.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="CheckOutputz.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckCloseToExit.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 114</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailProviderComboBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ComboDispTitle.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;lblInputBackcolor.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="&gt;&gt;CheckRetweetNoConfirm.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;Label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;Label22.Name" xml:space="preserve">
+    <value>Label22</value>
+  </data>
+  <data name="IsListsIncludeRtsCheckBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label63.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckCloseToExit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label14.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label60.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblDetailBackcolor.Name" xml:space="preserve">
+    <value>lblDetailBackcolor</value>
+  </data>
+  <data name="FavoritesTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="&gt;&gt;CheckDispUsername.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="OneWayLv.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CheckListMemberRemovedEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="lblListFont.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label60.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="UReadMng.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="CheckForceEventNotify.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 222</value>
+  </data>
+  <data name="RadioProxyIE.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Label29.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="&gt;&gt;cmbNameBalloon.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;Label67.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;CheckHashSupple.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="Label27.Text" xml:space="preserve">
+    <value>POSTキー（デフォルトEnter）</value>
+  </data>
+  <data name="&gt;&gt;CmbDateTimeFormat.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxTranslateLanguage.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="PlaySnd.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckMinimizeToTray.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label14.Name" xml:space="preserve">
+    <value>Label14</value>
+  </data>
+  <data name="Label33.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 12</value>
+  </data>
+  <data name="btnSelf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="Label57.Size" type="System.Drawing.Size, System.Drawing">
+    <value>340, 12</value>
+  </data>
+  <data name="LabelProxyPassword.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 12</value>
+  </data>
+  <data name="CheckStartupFollowers.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items109" xml:space="preserve">
+    <value>Spanish (Puerto Rico)</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items119" xml:space="preserve">
+    <value>Venda</value>
+  </data>
+  <data name="GetCountPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="Label27.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 12</value>
+  </data>
+  <data name="&gt;&gt;ComboDispTitle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label42.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="ActionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="UseChangeGetCount.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Save.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label35.Size" type="System.Drawing.Size, System.Drawing">
+    <value>176, 12</value>
+  </data>
+  <data name="&gt;&gt;GroupBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CheckSortOrderLock.Text" xml:space="preserve">
+    <value>ソート順を変更できないようにロックする</value>
+  </data>
+  <data name="chkReadOwnPost.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items38" xml:space="preserve">
+    <value>English (South Africa)</value>
+  </data>
+  <data name="&gt;&gt;CheckSortOrderLock.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="HotkeyWin.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 16</value>
+  </data>
+  <data name="IsListsIncludeRtsCheckBox.Text" xml:space="preserve">
+    <value>Listの発言取得に公式RTを含める</value>
+  </data>
+  <data name="LanguageCombo.Items1" xml:space="preserve">
+    <value>Japanese</value>
+  </data>
+  <data name="Label22.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 73</value>
+  </data>
+  <data name="&gt;&gt;LanguageCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="GroupBox1.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="IsPreviewFoursquareCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label76.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 12</value>
+  </data>
+  <data name="label48.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 22</value>
+  </data>
+  <data name="CheckHashSupple.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;IconSize.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="Label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckUseSsl.Text" xml:space="preserve">
+    <value>通信にHTTPSを使用する</value>
+  </data>
+  <data name="CheckTinyURL.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnRetweet.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="Label55.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;btnListBack.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;Cancel.Name" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="&gt;&gt;lblInputFont.Name" xml:space="preserve">
+    <value>lblInputFont</value>
+  </data>
+  <data name="TweetActPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;ListsPeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="Label25.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 186</value>
+  </data>
+  <data name="btnListFont.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 25</value>
+  </data>
+  <data name="&gt;&gt;Button3.Name" xml:space="preserve">
+    <value>Button3</value>
+  </data>
+  <data name="&gt;&gt;GetCountPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label57.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 12</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items45" xml:space="preserve">
+    <value>Farsi</value>
+  </data>
+  <data name="&gt;&gt;Label22.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TextCountApiReply.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="&gt;&gt;Label55.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnTarget.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="GroupBox5.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label34.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckFollowEvent.ToolTip" xml:space="preserve">
+    <value>チェックを不確定状態にすると他者が発生させたイベントのみ通知します</value>
+  </data>
+  <data name="&gt;&gt;StatusText.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="ComboBoxPostKeySelect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>184, 19</value>
+  </data>
+  <data name="lblUnread.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxAutoShortUrlFirst.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 29</value>
   </data>
   <data name="&gt;&gt;HotkeyAlt.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;HotkeyAlt.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
+  <data name="&gt;&gt;DMPeriod.Name" xml:space="preserve">
+    <value>DMPeriod</value>
   </data>
-  <data name="&gt;&gt;HotkeyAlt.ZOrder" xml:space="preserve">
+  <data name="btnAtFromTarget.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="&gt;&gt;btnRetweet.Name" xml:space="preserve">
+    <value>btnRetweet</value>
+  </data>
+  <data name="&gt;&gt;GetPeriodPanel.Name" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailProviderComboBox.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="Label3.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblAtFromTarget.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;SearchTextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="RadioProxyIE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>190, 16</value>
+  </data>
+  <data name="CheckUseSsl.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="HotkeyCheck.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnFav.Text" xml:space="preserve">
+    <value>文字色</value>
+  </data>
+  <data name="Label61.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckViewTabBottom.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxEventNotifySound.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="TextCountApi.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="Label31.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;RadioProxyIE.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="HotkeyShift.AutoSize" type="System.Boolean, mscorlib">
+  <data name="&gt;&gt;ComboBoxOutputzUrlmode.Name" xml:space="preserve">
+    <value>ComboBoxOutputzUrlmode</value>
+  </data>
+  <data name="Label69.Size" type="System.Drawing.Size, System.Drawing">
+    <value>123, 12</value>
+  </data>
+  <data name="Label62.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblTarget.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;TextBitlyPw.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 12</value>
+  </data>
+  <data name="ListTextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="FirstTextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblAtTo.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="Label6.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;ReplyPeriod.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="LabelApiUsingUserStreamEnabled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 12</value>
+  </data>
+  <data name="CheckFollowEvent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 77</value>
+  </data>
+  <data name="lblDetailBackcolor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>216, 196</value>
+  </data>
+  <data name="LabelDateTimeFormatApplied.Location" type="System.Drawing.Point, System.Drawing">
+    <value>264, 134</value>
+  </data>
+  <data name="&gt;&gt;CheckBalloonLimit.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblListFont.Name" xml:space="preserve">
+    <value>lblListFont</value>
+  </data>
+  <data name="&gt;&gt;lblSelf.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCtrl.Name" xml:space="preserve">
+    <value>HotkeyCtrl</value>
+  </data>
+  <data name="ComboBoxPostKeySelect.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="UserstreamPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 12</value>
+  </data>
+  <data name="&gt;&gt;LanguageCombo.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="Label72.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label45.Text" xml:space="preserve">
+    <value>タイトルバー</value>
+  </data>
+  <data name="lblRetweet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="&gt;&gt;CheckAtIdSupple.Name" xml:space="preserve">
+    <value>CheckAtIdSupple</value>
+  </data>
+  <data name="CheckSortOrderLock.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Label37.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label53.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 12</value>
+  </data>
+  <data name="&gt;&gt;CheckRetweetNoConfirm.Parent" xml:space="preserve">
+    <value>TweetActPanel</value>
+  </data>
+  <data name="BrowserPathText.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;btnAtFromTarget.Name" xml:space="preserve">
+    <value>btnAtFromTarget</value>
+  </data>
+  <data name="lblSelf.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CheckUseSsl.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="UseChangeGetCount.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ShortUrlPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Button3.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;HotkeyCtrl.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;ConnectionTimeOut.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label52.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btnFav.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;Label62.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="HotkeyCode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>13, 14</value>
+  </data>
+  <data name="btnListBack.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label71.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ButtonBackToDefaultFontColor.Text" xml:space="preserve">
+    <value>デフォルトに戻す</value>
+  </data>
+  <data name="RadioProxyNone.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckForceResolve.Text" xml:space="preserve">
+    <value>すべてのURLについて解決を試みる</value>
+  </data>
+  <data name="CheckStartupVersion.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="DMPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 103</value>
+  </data>
+  <data name="ShortUrlPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;CheckAutoConvertUrl.Name" xml:space="preserve">
+    <value>CheckAutoConvertUrl</value>
+  </data>
+  <data name="ShortenTcoCheck.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ReplyIconStateCombo.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TextCountApiReply.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="RadioProxyNone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 19</value>
+  </data>
+  <data name="&gt;&gt;Label52.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;SearchTextCountApi.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailZoomTextBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="Label7.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckNicoms.Size" type="System.Drawing.Size, System.Drawing">
+    <value>237, 16</value>
+  </data>
+  <data name="&gt;&gt;Label63.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="CheckAutoConvertUrl.Text" xml:space="preserve">
+    <value>入力欄のURLを投稿する際に自動で短縮する</value>
+  </data>
+  <data name="Label52.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnInputFont.Text" xml:space="preserve">
+    <value>フォント&amp;&amp;色</value>
+  </data>
+  <data name="TreeViewSetting.Size" type="System.Drawing.Size, System.Drawing">
+    <value>168, 368</value>
+  </data>
+  <data name="Label27.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="RadioProxySpecified.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 62</value>
+  </data>
+  <data name="CheckMinimizeToTray.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;PreviewPanel.Name" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="ListsPeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="ComboBoxOutputzUrlmode.Items1" xml:space="preserve">
+    <value>twitter.com/username</value>
+  </data>
+  <data name="btnAtSelf.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="LabelProxyPassword.Text" xml:space="preserve">
+    <value>パスワード(&amp;W)</value>
+  </data>
+  <data name="CheckAutoConvertUrl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>242, 16</value>
+  </data>
+  <data name="HotkeyText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="HotkeyShift.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="HotkeyShift.Location" type="System.Drawing.Point, System.Drawing">
-    <value>155, 19</value>
-  </data>
-  <data name="HotkeyShift.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="HotkeyShift.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 24</value>
-  </data>
-  <data name="HotkeyShift.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="HotkeyShift.Text" xml:space="preserve">
-    <value>Shift</value>
-  </data>
-  <data name="&gt;&gt;HotkeyShift.Name" xml:space="preserve">
-    <value>HotkeyShift</value>
-  </data>
-  <data name="&gt;&gt;HotkeyShift.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HotkeyShift.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;HotkeyShift.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="HotkeyCtrl.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="HotkeyCtrl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="HotkeyCtrl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 19</value>
-  </data>
-  <data name="HotkeyCtrl.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="HotkeyCtrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 24</value>
-  </data>
-  <data name="HotkeyCtrl.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="HotkeyCtrl.Text" xml:space="preserve">
-    <value>Ctrl</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCtrl.Name" xml:space="preserve">
-    <value>HotkeyCtrl</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCtrl.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCtrl.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;HotkeyCtrl.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="GroupBox3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>28, 410</value>
-  </data>
-  <data name="GroupBox3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>632, 50</value>
-  </data>
-  <data name="GroupBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="GroupBox3.Text" xml:space="preserve">
-    <value>ホットキー</value>
-  </data>
-  <data name="&gt;&gt;GroupBox3.Name" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;GroupBox3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GroupBox3.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;GroupBox3.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label57.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label57.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label57.Location" type="System.Drawing.Point, System.Drawing">
-    <value>35, 262</value>
-  </data>
-  <data name="Label57.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label57.Size" type="System.Drawing.Size, System.Drawing">
-    <value>424, 15</value>
-  </data>
-  <data name="Label57.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="Label57.Text" xml:space="preserve">
-    <value>発言を再取得してFav結果を検証します。通信量が増えるのでOff推奨</value>
-  </data>
-  <data name="&gt;&gt;Label57.Name" xml:space="preserve">
-    <value>Label57</value>
-  </data>
-  <data name="&gt;&gt;Label57.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label57.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label57.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="CheckFavRestrict.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckFavRestrict.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckFavRestrict.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 235</value>
-  </data>
-  <data name="CheckFavRestrict.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckFavRestrict.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 19</value>
-  </data>
-  <data name="CheckFavRestrict.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="CheckFavRestrict.Text" xml:space="preserve">
-    <value>Fav操作結果を厳密にチェックする</value>
-  </data>
-  <data name="&gt;&gt;CheckFavRestrict.Name" xml:space="preserve">
-    <value>CheckFavRestrict</value>
-  </data>
-  <data name="&gt;&gt;CheckFavRestrict.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckFavRestrict.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckFavRestrict.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Button3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Button3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>557, 198</value>
-  </data>
-  <data name="Button3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="Button3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 26</value>
-  </data>
-  <data name="Button3.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="Button3.Text" xml:space="preserve">
-    <value>参照</value>
-  </data>
-  <data name="&gt;&gt;Button3.Name" xml:space="preserve">
-    <value>Button3</value>
-  </data>
-  <data name="&gt;&gt;Button3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Button3.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;Button3.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="PlaySnd.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="PlaySnd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="PlaySnd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 25</value>
-  </data>
-  <data name="PlaySnd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="PlaySnd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 19</value>
-  </data>
-  <data name="PlaySnd.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="PlaySnd.Text" xml:space="preserve">
-    <value>サウンドを再生する</value>
+  <data name="ReplyPeriod.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 79</value>
   </data>
-  <data name="&gt;&gt;PlaySnd.Name" xml:space="preserve">
-    <value>PlaySnd</value>
+  <data name="&gt;&gt;UserTimelinePeriod.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;PlaySnd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;ChkNewMentionsBlink.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;PlaySnd.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
+  <data name="&gt;&gt;Label45.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
   </data>
-  <data name="&gt;&gt;PlaySnd.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="ComboBoxTranslateLanguage.Items58" xml:space="preserve">
+    <value>German (Liechtenstein)</value>
   </data>
-  <data name="chkReadOwnPost.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkReadOwnPost.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chkReadOwnPost.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 319</value>
-  </data>
-  <data name="chkReadOwnPost.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="chkReadOwnPost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 19</value>
-  </data>
-  <data name="chkReadOwnPost.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="chkReadOwnPost.Text" xml:space="preserve">
-    <value>自分の発言を既読にする</value>
-  </data>
-  <data name="&gt;&gt;chkReadOwnPost.Name" xml:space="preserve">
-    <value>chkReadOwnPost</value>
-  </data>
-  <data name="&gt;&gt;chkReadOwnPost.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkReadOwnPost.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;chkReadOwnPost.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="Label15.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label15.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 52</value>
-  </data>
-  <data name="Label15.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 28</value>
-  </data>
-  <data name="Label15.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="Label15.Text" xml:space="preserve">
-    <value>タブのサウンドを設定した上で、「再生する」を選ぶとサウンドが再生されます。</value>
-  </data>
-  <data name="&gt;&gt;Label15.Name" xml:space="preserve">
-    <value>Label15</value>
-  </data>
-  <data name="&gt;&gt;Label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label15.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label15.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="BrowserPathText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>245, 200</value>
-  </data>
-  <data name="BrowserPathText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="&gt;&gt;CooperatePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="BrowserPathText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>303, 22</value>
-  </data>
-  <data name="BrowserPathText.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;BrowserPathText.Name" xml:space="preserve">
-    <value>BrowserPathText</value>
-  </data>
-  <data name="&gt;&gt;BrowserPathText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BrowserPathText.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;BrowserPathText.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="UReadMng.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="UReadMng.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="UReadMng.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 89</value>
-  </data>
-  <data name="UReadMng.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="UReadMng.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 19</value>
-  </data>
-  <data name="UReadMng.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="UReadMng.Text" xml:space="preserve">
-    <value>未読管理を行う</value>
-  </data>
-  <data name="&gt;&gt;UReadMng.Name" xml:space="preserve">
-    <value>UReadMng</value>
-  </data>
-  <data name="&gt;&gt;UReadMng.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;UReadMng.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;UReadMng.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="Label44.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label44.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label44.Location" type="System.Drawing.Point, System.Drawing">
-    <value>28, 205</value>
-  </data>
-  <data name="Label44.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label44.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 15</value>
-  </data>
-  <data name="Label44.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="Label44.Text" xml:space="preserve">
-    <value>ブラウザパス</value>
-  </data>
-  <data name="&gt;&gt;Label44.Name" xml:space="preserve">
-    <value>Label44</value>
-  </data>
-  <data name="&gt;&gt;Label44.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label44.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;Label44.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="CheckCloseToExit.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckCloseToExit.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckCloseToExit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 142</value>
-  </data>
-  <data name="CheckCloseToExit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckCloseToExit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 19</value>
-  </data>
-  <data name="CheckCloseToExit.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="CheckCloseToExit.Text" xml:space="preserve">
-    <value>×ボタンを押したときに終了する</value>
-  </data>
-  <data name="&gt;&gt;CheckCloseToExit.Name" xml:space="preserve">
-    <value>CheckCloseToExit</value>
-  </data>
-  <data name="&gt;&gt;CheckCloseToExit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckCloseToExit.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckCloseToExit.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="CheckMinimizeToTray.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckMinimizeToTray.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckMinimizeToTray.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 171</value>
-  </data>
-  <data name="CheckMinimizeToTray.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckMinimizeToTray.Size" type="System.Drawing.Size, System.Drawing">
-    <value>211, 19</value>
-  </data>
-  <data name="CheckMinimizeToTray.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="CheckMinimizeToTray.Text" xml:space="preserve">
-    <value>最小化したときにアイコン化する</value>
-  </data>
-  <data name="&gt;&gt;CheckMinimizeToTray.Name" xml:space="preserve">
-    <value>CheckMinimizeToTray</value>
-  </data>
-  <data name="&gt;&gt;CheckMinimizeToTray.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckMinimizeToTray.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckMinimizeToTray.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="CheckReadOldPosts.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="CheckReadOldPosts.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="CheckReadOldPosts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 115</value>
-  </data>
-  <data name="CheckReadOldPosts.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="CheckReadOldPosts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 19</value>
-  </data>
-  <data name="CheckReadOldPosts.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="CheckReadOldPosts.Text" xml:space="preserve">
-    <value>新着時に未読をクリアする</value>
-  </data>
-  <data name="&gt;&gt;CheckReadOldPosts.Name" xml:space="preserve">
-    <value>CheckReadOldPosts</value>
-  </data>
-  <data name="&gt;&gt;CheckReadOldPosts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CheckReadOldPosts.Parent" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;CheckReadOldPosts.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="ActionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="ActionPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="ActionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="ActionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ActionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="ActionPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="ActionPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;ActionPanel.Name" xml:space="preserve">
-    <value>ActionPanel</value>
-  </data>
-  <data name="&gt;&gt;ActionPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ActionPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;ActionPanel.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="btnRetweet.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnRetweet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnRetweet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 151</value>
-  </data>
-  <data name="btnRetweet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnRetweet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnRetweet.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="btnRetweet.Text" xml:space="preserve">
-    <value>文字色</value>
-  </data>
-  <data name="&gt;&gt;btnRetweet.Name" xml:space="preserve">
-    <value>btnRetweet</value>
-  </data>
-  <data name="&gt;&gt;btnRetweet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnRetweet.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnRetweet.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lblRetweet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblRetweet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 151</value>
-  </data>
-  <data name="lblRetweet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblRetweet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblRetweet.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="lblRetweet.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblRetweet.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblRetweet.Name" xml:space="preserve">
-    <value>lblRetweet</value>
-  </data>
-  <data name="&gt;&gt;lblRetweet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblRetweet.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblRetweet.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label80.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label80.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label80.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 154</value>
-  </data>
-  <data name="Label80.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label80.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 15</value>
-  </data>
-  <data name="Label80.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="Label80.Text" xml:space="preserve">
-    <value>ReTweet</value>
-  </data>
-  <data name="&gt;&gt;Label80.Name" xml:space="preserve">
-    <value>Label80</value>
-  </data>
-  <data name="&gt;&gt;Label80.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label80.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label80.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>233, 294</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 31</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor.Text" xml:space="preserve">
-    <value>デフォルトに戻す</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor.Name" xml:space="preserve">
-    <value>ButtonBackToDefaultFontColor</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="btnDetailLink.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnDetailLink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnDetailLink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 214</value>
-  </data>
-  <data name="btnDetailLink.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnDetailLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnDetailLink.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="btnDetailLink.Text" xml:space="preserve">
-    <value>文字色</value>
-  </data>
-  <data name="&gt;&gt;btnDetailLink.Name" xml:space="preserve">
-    <value>btnDetailLink</value>
-  </data>
-  <data name="&gt;&gt;btnDetailLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnDetailLink.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnDetailLink.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="lblDetailLink.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblDetailLink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 214</value>
-  </data>
-  <data name="lblDetailLink.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblDetailLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblDetailLink.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="lblDetailLink.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblDetailLink.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblDetailLink.Name" xml:space="preserve">
-    <value>lblDetailLink</value>
-  </data>
-  <data name="&gt;&gt;lblDetailLink.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDetailLink.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblDetailLink.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Label18.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label18.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label18.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 216</value>
-  </data>
-  <data name="Label18.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label18.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 15</value>
-  </data>
-  <data name="Label18.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="Label18.Text" xml:space="preserve">
-    <value>発言詳細リンク</value>
-  </data>
-  <data name="&gt;&gt;Label18.Name" xml:space="preserve">
-    <value>Label18</value>
-  </data>
-  <data name="&gt;&gt;Label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label18.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label18.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="btnUnread.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnUnread.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnUnread.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 58</value>
-  </data>
-  <data name="btnUnread.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnUnread.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 31</value>
-  </data>
-  <data name="btnUnread.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="btnUnread.Text" xml:space="preserve">
-    <value>フォント&amp;&amp;色</value>
-  </data>
-  <data name="&gt;&gt;btnUnread.Name" xml:space="preserve">
-    <value>btnUnread</value>
-  </data>
-  <data name="&gt;&gt;btnUnread.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnUnread.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnUnread.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="lblUnread.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblUnread.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 58</value>
-  </data>
-  <data name="lblUnread.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblUnread.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblUnread.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="lblUnread.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblUnread.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblUnread.Name" xml:space="preserve">
-    <value>lblUnread</value>
-  </data>
-  <data name="&gt;&gt;lblUnread.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblUnread.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblUnread.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Label20.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label20.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label20.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 60</value>
-  </data>
-  <data name="Label20.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label20.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 15</value>
-  </data>
-  <data name="Label20.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Label20.Text" xml:space="preserve">
-    <value>未読フォント</value>
-  </data>
-  <data name="&gt;&gt;Label20.Name" xml:space="preserve">
-    <value>Label20</value>
-  </data>
-  <data name="&gt;&gt;Label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label20.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label20.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="btnDetailBack.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnDetailBack.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnDetailBack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 245</value>
-  </data>
-  <data name="btnDetailBack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnDetailBack.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnDetailBack.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="btnDetailBack.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnDetailBack.Name" xml:space="preserve">
-    <value>btnDetailBack</value>
-  </data>
-  <data name="&gt;&gt;btnDetailBack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnDetailBack.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnDetailBack.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="lblDetailBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblDetailBackcolor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 245</value>
-  </data>
-  <data name="lblDetailBackcolor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblDetailBackcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblDetailBackcolor.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="lblDetailBackcolor.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblDetailBackcolor.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblDetailBackcolor.Name" xml:space="preserve">
-    <value>lblDetailBackcolor</value>
-  </data>
-  <data name="&gt;&gt;lblDetailBackcolor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDetailBackcolor.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblDetailBackcolor.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="Label37.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label37.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label37.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 248</value>
-  </data>
-  <data name="Label37.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label37.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 15</value>
-  </data>
-  <data name="Label37.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="Label37.Text" xml:space="preserve">
-    <value>発言詳細背景色</value>
-  </data>
-  <data name="&gt;&gt;Label37.Name" xml:space="preserve">
-    <value>Label37</value>
-  </data>
-  <data name="&gt;&gt;Label37.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label37.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label37.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="btnDetail.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnDetail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnDetail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 182</value>
-  </data>
-  <data name="btnDetail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnDetail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 31</value>
-  </data>
-  <data name="btnDetail.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="btnDetail.Text" xml:space="preserve">
-    <value>フォント&amp;&amp;色</value>
-  </data>
-  <data name="&gt;&gt;btnDetail.Name" xml:space="preserve">
-    <value>btnDetail</value>
-  </data>
-  <data name="&gt;&gt;btnDetail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnDetail.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnDetail.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="lblDetail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblDetail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 182</value>
-  </data>
-  <data name="lblDetail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblDetail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblDetail.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="lblDetail.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblDetail.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblDetail.Name" xml:space="preserve">
-    <value>lblDetail</value>
-  </data>
-  <data name="&gt;&gt;lblDetail.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblDetail.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblDetail.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="Label26.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label26.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label26.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 185</value>
-  </data>
-  <data name="Label26.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 15</value>
-  </data>
-  <data name="Label26.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="Label26.Text" xml:space="preserve">
-    <value>発言詳細文字</value>
-  </data>
-  <data name="&gt;&gt;Label26.Name" xml:space="preserve">
-    <value>Label26</value>
-  </data>
-  <data name="&gt;&gt;Label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label26.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label26.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="btnOWL.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnOWL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnOWL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 120</value>
-  </data>
-  <data name="btnOWL.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnOWL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnOWL.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="btnOWL.Text" xml:space="preserve">
-    <value>文字色</value>
-  </data>
-  <data name="&gt;&gt;btnOWL.Name" xml:space="preserve">
-    <value>btnOWL</value>
-  </data>
-  <data name="&gt;&gt;btnOWL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnOWL.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnOWL.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="lblOWL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblOWL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 120</value>
-  </data>
-  <data name="lblOWL.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblOWL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblOWL.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="lblOWL.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblOWL.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblOWL.Name" xml:space="preserve">
-    <value>lblOWL</value>
-  </data>
-  <data name="&gt;&gt;lblOWL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblOWL.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblOWL.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="Label24.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label24.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label24.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 122</value>
-  </data>
-  <data name="Label24.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 15</value>
-  </data>
-  <data name="Label24.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="Label24.Text" xml:space="preserve">
-    <value>片思い発言</value>
-  </data>
-  <data name="&gt;&gt;Label24.Name" xml:space="preserve">
-    <value>Label24</value>
-  </data>
-  <data name="&gt;&gt;Label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label24.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label24.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="btnFav.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnFav.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnFav.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 89</value>
-  </data>
-  <data name="btnFav.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnFav.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnFav.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="btnFav.Text" xml:space="preserve">
-    <value>文字色</value>
-  </data>
-  <data name="&gt;&gt;btnFav.Name" xml:space="preserve">
-    <value>btnFav</value>
-  </data>
-  <data name="&gt;&gt;btnFav.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFav.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnFav.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="lblFav.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblFav.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 89</value>
-  </data>
-  <data name="lblFav.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblFav.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblFav.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblFav.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblFav.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblFav.Name" xml:space="preserve">
-    <value>lblFav</value>
-  </data>
-  <data name="&gt;&gt;lblFav.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFav.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblFav.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="Label22.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label22.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label22.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 91</value>
-  </data>
-  <data name="Label22.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label22.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 15</value>
-  </data>
-  <data name="Label22.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="Label22.Text" xml:space="preserve">
-    <value>Fav発言</value>
-  </data>
-  <data name="&gt;&gt;Label22.Name" xml:space="preserve">
-    <value>Label22</value>
-  </data>
-  <data name="&gt;&gt;Label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label22.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label22.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="btnListFont.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnListFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnListFont.Location" type="System.Drawing.Point, System.Drawing">
-    <value>441, 26</value>
-  </data>
-  <data name="btnListFont.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnListFont.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 31</value>
-  </data>
-  <data name="btnListFont.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="btnListFont.Text" xml:space="preserve">
-    <value>フォント&amp;&amp;色</value>
-  </data>
-  <data name="&gt;&gt;btnListFont.Name" xml:space="preserve">
-    <value>btnListFont</value>
-  </data>
-  <data name="&gt;&gt;btnListFont.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnListFont.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnListFont.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="lblListFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblListFont.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 26</value>
-  </data>
-  <data name="lblListFont.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblListFont.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 24</value>
-  </data>
-  <data name="lblListFont.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="lblListFont.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblListFont.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblListFont.Name" xml:space="preserve">
-    <value>lblListFont</value>
-  </data>
-  <data name="&gt;&gt;lblListFont.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblListFont.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;lblListFont.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="Label61.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label61.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label61.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 29</value>
-  </data>
-  <data name="Label61.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label61.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 15</value>
-  </data>
-  <data name="Label61.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label61.Text" xml:space="preserve">
-    <value>リストフォント</value>
-  </data>
-  <data name="&gt;&gt;Label61.Name" xml:space="preserve">
-    <value>Label61</value>
-  </data>
-  <data name="&gt;&gt;Label61.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label61.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;Label61.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="GroupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 22</value>
-  </data>
-  <data name="GroupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>572, 334</value>
-  </data>
-  <data name="GroupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="GroupBox1.Text" xml:space="preserve">
-    <value>フォント＆色設定</value>
-  </data>
-  <data name="&gt;&gt;GroupBox1.Name" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;GroupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GroupBox1.Parent" xml:space="preserve">
-    <value>FontPanel</value>
-  </data>
-  <data name="&gt;&gt;GroupBox1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="FontPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="FontPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="FontPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="FontPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="FontPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="FontPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="FontPanel.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;FontPanel.Name" xml:space="preserve">
-    <value>FontPanel</value>
-  </data>
-  <data name="&gt;&gt;FontPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FontPanel.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;FontPanel.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="Label65.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label65.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label65.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 275</value>
-  </data>
-  <data name="Label65.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label65.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 15</value>
-  </data>
-  <data name="Label65.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
-  <data name="Label65.Text" xml:space="preserve">
-    <value>入力欄フォント</value>
-  </data>
-  <data name="&gt;&gt;Label65.Name" xml:space="preserve">
-    <value>Label65</value>
-  </data>
-  <data name="&gt;&gt;Label65.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label65.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label65.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Label52.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label52.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label52.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 244</value>
-  </data>
-  <data name="Label52.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label52.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 15</value>
-  </data>
-  <data name="Label52.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="Label52.Text" xml:space="preserve">
-    <value>入力欄アクティブ時背景色</value>
-  </data>
-  <data name="&gt;&gt;Label52.Name" xml:space="preserve">
-    <value>Label52</value>
-  </data>
-  <data name="&gt;&gt;Label52.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label52.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label52.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label49.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label49.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label49.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 181</value>
-  </data>
-  <data name="Label49.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label49.Size" type="System.Drawing.Size, System.Drawing">
-    <value>127, 15</value>
-  </data>
-  <data name="Label49.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="Label49.Text" xml:space="preserve">
-    <value>その発言の@先発言</value>
-  </data>
-  <data name="&gt;&gt;Label49.Name" xml:space="preserve">
-    <value>Label49</value>
-  </data>
-  <data name="&gt;&gt;Label49.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label49.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label49.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="Label9.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 212</value>
-  </data>
-  <data name="Label9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 15</value>
-  </data>
-  <data name="Label9.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="Label9.Text" xml:space="preserve">
-    <value>一般発言</value>
-  </data>
-  <data name="&gt;&gt;Label9.Name" xml:space="preserve">
-    <value>Label9</value>
-  </data>
-  <data name="&gt;&gt;Label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label9.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label9.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Label14.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label14.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label14.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 150</value>
-  </data>
-  <data name="Label14.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 15</value>
-  </data>
-  <data name="Label14.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="Label14.Text" xml:space="preserve">
-    <value>その発言の@先の人の発言</value>
-  </data>
-  <data name="&gt;&gt;Label14.Name" xml:space="preserve">
-    <value>Label14</value>
-  </data>
-  <data name="&gt;&gt;Label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label14.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label14.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Label16.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label16.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label16.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 119</value>
-  </data>
-  <data name="Label16.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 15</value>
-  </data>
-  <data name="Label16.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="Label16.Text" xml:space="preserve">
-    <value>その人への@返信</value>
-  </data>
-  <data name="&gt;&gt;Label16.Name" xml:space="preserve">
-    <value>Label16</value>
-  </data>
-  <data name="&gt;&gt;Label16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label16.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label16.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Label32.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label32.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label32.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 88</value>
-  </data>
-  <data name="Label32.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 15</value>
-  </data>
-  <data name="Label32.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="Label32.Text" xml:space="preserve">
-    <value>その人の発言</value>
-  </data>
-  <data name="&gt;&gt;Label32.Name" xml:space="preserve">
-    <value>Label32</value>
-  </data>
-  <data name="&gt;&gt;Label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label32.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label32.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Label34.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label34.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label34.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 56</value>
-  </data>
-  <data name="Label34.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label34.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 15</value>
-  </data>
-  <data name="Label34.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Label34.Text" xml:space="preserve">
-    <value>自分への@返信</value>
-  </data>
-  <data name="&gt;&gt;Label34.Name" xml:space="preserve">
-    <value>Label34</value>
-  </data>
-  <data name="&gt;&gt;Label34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label34.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label34.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="Label36.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label36.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label36.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 25</value>
-  </data>
-  <data name="Label36.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="Label36.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 15</value>
-  </data>
-  <data name="Label36.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="Label36.Text" xml:space="preserve">
-    <value>自分の発言</value>
-  </data>
-  <data name="&gt;&gt;Label36.Name" xml:space="preserve">
-    <value>Label36</value>
-  </data>
-  <data name="&gt;&gt;Label36.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label36.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;Label36.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="btnInputFont.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnInputFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnInputFont.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 269</value>
-  </data>
-  <data name="btnInputFont.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnInputFont.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 31</value>
-  </data>
-  <data name="btnInputFont.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
-  </data>
-  <data name="btnInputFont.Text" xml:space="preserve">
-    <value>フォント&amp;&amp;色</value>
-  </data>
-  <data name="&gt;&gt;btnInputFont.Name" xml:space="preserve">
-    <value>btnInputFont</value>
-  </data>
-  <data name="&gt;&gt;btnInputFont.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnInputFont.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnInputFont.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="btnInputBackcolor.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnInputBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnInputBackcolor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 238</value>
-  </data>
-  <data name="btnInputBackcolor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnInputBackcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnInputBackcolor.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="btnInputBackcolor.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnInputBackcolor.Name" xml:space="preserve">
-    <value>btnInputBackcolor</value>
-  </data>
-  <data name="&gt;&gt;btnInputBackcolor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnInputBackcolor.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnInputBackcolor.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="btnAtTo.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnAtTo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnAtTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 175</value>
-  </data>
-  <data name="btnAtTo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnAtTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnAtTo.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="btnAtTo.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnAtTo.Name" xml:space="preserve">
-    <value>btnAtTo</value>
-  </data>
-  <data name="&gt;&gt;btnAtTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAtTo.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnAtTo.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="btnListBack.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnListBack.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnListBack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 206</value>
-  </data>
-  <data name="btnListBack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnListBack.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnListBack.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="btnListBack.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnListBack.Name" xml:space="preserve">
-    <value>btnListBack</value>
-  </data>
-  <data name="&gt;&gt;btnListBack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnListBack.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnListBack.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="btnAtFromTarget.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnAtFromTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnAtFromTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 144</value>
-  </data>
-  <data name="btnAtFromTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnAtFromTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnAtFromTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="btnAtFromTarget.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnAtFromTarget.Name" xml:space="preserve">
-    <value>btnAtFromTarget</value>
-  </data>
-  <data name="&gt;&gt;btnAtFromTarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAtFromTarget.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnAtFromTarget.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="btnAtTarget.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnAtTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnAtTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 112</value>
-  </data>
-  <data name="btnAtTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnAtTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnAtTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="btnAtTarget.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnAtTarget.Name" xml:space="preserve">
-    <value>btnAtTarget</value>
-  </data>
-  <data name="&gt;&gt;btnAtTarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAtTarget.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnAtTarget.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="btnTarget.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 81</value>
-  </data>
-  <data name="btnTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="btnTarget.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnTarget.Name" xml:space="preserve">
-    <value>btnTarget</value>
-  </data>
-  <data name="&gt;&gt;btnTarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnTarget.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnTarget.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="btnAtSelf.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnAtSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnAtSelf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 50</value>
-  </data>
-  <data name="btnAtSelf.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnAtSelf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnAtSelf.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="btnAtSelf.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnAtSelf.Name" xml:space="preserve">
-    <value>btnAtSelf</value>
-  </data>
-  <data name="&gt;&gt;btnAtSelf.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnAtSelf.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnAtSelf.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="btnSelf.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnSelf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>452, 19</value>
-  </data>
-  <data name="btnSelf.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnSelf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="btnSelf.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="btnSelf.Text" xml:space="preserve">
-    <value>背景色</value>
-  </data>
-  <data name="&gt;&gt;btnSelf.Name" xml:space="preserve">
-    <value>btnSelf</value>
-  </data>
-  <data name="&gt;&gt;btnSelf.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnSelf.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;btnSelf.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="lblInputFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblInputFont.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 272</value>
-  </data>
-  <data name="lblInputFont.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblInputFont.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblInputFont.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
-  </data>
-  <data name="lblInputFont.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblInputFont.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblInputFont.Name" xml:space="preserve">
-    <value>lblInputFont</value>
-  </data>
-  <data name="&gt;&gt;lblInputFont.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblInputFont.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblInputFont.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="lblInputBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblInputBackcolor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 241</value>
-  </data>
-  <data name="lblInputBackcolor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblInputBackcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblInputBackcolor.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="lblInputBackcolor.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblInputBackcolor.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblInputBackcolor.Name" xml:space="preserve">
-    <value>lblInputBackcolor</value>
-  </data>
-  <data name="&gt;&gt;lblInputBackcolor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblInputBackcolor.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblInputBackcolor.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="lblAtTo.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAtTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 179</value>
-  </data>
-  <data name="lblAtTo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAtTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblAtTo.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="lblAtTo.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblAtTo.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblAtTo.Name" xml:space="preserve">
-    <value>lblAtTo</value>
-  </data>
-  <data name="&gt;&gt;lblAtTo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAtTo.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblAtTo.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="lblListBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblListBackcolor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 210</value>
-  </data>
-  <data name="lblListBackcolor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblListBackcolor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblListBackcolor.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="lblListBackcolor.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblListBackcolor.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblListBackcolor.Name" xml:space="preserve">
-    <value>lblListBackcolor</value>
-  </data>
-  <data name="&gt;&gt;lblListBackcolor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblListBackcolor.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblListBackcolor.ZOrder" xml:space="preserve">
-    <value>21</value>
-  </data>
-  <data name="lblAtFromTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAtFromTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 148</value>
-  </data>
-  <data name="lblAtFromTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAtFromTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblAtFromTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="lblAtFromTarget.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblAtFromTarget.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblAtFromTarget.Name" xml:space="preserve">
-    <value>lblAtFromTarget</value>
-  </data>
-  <data name="&gt;&gt;lblAtFromTarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAtFromTarget.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblAtFromTarget.ZOrder" xml:space="preserve">
-    <value>22</value>
-  </data>
-  <data name="lblAtTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAtTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 116</value>
-  </data>
-  <data name="lblAtTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAtTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblAtTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="lblAtTarget.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblAtTarget.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblAtTarget.Name" xml:space="preserve">
-    <value>lblAtTarget</value>
-  </data>
-  <data name="&gt;&gt;lblAtTarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAtTarget.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblAtTarget.ZOrder" xml:space="preserve">
-    <value>23</value>
-  </data>
-  <data name="lblTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblTarget.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 85</value>
-  </data>
-  <data name="lblTarget.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblTarget.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblTarget.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="lblTarget.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblTarget.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblTarget.Name" xml:space="preserve">
-    <value>lblTarget</value>
-  </data>
-  <data name="&gt;&gt;lblTarget.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblTarget.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblTarget.ZOrder" xml:space="preserve">
-    <value>24</value>
-  </data>
-  <data name="lblAtSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblAtSelf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 54</value>
-  </data>
-  <data name="lblAtSelf.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblAtSelf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblAtSelf.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="lblAtSelf.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblAtSelf.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblAtSelf.Name" xml:space="preserve">
-    <value>lblAtSelf</value>
-  </data>
-  <data name="&gt;&gt;lblAtSelf.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblAtSelf.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblAtSelf.ZOrder" xml:space="preserve">
-    <value>25</value>
-  </data>
-  <data name="lblSelf.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblSelf.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 21</value>
-  </data>
-  <data name="lblSelf.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblSelf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 24</value>
-  </data>
-  <data name="lblSelf.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="lblSelf.Text" xml:space="preserve">
-    <value>This is sample.</value>
-  </data>
-  <data name="lblSelf.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblSelf.Name" xml:space="preserve">
-    <value>lblSelf</value>
-  </data>
-  <data name="&gt;&gt;lblSelf.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblSelf.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;lblSelf.ZOrder" xml:space="preserve">
-    <value>26</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>255, 315</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 31</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
-  </data>
-  <data name="ButtonBackToDefaultFontColor2.Text" xml:space="preserve">
-    <value>デフォルトに戻す</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.Name" xml:space="preserve">
-    <value>ButtonBackToDefaultFontColor2</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.ZOrder" xml:space="preserve">
-    <value>27</value>
-  </data>
-  <data name="GroupBox5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 22</value>
-  </data>
-  <data name="GroupBox5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="GroupBox5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>572, 362</value>
-  </data>
-  <data name="GroupBox5.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="GroupBox5.Text" xml:space="preserve">
-    <value>フォント＆色設定</value>
-  </data>
-  <data name="&gt;&gt;GroupBox5.Name" xml:space="preserve">
-    <value>GroupBox5</value>
-  </data>
-  <data name="&gt;&gt;GroupBox5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GroupBox5.Parent" xml:space="preserve">
-    <value>FontPanel2</value>
-  </data>
-  <data name="&gt;&gt;GroupBox5.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="FontPanel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="FontPanel2.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="FontPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="FontPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="FontPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>691, 460</value>
-  </data>
-  <data name="FontPanel2.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="FontPanel2.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;FontPanel2.Name" xml:space="preserve">
-    <value>FontPanel2</value>
-  </data>
-  <data name="&gt;&gt;FontPanel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FontPanel2.Parent" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;FontPanel2.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel2.Name" xml:space="preserve">
-    <value>SplitContainer1.Panel2</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel2.Parent" xml:space="preserve">
-    <value>SplitContainer1</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Panel2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="SplitContainer1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>921, 460</value>
-  </data>
-  <data name="SplitContainer1.SplitterDistance" type="System.Int32, mscorlib">
-    <value>225</value>
-  </data>
-  <data name="SplitContainer1.SplitterWidth" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="SplitContainer1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Name" xml:space="preserve">
-    <value>SplitContainer1</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;SplitContainer1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Save.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Save.Location" type="System.Drawing.Point, System.Drawing">
-    <value>695, 468</value>
-  </data>
-  <data name="Save.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="Save.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 29</value>
-  </data>
-  <data name="Save.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Save.Text" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="&gt;&gt;Save.Name" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="&gt;&gt;Save.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Save.Parent" xml:space="preserve">
-    <value>$this</value>
+    <value>228, 19</value>
   </data>
   <data name="&gt;&gt;Save.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="Cancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="TextProxyPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>309, 82</value>
   </data>
-  <data name="Cancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>805, 468</value>
+  <data name="&gt;&gt;btnInputFont.Name" xml:space="preserve">
+    <value>btnInputFont</value>
   </data>
-  <data name="Cancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
+  <data name="Label29.Text" xml:space="preserve">
+    <value>発言翻訳先の言語</value>
   </data>
-  <data name="Cancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 29</value>
+  <data name="CheckAlwaysTop.Text" xml:space="preserve">
+    <value>常に最前面に表示する</value>
   </data>
-  <data name="Cancel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="LabelUserStreamActive.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 261</value>
   </data>
-  <data name="Cancel.Text" xml:space="preserve">
-    <value>キャンセル</value>
+  <data name="&gt;&gt;Label42.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Cancel.Name" xml:space="preserve">
-    <value>Cancel</value>
+  <data name="FollowCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>103, 16</value>
   </data>
-  <data name="&gt;&gt;Cancel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;TextProxyPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Cancel.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="lblAtTo.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
   </data>
-  <data name="&gt;&gt;Cancel.ZOrder" xml:space="preserve">
+  <data name="ProxyPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="MapThumbnailProviderComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <metadata name="ColorDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>140, 17</value>
-  </metadata>
+  <data name="&gt;&gt;Label11.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="&gt;&gt;TweetActPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;ComboDispTitle.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="TextProxyPassword.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label44.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblInputBackcolor.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckFavRestrict.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="CheckOutputz.Text" xml:space="preserve">
+    <value>Outputzに対応する</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailGroupBox.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="&gt;&gt;FirstTextCountApi.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cmbNameBalloon.Size" type="System.Drawing.Size, System.Drawing">
+    <value>136, 20</value>
+  </data>
+  <data name="&gt;&gt;Label4.Parent" xml:space="preserve">
+    <value>BasedPanel</value>
+  </data>
+  <data name="&gt;&gt;Label59.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnDetailBack.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="&gt;&gt;UserAppointUrlText.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Label42.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;chkReadOwnPost.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="IsPreviewFoursquareCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>24, 254</value>
+  </data>
+  <data name="lblDetail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="btnListBack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="&gt;&gt;GetPeriodPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label67.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 12</value>
+  </data>
+  <data name="&gt;&gt;Label65.Name" xml:space="preserve">
+    <value>Label65</value>
+  </data>
+  <data name="&gt;&gt;DMPeriod.Parent" xml:space="preserve">
+    <value>GetPeriodPanel</value>
+  </data>
+  <data name="CheckSortOrderLock.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;HotkeyCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label69.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label24.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="CheckMinimizeToTray.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label38.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="GetMoreTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailZoomTextBox.Name" xml:space="preserve">
+    <value>MapThumbnailZoomTextBox</value>
+  </data>
+  <data name="Label53.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnAtFromTarget.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;btnUnread.Name" xml:space="preserve">
+    <value>btnUnread</value>
+  </data>
+  <data name="LabelProxyPort.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="FontPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="RadioProxyNone.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;FollowCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AuthUserCombo.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="CheckUseRecommendStatus.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckOpenUserTimeline.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailWidthTextBox.Parent" xml:space="preserve">
+    <value>MapThumbnailGroupBox</value>
+  </data>
+  <data name="&gt;&gt;btnInputFont.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckReadOldPosts.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items80" xml:space="preserve">
+    <value>Rhaeto-Romanic</value>
+  </data>
+  <data name="&gt;&gt;OneWayLv.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="Label76.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblRetweet.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="TabMouseLockCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 304</value>
+  </data>
+  <data name="&gt;&gt;CheckShowGrid.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="Label19.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CreateAccountButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblDetailLink.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 19</value>
+  </data>
+  <data name="ActionPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label40.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 12</value>
+  </data>
+  <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="lblUnread.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label18.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 12</value>
+  </data>
+  <data name="&gt;&gt;CheckEventNotify.Name" xml:space="preserve">
+    <value>CheckEventNotify</value>
+  </data>
+  <data name="&gt;&gt;ButtonBackToDefaultFontColor2.Name" xml:space="preserve">
+    <value>ButtonBackToDefaultFontColor2</value>
+  </data>
+  <data name="&gt;&gt;ProxyPanel.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="btnTarget.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;lblAtFromTarget.Name" xml:space="preserve">
+    <value>lblAtFromTarget</value>
+  </data>
+  <data name="ShortenTcoCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="ComboBoxOutputzUrlmode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>205, 72</value>
+  </data>
+  <data name="TextBox3.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;BasedPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckCloseToExit.Text" xml:space="preserve">
+    <value>×ボタンを押したときに終了する</value>
+  </data>
+  <data name="HotkeyCode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;UserTimelineTextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="btnTarget.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="LabelApiUsing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 12</value>
+  </data>
+  <data name="btnDetailBack.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label49.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 12</value>
+  </data>
+  <data name="Label59.Location" type="System.Drawing.Point, System.Drawing">
+    <value>36, 47</value>
+  </data>
+  <data name="Label21.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label17.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label49.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 145</value>
+  </data>
+  <data name="&gt;&gt;RadioProxyNone.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;CheckListCreatedEvent.Parent" xml:space="preserve">
+    <value>NotifyPanel</value>
+  </data>
+  <data name="&gt;&gt;TabMouseLockCheck.Name" xml:space="preserve">
+    <value>TabMouseLockCheck</value>
+  </data>
+  <data name="LabelPostAndGet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GroupBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;CheckBox3.Name" xml:space="preserve">
+    <value>CheckBox3</value>
+  </data>
+  <data name="btnListBack.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="TabMouseLockCheck.Text" xml:space="preserve">
+    <value>マウスでのタブ移動を禁止する</value>
+  </data>
+  <data name="Label69.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblDetailBackcolor.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckRetweetNoConfirm.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnSelf.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="&gt;&gt;Label60.Name" xml:space="preserve">
+    <value>Label60</value>
+  </data>
+  <data name="Label18.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnRetweet.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label19.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="Label31.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="IsPreviewFoursquareCheckBox.Text" xml:space="preserve">
+    <value>FoursquareのURLからプレビューを表示する（非常に重くなります）</value>
+  </data>
+  <data name="IconSize.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 149</value>
+  </data>
+  <data name="CheckAlwaysTop.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TwitterSearchAPIText.Text" xml:space="preserve">
+    <value>search.twitter.com</value>
+  </data>
+  <data name="&gt;&gt;lblListBackcolor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label29.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CheckStartupFollowers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label63.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 12</value>
+  </data>
+  <data name="&gt;&gt;Label38.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="CheckNicoms.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;StartAuthButton.Parent" xml:space="preserve">
+    <value>BasedPanel</value>
+  </data>
+  <data name="Save.Location" type="System.Drawing.Point, System.Drawing">
+    <value>521, 374</value>
+  </data>
+  <data name="&gt;&gt;ToolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ConnectionPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;Label61.Name" xml:space="preserve">
+    <value>Label61</value>
+  </data>
+  <data name="HideDuplicatedRetweetsCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 16</value>
+  </data>
+  <data name="&gt;&gt;label48.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label13.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;TextProxyAddress.Name" xml:space="preserve">
+    <value>TextProxyAddress</value>
+  </data>
+  <data name="Label2.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="lblListFont.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="CheckBox3.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="IconSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>163, 20</value>
+  </data>
+  <data name="&gt;&gt;HotkeyWin.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblDetail.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ButtonBackToDefaultFontColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckFavRestrict.Text" xml:space="preserve">
+    <value>Fav操作結果を厳密にチェックする</value>
+  </data>
+  <data name="&gt;&gt;lblFav.Name" xml:space="preserve">
+    <value>lblFav</value>
+  </data>
+  <data name="&gt;&gt;RadioProxySpecified.Name" xml:space="preserve">
+    <value>RadioProxySpecified</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items59" xml:space="preserve">
+    <value>Greek</value>
+  </data>
+  <data name="Label37.Text" xml:space="preserve">
+    <value>発言詳細背景色</value>
+  </data>
+  <data name="&gt;&gt;CheckReadOldPosts.Name" xml:space="preserve">
+    <value>CheckReadOldPosts</value>
+  </data>
+  <data name="&gt;&gt;TwitterSearchAPIText.Name" xml:space="preserve">
+    <value>TwitterSearchAPIText</value>
+  </data>
+  <data name="lblAtSelf.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;HotkeyCheck.Name" xml:space="preserve">
+    <value>HotkeyCheck</value>
+  </data>
+  <data name="&gt;&gt;TwitterAPIText.Name" xml:space="preserve">
+    <value>TwitterAPIText</value>
+  </data>
+  <data name="CheckForceResolve.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label20.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items68" xml:space="preserve">
+    <value>Korean</value>
+  </data>
+  <data name="ReplyPeriod.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 19</value>
+  </data>
+  <data name="CheckNicoms.Text" xml:space="preserve">
+    <value>ニコニコ動画のURLをnico.msで短縮して送信</value>
+  </data>
+  <data name="Button3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>418, 158</value>
+  </data>
+  <data name="PreviewPanel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label65.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="Label44.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 164</value>
+  </data>
+  <data name="&gt;&gt;Label38.Name" xml:space="preserve">
+    <value>Label38</value>
+  </data>
+  <data name="Label36.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label67.Text" xml:space="preserve">
+    <value>標準取得件数</value>
+  </data>
+  <data name="TimelinePeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="LabelApiUsing.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label62.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="&gt;&gt;cmbNameBalloon.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblTarget.Name" xml:space="preserve">
+    <value>lblTarget</value>
+  </data>
+  <data name="&gt;&gt;RadioProxySpecified.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckFavEventUnread.Name" xml:space="preserve">
+    <value>CheckFavEventUnread</value>
+  </data>
+  <data name="Save.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="Label49.Text" xml:space="preserve">
+    <value>その発言の@先発言</value>
+  </data>
+  <data name="IsNotifyUseGrowlCheckBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckListMemberRemovedEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnListFont.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label14.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Label40.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckStartupVersion.Name" xml:space="preserve">
+    <value>CheckStartupVersion</value>
+  </data>
+  <data name="btnAtTarget.Text" xml:space="preserve">
+    <value>背景色</value>
+  </data>
+  <data name="Label20.Text" xml:space="preserve">
+    <value>未読フォント</value>
+  </data>
+  <data name="&gt;&gt;Label15.Parent" xml:space="preserve">
+    <value>ActionPanel</value>
+  </data>
+  <data name="Label21.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblOWL.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="MapThumbnailWidthTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 46</value>
+  </data>
+  <data name="IconSize.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;StartupReaded.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;StartupReaded.Parent" xml:space="preserve">
+    <value>StartupPanel</value>
+  </data>
+  <data name="CheckShowGrid.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;DMPeriod.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label52.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 195</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items107" xml:space="preserve">
+    <value>Spanish (Honduras)</value>
+  </data>
+  <data name="&gt;&gt;CheckPostAndGet.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;lblAtFromTarget.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="Label64.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblInputBackcolor.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="&gt;&gt;Label2.Name" xml:space="preserve">
+    <value>Label2</value>
+  </data>
+  <data name="Label20.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 48</value>
+  </data>
+  <data name="lblDetailBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;lblUnread.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckListMemberAddedEvent.Text" xml:space="preserve">
+    <value>Listsに追加された</value>
+  </data>
+  <data name="&gt;&gt;TreeViewSetting.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CmbDateTimeFormat.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;TextCountApi.Name" xml:space="preserve">
+    <value>TextCountApi</value>
+  </data>
+  <data name="LabelProxyAddress.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckFavRestrict.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label2.Text" xml:space="preserve">
+    <value>※別途DLLが必要です(マウスオーバーで表示)</value>
+  </data>
+  <data name="ShortUrlPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;CheckAlwaysTop.Name" xml:space="preserve">
+    <value>CheckAlwaysTop</value>
+  </data>
+  <data name="ButtonBackToDefaultFontColor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>175, 235</value>
+  </data>
+  <data name="MapThumbnailHeightTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>179, 46</value>
+  </data>
+  <data name="ComboDispTitle.Items3" xml:space="preserve">
+    <value>＠未読数</value>
+  </data>
+  <data name="ComboDispTitle.Items2" xml:space="preserve">
+    <value>最終発言</value>
+  </data>
+  <data name="ComboDispTitle.Items5" xml:space="preserve">
+    <value>未読数(@未読数)</value>
+  </data>
+  <data name="ComboDispTitle.Items4" xml:space="preserve">
+    <value>未読数</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items82" xml:space="preserve">
+    <value>Romanian (Republic of Moldova)</value>
+  </data>
+  <data name="LabelUserStreamActive.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GetPeriodPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="btnRetweet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>331, 121</value>
+  </data>
+  <data name="TextCountApi.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label47.Size" type="System.Drawing.Size, System.Drawing">
+    <value>131, 12</value>
+  </data>
+  <data name="Label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 133</value>
+  </data>
+  <data name="Label41.Location" type="System.Drawing.Point, System.Drawing">
+    <value>270, 49</value>
+  </data>
+  <data name="lblAtSelf.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="btnListBack.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;StartupPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;LabelProxyUser.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ConnectionPanel.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;GetMoreTextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="btnInputBackcolor.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;Label10.Name" xml:space="preserve">
+    <value>Label10</value>
+  </data>
+  <data name="CmbDateTimeFormat.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="Label12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 12</value>
+  </data>
+  <data name="LabelProxyPassword.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;AuthClearButton.Parent" xml:space="preserve">
+    <value>BasedPanel</value>
+  </data>
+  <data name="Label81.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>232, 20</value>
+  </data>
+  <data name="Label33.Text" xml:space="preserve">
+    <value>Lists更新間隔（秒）</value>
+  </data>
+  <data name="CheckMonospace.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label57.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="Label53.Text" xml:space="preserve">
+    <value>前データの更新</value>
+  </data>
+  <data name="&gt;&gt;CheckUnfavoritesEvent.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="LabelPostAndGet.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckNicoms.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="&gt;&gt;Label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label60.Location" type="System.Drawing.Point, System.Drawing">
+    <value>36, 75</value>
+  </data>
+  <data name="btnInputBackcolor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label46.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckListCreatedEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 16</value>
+  </data>
+  <data name="&gt;&gt;ConnectionPanel.Parent" xml:space="preserve">
+    <value>SplitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;CheckForceEventNotify.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="HotkeyWin.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ComboBoxPostKeySelect.Items2" xml:space="preserve">
+    <value>Shift+Enter</value>
+  </data>
+  <data name="&gt;&gt;LabelUserStreamActive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="HotkeyAlt.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckTinyURL.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CheckBox3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CheckListMemberAddedEvent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label31.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 128</value>
+  </data>
+  <data name="ShortenTcoCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 90</value>
+  </data>
+  <data name="Label44.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckPostAndGet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>33, 59</value>
+  </data>
+  <data name="btnAtTarget.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;btnListBack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FollowCheckBox.Name" xml:space="preserve">
+    <value>FollowCheckBox</value>
+  </data>
+  <data name="&gt;&gt;Label37.Name" xml:space="preserve">
+    <value>Label37</value>
+  </data>
+  <data name="CheckListCreatedEvent.Text" xml:space="preserve">
+    <value>Listsの作成に成功した</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items103" xml:space="preserve">
+    <value>Spanish (Uruguay)</value>
+  </data>
+  <data name="btnUnread.Text" xml:space="preserve">
+    <value>フォント&amp;&amp;色</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items123" xml:space="preserve">
+    <value>Zulu</value>
+  </data>
+  <data name="&gt;&gt;GroupBox3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label62.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;lblDetailBackcolor.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="&gt;&gt;lblInputFont.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CreateAccountButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label38.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="HotkeyAlt.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnInputBackcolor.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 190</value>
+  </data>
+  <data name="ReplyPeriod.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="lblAtSelf.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 19</value>
+  </data>
+  <data name="LabelApiUsing.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label63.Name" xml:space="preserve">
+    <value>Label63</value>
+  </data>
+  <data name="CheckPreviewEnable.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;btnUnread.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="btnAtTo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="CreateAccountButton.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="lblInputFont.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;Label3.Name" xml:space="preserve">
+    <value>Label3</value>
+  </data>
+  <data name="&gt;&gt;TextCountApiReply.Name" xml:space="preserve">
+    <value>TextCountApiReply</value>
+  </data>
+  <data name="&gt;&gt;EmailText.Name" xml:space="preserve">
+    <value>EmailText</value>
+  </data>
+  <data name="&gt;&gt;lblDetail.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ReplyIconStateCombo.Items1" xml:space="preserve">
+    <value>アイコン変更</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items83" xml:space="preserve">
+    <value>Russian</value>
+  </data>
+  <data name="SplitContainer1.SplitterDistance" type="System.Int32, mscorlib">
+    <value>168</value>
+  </data>
+  <data name="LabelApiUsing.Location" type="System.Drawing.Point, System.Drawing">
+    <value>27, 215</value>
+  </data>
+  <data name="StartupReaded.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 25</value>
+  </data>
+  <data name="CheckShowGrid.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="ListTextCountApi.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="ConnectionTimeOut.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label37.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;RadioProxyNone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ConnectionPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items1" xml:space="preserve">
+    <value>Albanian</value>
+  </data>
+  <data name="Label71.Location" type="System.Drawing.Point, System.Drawing">
+    <value>19, 141</value>
+  </data>
+  <data name="btnDetailBack.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="TextProxyAddress.Size" type="System.Drawing.Size, System.Drawing">
+    <value>135, 19</value>
+  </data>
+  <data name="CheckAutoConvertUrl.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Label43.Size" type="System.Drawing.Size, System.Drawing">
+    <value>460, 49</value>
+  </data>
+  <data name="&gt;&gt;ReplyIconStateCombo.Parent" xml:space="preserve">
+    <value>PreviewPanel</value>
+  </data>
+  <data name="CheckDispUsername.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 43</value>
+  </data>
+  <data name="&gt;&gt;lblRetweet.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items8" xml:space="preserve">
+    <value>Arabic (Tunisia)</value>
+  </data>
+  <data name="Label34.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="HotkeyCode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="HotkeyText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>257, 13</value>
+  </data>
+  <data name="&gt;&gt;Label9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckListMemberRemovedEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="StatusText.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items113" xml:space="preserve">
+    <value>Thai</value>
+  </data>
+  <data name="ReplyPeriod.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;lblOWL.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;chkUnreadStyle.Parent" xml:space="preserve">
+    <value>TweetPrvPanel</value>
+  </data>
+  <data name="CmbDateTimeFormat.Items7" xml:space="preserve">
+    <value>H:mm</value>
+  </data>
+  <data name="&gt;&gt;lblInputBackcolor.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TextProxyUser.Parent" xml:space="preserve">
+    <value>ProxyPanel</value>
+  </data>
+  <data name="Label46.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 15</value>
+  </data>
+  <data name="btnOWL.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="CheckBalloonLimit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>249, 16</value>
+  </data>
+  <data name="&gt;&gt;AuthUserCombo.Name" xml:space="preserve">
+    <value>AuthUserCombo</value>
+  </data>
+  <data name="&gt;&gt;Label44.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CheckOpenUserTimeline.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items10" xml:space="preserve">
+    <value>Arabic (Yemen)</value>
+  </data>
+  <data name="UReadMng.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckBox3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>22, 215</value>
+  </data>
+  <data name="Label26.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;ListTextCountApi.Parent" xml:space="preserve">
+    <value>GetCountPanel</value>
+  </data>
+  <data name="Label59.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblTarget.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;Label43.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="Label65.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 12</value>
+  </data>
+  <data name="&gt;&gt;btnInputFont.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
+  </data>
+  <data name="UserTimelinePeriod.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items39" xml:space="preserve">
+    <value>English (Jamaica)</value>
+  </data>
+  <data name="&gt;&gt;IsPreviewFoursquareCheckBox.Parent" xml:space="preserve">
+    <value>CooperatePanel</value>
+  </data>
+  <data name="btnAtFromTarget.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 115</value>
+  </data>
+  <data name="&gt;&gt;UseChangeGetCount.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="MapThumbnailHeightTextBox.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ComboBoxTranslateLanguage.Items21" xml:space="preserve">
+    <value>Catalan</value>
+  </data>
+  <data name="MapThumbnailZoomTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>346, 46</value>
+  </data>
+  <data name="EmailText.Location" type="System.Drawing.Point, System.Drawing">
+    <value>143, 68</value>
+  </data>
+  <data name="CheckBlockEvent.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="TreeViewSetting.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label48.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="MapThumbnailHeightTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;MapThumbnailWidthTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="StatusText.Size" type="System.Drawing.Size, System.Drawing">
+    <value>232, 19</value>
+  </data>
+  <data name="TextCountApiReply.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="TextProxyAddress.Location" type="System.Drawing.Point, System.Drawing">
+    <value>114, 82</value>
+  </data>
+  <data name="CheckPreviewEnable.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;CheckFavEventUnread.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="AuthClearButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>303, 24</value>
+  </data>
+  <data name="UserTimelineTextCountApi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 19</value>
+  </data>
+  <data name="LabelProxyPort.Text" xml:space="preserve">
+    <value>ポート(&amp;P)</value>
+  </data>
+  <data name="&gt;&gt;lblOWL.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
+  <data name="Label55.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="HotkeyAlt.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 16</value>
+  </data>
+  <data name="&gt;&gt;lblInputBackcolor.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="TextProxyPort.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Disable</value>
+  </data>
+  <data name="&gt;&gt;ComboBoxOutputzUrlmode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblListBackcolor.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>AppendSettingDialog</value>
+  </data>
+  <data name="FontPanel2.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="lblRetweet.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="Label45.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;HotkeyShift.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CheckFavoritesEvent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 16</value>
+  </data>
+  <data name="LanguageCombo.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="CheckShowGrid.Text" xml:space="preserve">
+    <value>リストの区切り線を表示する</value>
+  </data>
+  <data name="Label28.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 12</value>
+  </data>
+  <data name="lblAtTarget.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="GroupBox2.Text" xml:space="preserve">
+    <value>Tweenサポート</value>
+  </data>
+  <data name="lblOWL.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="ComboBoxTranslateLanguage.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label19.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Label41.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 12</value>
+  </data>
+  <data name="&gt;&gt;UserstreamPeriod.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblDetailLink.Text" xml:space="preserve">
+    <value>This is sample.</value>
+  </data>
+  <data name="&gt;&gt;Label64.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="GroupBox5.Text" xml:space="preserve">
+    <value>フォント＆色設定</value>
+  </data>
+  <data name="&gt;&gt;HotkeyWin.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
+  </data>
+  <data name="ListTextCountApi.Location" type="System.Drawing.Point, System.Drawing">
+    <value>308, 183</value>
+  </data>
+  <data name="ListDoubleClickActionComboBox.Items7" xml:space="preserve">
+    <value>なし</value>
+  </data>
   <metadata name="FontDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="ToolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>268, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>82</value>
   </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>8, 15</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>921, 504</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>            </value>
-  </data>
-  <data name="&gt;&gt;ColorDialog1.Name" xml:space="preserve">
-    <value>ColorDialog1</value>
-  </data>
-  <data name="&gt;&gt;ColorDialog1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColorDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FontDialog1.Name" xml:space="preserve">
-    <value>FontDialog1</value>
-  </data>
-  <data name="&gt;&gt;FontDialog1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FontDialog, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ToolTip1.Name" xml:space="preserve">
-    <value>ToolTip1</value>
-  </data>
-  <data name="&gt;&gt;ToolTip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>AppendSettingDialog</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
+  <metadata name="ColorDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>140, 17</value>
+  </metadata>
 </root>

--- a/OpenTween/Setting/SettingCommon.cs
+++ b/OpenTween/Setting/SettingCommon.cs
@@ -136,6 +136,12 @@ namespace OpenTween
         public bool CloseToExit = false;
         public MyCommon.DispTitleEnum DispLatestPost = MyCommon.DispTitleEnum.Post;
         public bool SortOrderLock = false;
+
+        /// <summary>
+        /// タブを下部に表示するかどうか
+        /// </summary>
+        public bool ViewTabBottom = true;
+
         public bool TinyUrlResolve = true;
         public bool ShortUrlForceResolve = false;
         public bool PeriodAdjust = true;

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -725,6 +725,7 @@ namespace OpenTween
             SettingDialog.MinimizeToTray = _cfgCommon.MinimizeToTray;
             SettingDialog.DispLatestPost = _cfgCommon.DispLatestPost;
             SettingDialog.SortOrderLock = _cfgCommon.SortOrderLock;
+            SettingDialog.ViewTabBottom = _cfgCommon.ViewTabBottom;
             SettingDialog.TinyUrlResolve = _cfgCommon.TinyUrlResolve;
             SettingDialog.ShortUrlForceResolve = _cfgCommon.ShortUrlForceResolve;
 
@@ -1274,6 +1275,9 @@ namespace OpenTween
                 // 初回起動時だけ右下のメニューを目立たせる
                 HashStripSplitButton.ShowDropDown();
             }
+
+            // タブの位置を調整する
+            SetTabAlignment();
         }
 
         private void CreatePictureServices()
@@ -3997,6 +4001,9 @@ namespace OpenTween
                         throw;
                     }
 
+                    // タブの表示位置の決定
+                    SetTabAlignment();
+
                     PlaySoundMenuItem.Checked = SettingDialog.PlaySound;
                     this.PlaySoundFileMenuItem.Checked = SettingDialog.PlaySound;
                     _fntUnread = SettingDialog.FontUnread;
@@ -4169,6 +4176,14 @@ namespace OpenTween
 
             this.TopMost = SettingDialog.AlwaysTop;
             SaveConfigsAll(false);
+        }
+
+        /// <summary>
+        /// タブの表示位置を設定する
+        /// </summary>
+        private void SetTabAlignment()
+        {
+            ListTab.Alignment = (SettingDialog.ViewTabBottom ? TabAlignment.Bottom : TabAlignment.Top);
         }
 
         private void PostBrowser_Navigated(object sender, WebBrowserNavigatedEventArgs e)
@@ -7718,6 +7733,7 @@ namespace OpenTween
                 _cfgCommon.CloseToExit = SettingDialog.CloseToExit;
                 _cfgCommon.DispLatestPost = SettingDialog.DispLatestPost;
                 _cfgCommon.SortOrderLock = SettingDialog.SortOrderLock;
+                _cfgCommon.ViewTabBottom = SettingDialog.ViewTabBottom;
                 _cfgCommon.TinyUrlResolve = SettingDialog.TinyUrlResolve;
                 _cfgCommon.ShortUrlForceResolve = SettingDialog.ShortUrlForceResolve;
                 _cfgCommon.PeriodAdjust = SettingDialog.PeriodAdjust;
@@ -12336,8 +12352,6 @@ namespace OpenTween
             {
                 ImageSelectedPicture.Image = ImageSelectedPicture.InitialImage;
                 ImageSelectedPicture.Tag = MyCommon.UploadFileType.Invalid;
-                TimelinePanel.Visible = true;
-                TimelinePanel.Enabled = true;
                 ImageSelectionPanel.Visible = false;
                 ImageSelectionPanel.Enabled = false;
                 ((DetailsListView)ListTab.SelectedTab.Tag).Focus();
@@ -12395,8 +12409,6 @@ namespace OpenTween
         private void ImageCancelButton_Click(object sender, EventArgs e)
         {
             ImagefilePathText.CausesValidation = false;
-            TimelinePanel.Visible = true;
-            TimelinePanel.Enabled = true;
             ImageSelectionPanel.Visible = false;
             ImageSelectionPanel.Enabled = false;
             ((DetailsListView)ListTab.SelectedTab.Tag).Focus();


### PR DESCRIPTION
見た目のカスタマイズ要素を1つ増やしました。

タブが下についているのが気持ち悪いので、上にも表示できるようにして、慣れたほうで使えるようにしてあります。
