### PR TITLE
DetailsListView の描画範囲制御を 1.0.9 相当に戻す

### DIFF
--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -2055,7 +2055,8 @@ namespace OpenTween
 
             if (_post == null) return;
 
-            var itemColorTuple = new Tuple<ListViewItem, Color>[] { };
+            var itemColors = new Color[] { };
+            int itemIndex = -1;
 
             this.itemCacheLock.EnterReadLock();
             try
@@ -2064,17 +2065,20 @@ namespace OpenTween
 
                 var query = 
                     from i in Enumerable.Range(0, this._itemCache.Length)
-                    select new Tuple<ListViewItem, Color>(this._itemCache[i], this.JudgeColor(_post, this._postCache[i]));
+                    select this.JudgeColor(_post, this._postCache[i]);
                 
-                itemColorTuple = query.ToArray();
+                itemColors = query.ToArray();
+                itemIndex = _itemCacheIndex;
             }
             finally { this.itemCacheLock.ExitReadLock(); }
 
-            foreach (var tuple in itemColorTuple)
+            if (itemIndex < 0) return;
+
+            foreach (var backColor in itemColors)
             {
                 // この処理中に MyList_CacheVirtualItems が呼ばれることがあるため、
                 // 同一スレッド内での二重ロックを避けるためにロックの外で実行する必要がある
-                tuple.Item1.SubItems[0].BackColor = tuple.Item2;
+                _curList.ChangeItemBackColor(itemIndex++, backColor);
             }
         }
 

--- a/OpenTween/Win32Api.cs
+++ b/OpenTween/Win32Api.cs
@@ -546,6 +546,11 @@ namespace OpenTween
         private const Int32 FLASHW_TIMERNOFG = 0xC;
         #endregion
 
+        [DllImport("user32.dll")]
+        public static extern bool ValidateRect(
+            IntPtr hwnd,
+            IntPtr rect);
+
         #region "スクリーンセーバー起動中か判定"
         [DllImport("user32", CharSet = CharSet.Auto)]
         private static extern int SystemParametersInfo(


### PR DESCRIPTION
1.1.0 での変更で DetailsListView から描画範囲を制御するコードが削除されましたが、VM上のXPで確認したところ、スクロールの処理がかなり重くなってしまってます。
1.0.9 のコードでは問題なくスクロールできるため、特に問題がなければ戻した方がいいのではないかと思いますが、いかがでしょうか？

加えて、Postキャッシュを使用する部分のロック処理を厳密にしてあります。DetailsListView での変更はデッドロック回避のためと思いますが、コードを戻して数日使用してみて、今のところデッドロック等は起こっていません。
