### PR TITLE
(OSDN チケット # 35234)発言内URLを開くの挙動修正

### DIFF
--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -4513,7 +4513,8 @@ namespace OpenTween
             else if (e.Url.AbsoluteUri != "about:blank")
             {
                 e.Cancel = true;
-                await this.OpenUriAsync(e.Url);
+                // Ctrlを押しながらリンクを開いた場合は、設定と逆の動作をするフラグを true としておく
+                await this.OpenUriAsync( e.Url, MyCommon.IsKeyDown( Keys.Control ) );
             }
         }
 
@@ -10937,7 +10938,7 @@ namespace OpenTween
             return nw;
         }
 
-        public async Task OpenUriAsync(Uri uri)
+        public async Task OpenUriAsync(Uri uri, bool isReverseSettings = false)
         {
             var uriStr = uri.AbsoluteUri;
 
@@ -10966,9 +10967,9 @@ namespace OpenTween
             }
 
             // ユーザープロフィールURL
-            // Ctrlを押しながらリンクをクリックした場合は設定と逆の動作をする
-            if (this._cfgCommon.OpenUserTimeline && !MyCommon.IsKeyDown(Keys.Control) ||
-                !this._cfgCommon.OpenUserTimeline && MyCommon.IsKeyDown(Keys.Control))
+            // フラグが立っている場合は設定と逆の動作をする
+            if( this._cfgCommon.OpenUserTimeline && !isReverseSettings ||
+                !this._cfgCommon.OpenUserTimeline && isReverseSettings )
             {
                 var userUriMatch = Regex.Match(uriStr, "^https?://twitter.com/(#!/)?(?<ScreenName>[a-zA-Z0-9_]+)$");
                 if (userUriMatch.Success)


### PR DESCRIPTION
[OSDN チケット #35234](http://osdn.jp/ticket/browse.php?group_id=6526&tid=35234) の不具合修正です。

操作 ＞ 開く ＞ 発言内URLを開く　の処理がショートカットキー `Ctrl + E` となっていますが、URLを開く処理( TweenMainクラスの `OpenUriAsync` 関数 )内にて「Ctrlを押しながらリンクをクリックした場合は設定と逆の動作をする」処理があり、ここでCtrlキーが押されている判定になってしまっているために発生していたため、それを回避するよう修正致しました。
ご検討いただければ幸いです(o_ _)o

※クリック以外にも、リンク部分をTab等で選択しEnterで開く事も出来たため、コメントを若干修正しています。