### PR TITLE
Tweet時のエラー対策

### DIFF
--- a/OpenTween/Connection/HttpConnection.cs
+++ b/OpenTween/Connection/HttpConnection.cs
@@ -110,6 +110,9 @@ namespace OpenTween
 
             webReq.UserAgent = Networking.GetUserAgentString();
 
+            // KeepAlive無効なサーバー(Twitter等)に使用すると、タイムアウト後にWebExceptionが発生する場合あり
+            webReq.KeepAlive = false;
+
             return webReq;
         }
 
@@ -257,6 +260,9 @@ namespace OpenTween
             if (this.UseCookie) webReq.CookieContainer = this.cookieContainer;
             //タイムアウト設定
             webReq.Timeout = this.InstanceTimeout ?? (int)Networking.DefaultTimeout.TotalMilliseconds;
+
+            // KeepAlive無効なサーバー(Twitter等)に使用すると、タイムアウト後にWebExceptionが発生する場合あり
+            webReq.KeepAlive = false;
 
             return webReq;
         }


### PR DESCRIPTION
投稿エラーが最近よく出るので、原因と思われる部分に手を入れました。
自分の環境では昨日・今日と発生数が0になり、今晩22～23時あたりにフォロワー数名にバイナリ配って使っていただいたところ、エラーは起きていないようです。

捕まえた例外は以下のもの。
![clipboard02](https://cloud.githubusercontent.com/assets/1900919/4109640/cb8eaba0-31e7-11e4-8de9-bcd0688fb303.jpg)

OpenTween内で、KeepAliveが有用な用途(接続)があるのであれば、あちこちにenable_keepaliveみたいな引数を渡していく感じにするのでしょうが、現状思いつかないので、HttpConnectionのCreateRequestにベタ書きです。

ひとつ心配なのは、挙動が変わってはいないけれどもエラーメッセージが変わったバグ(?)があるらしいことです。
https://twitter.com/tsh_paper/status/506444290822639616
KeepAliveの例外の後ろに隠れていたものが出てきたのではないかと思いますが…。こちらは手元の環境で再現しないため、ちょっと困っています。
