### PR TITLE
TweenMain, ListTab のイベントハンドラ名をコントロール名で統一

### DIFF
--- a/OpenTween/Tween.Designer.cs
+++ b/OpenTween/Tween.Designer.cs
@@ -566,12 +566,12 @@
             this.ListTab.SelectedIndexChanged += new System.EventHandler(this.ListTab_SelectedIndexChanged);
             this.ListTab.Selecting += new System.Windows.Forms.TabControlCancelEventHandler(this.ListTab_Selecting);
             this.ListTab.Deselected += new System.Windows.Forms.TabControlEventHandler(this.ListTab_Deselected);
-            this.ListTab.DragDrop += new System.Windows.Forms.DragEventHandler(this.Tabs_DragDrop);
-            this.ListTab.DragEnter += new System.Windows.Forms.DragEventHandler(this.Tabs_DragEnter);
+            this.ListTab.DragDrop += new System.Windows.Forms.DragEventHandler(this.ListTab_DragDrop);
+            this.ListTab.DragEnter += new System.Windows.Forms.DragEventHandler(this.ListTab_DragEnter);
             this.ListTab.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ListTab_KeyDown);
             this.ListTab.MouseClick += new System.Windows.Forms.MouseEventHandler(this.ListTab_MouseClick);
-            this.ListTab.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.Tabs_DoubleClick);
-            this.ListTab.MouseDown += new System.Windows.Forms.MouseEventHandler(this.Tabs_MouseDown);
+            this.ListTab.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ListTab_DoubleClick);
+            this.ListTab.MouseDown += new System.Windows.Forms.MouseEventHandler(this.ListTab_MouseDown);
             this.ListTab.MouseMove += new System.Windows.Forms.MouseEventHandler(this.ListTab_MouseMove);
             this.ListTab.MouseUp += new System.Windows.Forms.MouseEventHandler(this.ListTab_MouseUp);
             // 
@@ -2499,11 +2499,11 @@
             this.ToolTip1.SetToolTip(this, resources.GetString("$this.ToolTip"));
             this.Activated += new System.EventHandler(this.TweenMain_Activated);
             this.Deactivate += new System.EventHandler(this.TweenMain_Deactivate);
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Tween_FormClosing);
-            this.Load += new System.EventHandler(this.Form1_Load);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.TweenMain_FormClosing);
+            this.Load += new System.EventHandler(this.TweenMain_Load);
             this.Shown += new System.EventHandler(this.TweenMain_Shown);
-            this.ClientSizeChanged += new System.EventHandler(this.Tween_ClientSizeChanged);
-            this.LocationChanged += new System.EventHandler(this.Tween_LocationChanged);
+            this.ClientSizeChanged += new System.EventHandler(this.TweenMain_ClientSizeChanged);
+            this.LocationChanged += new System.EventHandler(this.TweenMain_LocationChanged);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.TweenMain_DragDrop);
             this.DragOver += new System.Windows.Forms.DragEventHandler(this.TweenMain_DragOver);
             this.Resize += new System.EventHandler(this.TweenMain_Resize);

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -519,7 +519,7 @@ namespace OpenTween
             }
         }
 
-        private void Form1_Load(object sender, EventArgs e)
+        private void TweenMain_Load(object sender, EventArgs e)
         {
             _ignoreConfigSave = true;
             this.Visible = false;
@@ -2335,7 +2335,7 @@ namespace OpenTween
             this.Close();
         }
 
-        private void Tween_FormClosing(object sender, FormClosingEventArgs e)
+        private void TweenMain_FormClosing(object sender, FormClosingEventArgs e)
         {
             if (!SettingDialog.CloseToExit && e.CloseReason == CloseReason.UserClosing && MyCommon._endingFlag == false)
             {
@@ -3370,7 +3370,7 @@ namespace OpenTween
                 OpenUriAsync(MyCommon.TwitterUrl + "#!/" + GetCurTabPost(_curList.SelectedIndices[0]).ScreenName + "/favorites");
         }
 
-        private void Tween_ClientSizeChanged(object sender, EventArgs e)
+        private void TweenMain_ClientSizeChanged(object sender, EventArgs e)
         {
             if ((!_initialLayout) && this.Visible)
             {
@@ -3452,7 +3452,7 @@ namespace OpenTween
             _modifySettingCommon = true;
         }
 
-        private void Tween_LocationChanged(object sender, EventArgs e)
+        private void TweenMain_LocationChanged(object sender, EventArgs e)
         {
             if (this.WindowState == FormWindowState.Normal && !_initialLayout)
             {
@@ -8076,13 +8076,13 @@ namespace OpenTween
             }
         }
 
-        private void Tabs_DoubleClick(object sender, MouseEventArgs e)
+        private void ListTab_DoubleClick(object sender, MouseEventArgs e)
         {
             string tn = ListTab.SelectedTab.Text;
             TabRename(ref tn);
         }
 
-        private void Tabs_MouseDown(object sender, MouseEventArgs e)
+        private void ListTab_MouseDown(object sender, MouseEventArgs e)
         {
             if (SettingDialog.TabMouseLock) return;
             Point cpos = new Point(e.X, e.Y);
@@ -8104,7 +8104,7 @@ namespace OpenTween
             }
         }
 
-        private void Tabs_DragEnter(object sender, DragEventArgs e)
+        private void ListTab_DragEnter(object sender, DragEventArgs e)
         {
             if (e.Data.GetDataPresent(typeof(TabPage)))
                 e.Effect = DragDropEffects.Move;
@@ -8112,7 +8112,7 @@ namespace OpenTween
                 e.Effect = DragDropEffects.None;
         }
 
-        private void Tabs_DragDrop(object sender, DragEventArgs e)
+        private void ListTab_DragDrop(object sender, DragEventArgs e)
         {
             if (!e.Data.GetDataPresent(typeof(TabPage))) return;
 


### PR DESCRIPTION
イベントハンドラ名が Form1_Load だったり TweenMain_Shown だったり Tween_FormClosing だったりしたので、それぞれコントロール名で統一しました。
