### PR TITLE
ツイート選択時にサムネイル枠のスクロールバー選択位置を初期化する

### DIFF
--- a/OpenTween/TweetThumbnail.cs
+++ b/OpenTween/TweetThumbnail.cs
@@ -111,8 +111,6 @@ namespace OpenTween
                             cancelToken.ThrowIfCancellationRequested();
                         }
 
-                        this.scrollBar.Maximum = thumbnails.Count - 1;
-
                         if (thumbnails.Count > 1)
                             this.scrollBar.Enabled = true;
 
@@ -206,8 +204,6 @@ namespace OpenTween
         {
             this.SuspendLayout();
 
-            this.scrollBar.Maximum = count;
-
             this.panelPictureBox.Controls.Clear();
             foreach (var picbox in this.pictureBox)
             {
@@ -218,6 +214,9 @@ namespace OpenTween
                     memoryImage.Dispose();
             }
             this.pictureBox.Clear();
+
+            this.scrollBar.Maximum = (count > 0) ? count - 1 : 0;
+            this.scrollBar.Value = 0;
 
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
複数の画像 URL を持つツイート間を移動する際に、スクロールバーの位置が初期化されず、選択状態がおかしくなるバグの修正です。
