### PR TITLE
Fixes label of the Start Authentication button.

### DIFF
--- a/OpenTween/Setting/Panel/BasedPanel.en.resx
+++ b/OpenTween/Setting/Panel/BasedPanel.en.resx
@@ -121,7 +121,7 @@
     <value>Sign up for Twitter account</value>
   </data>
   <data name="StartAuthButton.Text" xml:space="preserve">
-    <value>Start Authentiation</value>
+    <value>Start Authentication</value>
   </data>
   <data name="AuthClearButton.Text" xml:space="preserve">
     <value>Remove</value>


### PR DESCRIPTION
Authentication was spelled "Authentiation"