### PR TITLE
二重起動時に既存のプロセスがアクティブにならない問題の修正

### DIFF
--- a/OpenTween/ApplicationEvents.cs
+++ b/OpenTween/ApplicationEvents.cs
@@ -139,19 +139,15 @@ namespace OpenTween
         {
             // 実行中の同じアプリケーションのウィンドウ・ハンドルの取得
             var prevProcess = GetPreviousProcess();
-            if (prevProcess == null || prevProcess.MainWindowHandle == IntPtr.Zero)
+            if (prevProcess == null)
             {
                 return;
             }
 
-            var form = Control.FromHandle(prevProcess.MainWindowHandle) as Form;
-            if (form != null)
+            IntPtr windowHandle = NativeMethods.GetWindowHandle((uint)prevProcess.Id, Application.ProductName);
+            if (windowHandle != IntPtr.Zero)
             {
-                if (form.WindowState == FormWindowState.Minimized)
-                {
-                    NativeMethods.RestoreWindow(form);
-                }
-                form.Activate();
+                NativeMethods.SetActiveWindow(windowHandle);
             }
         }
 


### PR DESCRIPTION
二重起動時に既存のプロセスのウィンドウがアクティブにならない問題を修正してみました。
NativeMethods.csに実装しましたが、方針に沿わなければご指摘願います。

【変更点】
ウィンドウが表示されていない状態ではProcess.MainWindowHandleが正しいハンドルを返さない問題があったため、ウィンドウハンドルの検索とアクティブ化をWin32 APIで実装しました。