### PR TITLE
使用する画像投稿サービスの読み込み/保存に、インデックス値ではなくサービス名を使う

### DIFF
--- a/OpenTween/Setting/SettingCommon.cs
+++ b/OpenTween/Setting/SettingCommon.cs
@@ -199,6 +199,7 @@ namespace OpenTween
         public bool OpenUserTimeline = true;
         public int ListCountApi = 100;
         public int UseImageService = 0;
+        public string UseImageServiceName = "";
         public int ListDoubleClickAction = 0;
         public string UserAppointUrl = "";
         public bool HideDuplicatedRetweets = false;

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -977,7 +977,7 @@ namespace OpenTween
             SetImageServiceCombo();
             ImageSelectionPanel.Enabled = false;
 
-            ImageServiceCombo.SelectedIndex = _cfgCommon.UseImageService;
+            SelectImageServiceComboItem(_cfgCommon.UseImageServiceName, _cfgCommon.UseImageService);
 
             //ウィンドウ設定
             this.ClientSize = _cfgLocal.FormSize;
@@ -7858,6 +7858,7 @@ namespace OpenTween
                 _cfgCommon.OpenUserTimeline = SettingDialog.OpenUserTimeline;
                 _cfgCommon.ListCountApi = SettingDialog.ListCountApi;
                 _cfgCommon.UseImageService = ImageServiceCombo.SelectedIndex;
+                _cfgCommon.UseImageServiceName = this.ImageService;
                 _cfgCommon.ListDoubleClickAction = SettingDialog.ListDoubleClickAction;
                 _cfgCommon.UserAppointUrl = SettingDialog.UserAppointUrl;
                 _cfgCommon.HideDuplicatedRetweets = SettingDialog.HideDuplicatedRetweets;
@@ -12451,23 +12452,35 @@ namespace OpenTween
                 ImageServiceCombo.Items.Add(key);
             }
 
+            SelectImageServiceComboItem(svc);
+        }
+
+        private void SelectImageServiceComboItem(string svc, int? index = null)
+        {
+            int idx;
             if (string.IsNullOrEmpty(svc))
             {
-                ImageServiceCombo.SelectedIndex = 0;
+                idx = index ?? 0;
             }
             else
             {
-                int idx = ImageServiceCombo.Items.IndexOf(svc);
-                if (idx == -1)
-                    ImageServiceCombo.SelectedIndex = 0;
-                else
-                    ImageServiceCombo.SelectedIndex = idx;
+                idx = ImageServiceCombo.Items.IndexOf(svc);
+                if (idx == -1) idx = index ?? 0;
+            }
+
+            try
+            {
+                ImageServiceCombo.SelectedIndex = idx;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                ImageServiceCombo.SelectedIndex = 0;
             }
         }
 
         private string ImageService
         {
-            get { return (string)ImageServiceCombo.SelectedItem; }
+            get { return ImageServiceCombo.SelectedItem.ToString(); }
         }
 
         private void ImageCancelButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
SettingCommon.xml に UseImageServiceName を追加し、画像投稿サービス名で選択項目を初期化します。Tween にも同一設定があるようなので、お互いに投稿サービスのインデックス値が異なっていても、サービス名さえ同じであれば、設定を維持できると思います。
（UseImageService は互換性のためそのまま）
