### PR TITLE
高DPI環境下で詳細発言欄のプロフィール画像が拡大されない問題を修正

### DIFF
--- a/OpenTween/OTPictureBox.cs
+++ b/OpenTween/OTPictureBox.cs
@@ -50,6 +50,16 @@ namespace OpenTween
         }
         private MemoryImage memoryImage;
 
+        public new PictureBoxSizeMode SizeMode
+        {
+            get { return base.SizeMode; }
+            set
+            {
+                base.SizeMode = value;
+                this.previousSizeMode = value;
+            }
+        }
+
         /// <summary>
         /// InitialImage や ErrorImage の表示に SizeMode を一時的に変更するため、
         /// 以前の SizeMode を記憶しておくためのフィールド
@@ -65,7 +75,7 @@ namespace OpenTween
             base.Image = base.InitialImage;
 
             // InitialImage は SizeMode の値に依らず中央等倍に表示する必要がある
-            this.SizeMode = PictureBoxSizeMode.CenterImage;
+            base.SizeMode = PictureBoxSizeMode.CenterImage;
         }
 
         public void ShowErrorImage()
@@ -77,7 +87,7 @@ namespace OpenTween
             base.Image = base.ErrorImage;
 
             // ErrorImage は SizeMode の値に依らず中央等倍に表示する必要がある
-            this.SizeMode = PictureBoxSizeMode.CenterImage;
+            base.SizeMode = PictureBoxSizeMode.CenterImage;
         }
 
         private void RestoreSizeMode()


### PR DESCRIPTION
SizeMode プロパティが、初期値 Normal から Tween.resx ファイルの内容を適用されて Zoom になり、その後 Image プロパティへの代入によって 未初期化の previousSizeMode (= Normal) へと置き換わるため、拡大されなくなってしまうようです。
OTPictureBox.SizeMode への代入時に、previousSizeMode も書き換えておくように変更しました。
