### PR TITLE
検索ワード変更時に「前データを取得」が出来なくなることの修正

### DIFF
--- a/OpenTween/StatusDictionary.cs
+++ b/OpenTween/StatusDictionary.cs
@@ -1545,6 +1545,7 @@ namespace OpenTween
             set
             {
                 SinceId = 0;
+                OldestId = long.MaxValue;
                 _searchWords = value.Trim();
             }
         }


### PR DESCRIPTION
- 既存の挙動

PublicSearchタブの上部入力欄で検索ワードを変更した後、「前データを取得」で何も取得できないことがありました。問題のあるケースで、Twitter statusのID関係を調べると、次のようになっていました。
```
619878191180574721 ← 検索ワードを新しくしたあとの、タブ上にある最古ID
619340664858251263 ← APIを叩いたときのmax_id、おそらく旧検索でタブ上にあったデータから算出
```

- 変更内容

検索ワード変更時にOldestId(クエリーのmax_id相当)をリセットします。ここでSinceIdもリセットされているので、一緒のタイミングで。値は、クラス初期化のときと同じにしています。