### PR TITLE
140字を越えるツイートの投稿に対応

### DIFF
--- a/OpenTween.Tests/Api/TwitterApiTest.cs
+++ b/OpenTween.Tests/Api/TwitterApiTest.cs
@@ -223,6 +223,7 @@ namespace OpenTween.Api
                             { "media_ids", "10,20" },
                             { "auto_populate_reply_metadata", "true" },
                             { "exclude_reply_user_ids", "100,200" },
+                            { "attachment_url", "https://twitter.com/twitterapi/status/22634515958" },
                         })
                 )
                 .ReturnsAsync(LazyJson.Create(new TwitterStatus()));
@@ -230,7 +231,8 @@ namespace OpenTween.Api
                 twitterApi.apiConnection = mock.Object;
 
                 await twitterApi.StatusesUpdate("hogehoge", replyToId: 100L, mediaIds: new[] { 10L, 20L },
-                        autoPopulateReplyMetadata: true, excludeReplyUserIds: new[] { 100L, 200L })
+                        autoPopulateReplyMetadata: true, excludeReplyUserIds: new[] { 100L, 200L },
+                        attachmentUrl: "https://twitter.com/twitterapi/status/22634515958")
                     .IgnoreResponse()
                     .ConfigureAwait(false);
 

--- a/OpenTween.Tests/Api/TwitterApiTest.cs
+++ b/OpenTween.Tests/Api/TwitterApiTest.cs
@@ -221,13 +221,16 @@ namespace OpenTween.Api
                             { "tweet_mode", "extended" },
                             { "in_reply_to_status_id", "100" },
                             { "media_ids", "10,20" },
+                            { "auto_populate_reply_metadata", "true" },
+                            { "exclude_reply_user_ids", "100,200" },
                         })
                 )
                 .ReturnsAsync(LazyJson.Create(new TwitterStatus()));
 
                 twitterApi.apiConnection = mock.Object;
 
-                await twitterApi.StatusesUpdate("hogehoge", replyToId: 100L, mediaIds: new[] { 10L, 20L })
+                await twitterApi.StatusesUpdate("hogehoge", replyToId: 100L, mediaIds: new[] { 10L, 20L },
+                        autoPopulateReplyMetadata: true, excludeReplyUserIds: new[] { 100L, 200L })
                     .IgnoreResponse()
                     .ConfigureAwait(false);
 

--- a/OpenTween.Tests/Api/TwitterApiTest.cs
+++ b/OpenTween.Tests/Api/TwitterApiTest.cs
@@ -239,6 +239,35 @@ namespace OpenTween.Api
         }
 
         [Fact]
+        public async Task StatusesUpdate_ExcludeReplyUserIdsEmptyTest()
+        {
+            using (var twitterApi = new TwitterApi())
+            {
+                var mock = new Mock<IApiConnection>();
+                mock.Setup(x =>
+                    x.PostLazyAsync<TwitterStatus>(
+                        new Uri("statuses/update.json", UriKind.Relative),
+                        new Dictionary<string, string> {
+                            { "status", "hogehoge" },
+                            { "include_entities", "true" },
+                            { "include_ext_alt_text", "true" },
+                            { "tweet_mode", "extended" },
+                            // exclude_reply_user_ids は空の場合には送信されない
+                        })
+                )
+                .ReturnsAsync(LazyJson.Create(new TwitterStatus()));
+
+                twitterApi.apiConnection = mock.Object;
+
+                await twitterApi.StatusesUpdate("hogehoge", replyToId: null, mediaIds: null, excludeReplyUserIds: new long[0])
+                    .IgnoreResponse()
+                    .ConfigureAwait(false);
+
+                mock.VerifyAll();
+            }
+        }
+
+        [Fact]
         public async Task StatusesDestroy_Test()
         {
             using (var twitterApi = new TwitterApi())

--- a/OpenTween.Tests/Models/PostClassTest.cs
+++ b/OpenTween.Tests/Models/PostClassTest.cs
@@ -191,7 +191,7 @@ namespace OpenTween.Models
                 InReplyToUser = "hogehoge",
                 InReplyToUserId = 100L,
                 IsReply = true,
-                ReplyToList = new List<string> {"hogehoge"},
+                ReplyToList = new List<Tuple<long, string>> { Tuple.Create(100L, "hogehoge") },
             };
 
             post.IsDeleted = true;

--- a/OpenTween.Tests/TwitterTest.cs
+++ b/OpenTween.Tests/TwitterTest.cs
@@ -55,6 +55,22 @@ namespace OpenTween
         }
 
         [Theory]
+        [InlineData("https://twitter.com/twitterapi/status/22634515958", true)]
+        [InlineData("http://twitter.com/twitterapi/status/22634515958", true)]
+        [InlineData("https://mobile.twitter.com/twitterapi/status/22634515958", true)]
+        [InlineData("http://mobile.twitter.com/twitterapi/status/22634515958", true)]
+        [InlineData("https://twitter.com/i/web/status/22634515958", false)]
+        [InlineData("https://twitter.com/imgazyobuzi/status/293333871171354624/photo/1", false)]
+        [InlineData("https://pic.twitter.com/gbxdb2Oj", false)]
+        [InlineData("https://twitter.com/messages/compose?recipient_id=514241801", true)]
+        [InlineData("http://twitter.com/messages/compose?recipient_id=514241801", true)]
+        [InlineData("https://twitter.com/messages/compose?recipient_id=514241801&text=%E3%81%BB%E3%81%92", true)]
+        public void AttachmentUrlRegexTest(string url, bool isMatch)
+        {
+            Assert.Equal(isMatch, Twitter.AttachmentUrlRegex.IsMatch(url));
+        }
+
+        [Theory]
         [InlineData("http://favstar.fm/users/twitterapi/status/22634515958", new[] { "22634515958" })]
         [InlineData("http://ja.favstar.fm/users/twitterapi/status/22634515958", new[] { "22634515958" })]
         [InlineData("http://favstar.fm/t/22634515958", new[] { "22634515958" })]

--- a/OpenTween/Api/TwitterApi.cs
+++ b/OpenTween/Api/TwitterApi.cs
@@ -127,7 +127,7 @@ namespace OpenTween.Api
         }
 
         public Task<LazyJson<TwitterStatus>> StatusesUpdate(string status, long? replyToId, IReadOnlyList<long> mediaIds,
-            bool? autoPopulateReplyMetadata = null, IReadOnlyList<long> excludeReplyUserIds = null)
+            bool? autoPopulateReplyMetadata = null, IReadOnlyList<long> excludeReplyUserIds = null, string attachmentUrl = null)
         {
             var endpoint = new Uri("statuses/update.json", UriKind.Relative);
             var param = new Dictionary<string, string>
@@ -146,6 +146,8 @@ namespace OpenTween.Api
                 param["auto_populate_reply_metadata"] = autoPopulateReplyMetadata.Value ? "true" : "false";
             if (excludeReplyUserIds != null && excludeReplyUserIds.Count > 0)
                 param["exclude_reply_user_ids"] = string.Join(",", excludeReplyUserIds);
+            if (attachmentUrl != null)
+                param["attachment_url"] = attachmentUrl;
 
             return this.apiConnection.PostLazyAsync<TwitterStatus>(endpoint, param);
         }

--- a/OpenTween/Api/TwitterApi.cs
+++ b/OpenTween/Api/TwitterApi.cs
@@ -126,7 +126,8 @@ namespace OpenTween.Api
             return this.apiConnection.GetAsync<TwitterStatus>(endpoint, param, "/statuses/show/:id");
         }
 
-        public Task<LazyJson<TwitterStatus>> StatusesUpdate(string status, long? replyToId, IReadOnlyList<long> mediaIds)
+        public Task<LazyJson<TwitterStatus>> StatusesUpdate(string status, long? replyToId, IReadOnlyList<long> mediaIds,
+            bool? autoPopulateReplyMetadata = null, IReadOnlyList<long> excludeReplyUserIds = null)
         {
             var endpoint = new Uri("statuses/update.json", UriKind.Relative);
             var param = new Dictionary<string, string>
@@ -141,6 +142,10 @@ namespace OpenTween.Api
                 param["in_reply_to_status_id"] = replyToId.ToString();
             if (mediaIds != null && mediaIds.Count > 0)
                 param.Add("media_ids", string.Join(",", mediaIds));
+            if (autoPopulateReplyMetadata != null)
+                param["auto_populate_reply_metadata"] = autoPopulateReplyMetadata.Value ? "true" : "false";
+            if (excludeReplyUserIds != null)
+                param["exclude_reply_user_ids"] = string.Join(",", excludeReplyUserIds);
 
             return this.apiConnection.PostLazyAsync<TwitterStatus>(endpoint, param);
         }

--- a/OpenTween/Api/TwitterApi.cs
+++ b/OpenTween/Api/TwitterApi.cs
@@ -144,7 +144,7 @@ namespace OpenTween.Api
                 param.Add("media_ids", string.Join(",", mediaIds));
             if (autoPopulateReplyMetadata != null)
                 param["auto_populate_reply_metadata"] = autoPopulateReplyMetadata.Value ? "true" : "false";
-            if (excludeReplyUserIds != null)
+            if (excludeReplyUserIds != null && excludeReplyUserIds.Count > 0)
                 param["exclude_reply_user_ids"] = string.Join(",", excludeReplyUserIds);
 
             return this.apiConnection.PostLazyAsync<TwitterStatus>(endpoint, param);

--- a/OpenTween/Connection/IMediaUploadService.cs
+++ b/OpenTween/Connection/IMediaUploadService.cs
@@ -73,7 +73,7 @@ namespace OpenTween.Connection
         /// メディアのアップロードとツイートの投稿を行います
         /// </summary>
         /// <exception cref="WebApiException"/>
-        Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems);
+        Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds);
 
         /// <summary>
         /// 画像URLのために確保する必要のある文字数を返します

--- a/OpenTween/Connection/IMediaUploadService.cs
+++ b/OpenTween/Connection/IMediaUploadService.cs
@@ -73,7 +73,7 @@ namespace OpenTween.Connection
         /// メディアのアップロードとツイートの投稿を行います
         /// </summary>
         /// <exception cref="WebApiException"/>
-        Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds);
+        Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds, string attachmentUrl);
 
         /// <summary>
         /// 画像URLのために確保する必要のある文字数を返します

--- a/OpenTween/Connection/IMediaUploadService.cs
+++ b/OpenTween/Connection/IMediaUploadService.cs
@@ -70,10 +70,10 @@ namespace OpenTween.Connection
         long? GetMaxFileSize(string fileExtension);
 
         /// <summary>
-        /// メディアのアップロードとツイートの投稿を行います
+        /// メディアのアップロードを行い、結果の URL 等を <paramref name="postParams"/> に追加します
         /// </summary>
         /// <exception cref="WebApiException"/>
-        Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds, string attachmentUrl);
+        Task<PostStatusParams> UploadAsync(IMediaItem[] mediaItems, PostStatusParams postParams);
 
         /// <summary>
         /// 画像URLのために確保する必要のある文字数を返します

--- a/OpenTween/Connection/Imgur.cs
+++ b/OpenTween/Connection/Imgur.cs
@@ -98,8 +98,7 @@ namespace OpenTween.Connection
             return MaxFileSize;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems,
-            long[] excludeReplyUserIds, string attachmentUrl)
+        public async Task<PostStatusParams> UploadAsync(IMediaItem[] mediaItems, PostStatusParams postParams)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -118,7 +117,7 @@ namespace OpenTween.Connection
             XDocument xml;
             try
             {
-                xml = await this.imgurApi.UploadFileAsync(item, text)
+                xml = await this.imgurApi.UploadFileAsync(item, postParams.Text)
                     .ConfigureAwait(false);
             }
             catch (HttpRequestException ex)
@@ -137,10 +136,9 @@ namespace OpenTween.Connection
 
             var imageUrl = imageElm.Element("link").Value;
 
-            var textWithImageUrl = text + " " + imageUrl.Trim();
+            postParams.Text += " " + imageUrl.Trim();
 
-            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds, attachmentUrl: attachmentUrl)
-                .ConfigureAwait(false);
+            return postParams;
         }
 
         public int GetReservedTextLength(int mediaCount)

--- a/OpenTween/Connection/Imgur.cs
+++ b/OpenTween/Connection/Imgur.cs
@@ -98,7 +98,7 @@ namespace OpenTween.Connection
             return MaxFileSize;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems)
+        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -138,7 +138,7 @@ namespace OpenTween.Connection
 
             var textWithImageUrl = text + " " + imageUrl.Trim();
 
-            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId)
+            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds)
                 .ConfigureAwait(false);
         }
 

--- a/OpenTween/Connection/Imgur.cs
+++ b/OpenTween/Connection/Imgur.cs
@@ -98,7 +98,8 @@ namespace OpenTween.Connection
             return MaxFileSize;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds)
+        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems,
+            long[] excludeReplyUserIds, string attachmentUrl)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -138,7 +139,7 @@ namespace OpenTween.Connection
 
             var textWithImageUrl = text + " " + imageUrl.Trim();
 
-            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds)
+            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds, attachmentUrl: attachmentUrl)
                 .ConfigureAwait(false);
         }
 

--- a/OpenTween/Connection/Mobypicture.cs
+++ b/OpenTween/Connection/Mobypicture.cs
@@ -122,7 +122,8 @@ namespace OpenTween.Connection
             return MaxFileSize;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds)
+        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems,
+            long[] excludeReplyUserIds, string attachmentUrl)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -147,7 +148,7 @@ namespace OpenTween.Connection
 
             var textWithImageUrl = text + " " + imageUrlElm.Value.Trim();
 
-            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds)
+            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds, attachmentUrl: attachmentUrl)
                 .ConfigureAwait(false);
         }
 

--- a/OpenTween/Connection/Mobypicture.cs
+++ b/OpenTween/Connection/Mobypicture.cs
@@ -122,7 +122,7 @@ namespace OpenTween.Connection
             return MaxFileSize;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems)
+        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -147,7 +147,7 @@ namespace OpenTween.Connection
 
             var textWithImageUrl = text + " " + imageUrlElm.Value.Trim();
 
-            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId)
+            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds)
                 .ConfigureAwait(false);
         }
 

--- a/OpenTween/Connection/Mobypicture.cs
+++ b/OpenTween/Connection/Mobypicture.cs
@@ -122,8 +122,7 @@ namespace OpenTween.Connection
             return MaxFileSize;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems,
-            long[] excludeReplyUserIds, string attachmentUrl)
+        public async Task<PostStatusParams> UploadAsync(IMediaItem[] mediaItems, PostStatusParams postParams)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -139,17 +138,16 @@ namespace OpenTween.Connection
             if (!item.Exists)
                 throw new ArgumentException("Err:Media not found.");
 
-            var xml = await this.mobypictureApi.UploadFileAsync(item, text)
+            var xml = await this.mobypictureApi.UploadFileAsync(item, postParams.Text)
                 .ConfigureAwait(false);
 
             var imageUrlElm = xml.XPathSelectElement("/rsp/media/mediaurl");
             if (imageUrlElm == null)
                 throw new WebApiException("Invalid API response", xml.ToString());
 
-            var textWithImageUrl = text + " " + imageUrlElm.Value.Trim();
+            postParams.Text += " " + imageUrlElm.Value.Trim();
 
-            await this.twitter.PostStatus(textWithImageUrl, inReplyToStatusId, excludeReplyUserIds: excludeReplyUserIds, attachmentUrl: attachmentUrl)
-                .ConfigureAwait(false);
+            return postParams;
         }
 
         public int GetReservedTextLength(int mediaCount)

--- a/OpenTween/Connection/TwitterPhoto.cs
+++ b/OpenTween/Connection/TwitterPhoto.cs
@@ -78,7 +78,7 @@ namespace OpenTween.Connection
             return this.twitterConfig.PhotoSizeLimit;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems)
+        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -101,7 +101,7 @@ namespace OpenTween.Connection
             var mediaIds = await Task.WhenAll(uploadTasks)
                 .ConfigureAwait(false);
 
-            await this.tw.PostStatus(text, inReplyToStatusId, mediaIds)
+            await this.tw.PostStatus(text, inReplyToStatusId, mediaIds, excludeReplyUserIds)
                 .ConfigureAwait(false);
         }
 

--- a/OpenTween/Connection/TwitterPhoto.cs
+++ b/OpenTween/Connection/TwitterPhoto.cs
@@ -78,7 +78,8 @@ namespace OpenTween.Connection
             return this.twitterConfig.PhotoSizeLimit;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems, long[] excludeReplyUserIds)
+        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems,
+            long[] excludeReplyUserIds, string attachmentUrl)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -101,7 +102,7 @@ namespace OpenTween.Connection
             var mediaIds = await Task.WhenAll(uploadTasks)
                 .ConfigureAwait(false);
 
-            await this.tw.PostStatus(text, inReplyToStatusId, mediaIds, excludeReplyUserIds)
+            await this.tw.PostStatus(text, inReplyToStatusId, mediaIds, excludeReplyUserIds, attachmentUrl)
                 .ConfigureAwait(false);
         }
 

--- a/OpenTween/Connection/TwitterPhoto.cs
+++ b/OpenTween/Connection/TwitterPhoto.cs
@@ -78,8 +78,7 @@ namespace OpenTween.Connection
             return this.twitterConfig.PhotoSizeLimit;
         }
 
-        public async Task PostStatusAsync(string text, long? inReplyToStatusId, IMediaItem[] mediaItems,
-            long[] excludeReplyUserIds, string attachmentUrl)
+        public async Task<PostStatusParams> UploadAsync(IMediaItem[] mediaItems, PostStatusParams postParams)
         {
             if (mediaItems == null)
                 throw new ArgumentNullException(nameof(mediaItems));
@@ -102,8 +101,9 @@ namespace OpenTween.Connection
             var mediaIds = await Task.WhenAll(uploadTasks)
                 .ConfigureAwait(false);
 
-            await this.tw.PostStatus(text, inReplyToStatusId, mediaIds, excludeReplyUserIds, attachmentUrl)
-                .ConfigureAwait(false);
+            postParams.MediaIds = mediaIds;
+
+            return postParams;
         }
 
         // pic.twitter.com の URL は文字数にカウントされない

--- a/OpenTween/Models/PostClass.cs
+++ b/OpenTween/Models/PostClass.cs
@@ -102,7 +102,7 @@ namespace OpenTween.Models
         private long? _InReplyToStatusId;
         public string Source { get; set; }
         public Uri SourceUri { get; set; }
-        public List<string> ReplyToList { get; set; }
+        public List<Tuple<long, string>> ReplyToList { get; set; }
         public bool IsMe { get; set; }
         public bool IsDm { get; set; }
         public long UserId { get; set; }
@@ -191,7 +191,7 @@ namespace OpenTween.Models
         {
             RetweetedBy = "";
             Media = new List<MediaInfo>();
-            ReplyToList = new List<string>();
+            ReplyToList = new List<Tuple<long, string>>();
             QuoteStatusIds = new long[0];
             ExpandedUrls = new ExpandedUrlInfo[0];
         }
@@ -305,7 +305,7 @@ namespace OpenTween.Models
                     this.InReplyToUser = "";
                     this.InReplyToUserId = null;
                     this.IsReply = false;
-                    this.ReplyToList = new List<string>();
+                    this.ReplyToList = new List<Tuple<long, string>>();
                     this._states = States.None;
                 }
                 _IsDeleted = value;
@@ -461,7 +461,7 @@ namespace OpenTween.Models
         public PostClass Clone()
         {
             var clone = (PostClass)this.MemberwiseClone();
-            clone.ReplyToList = new List<string>(this.ReplyToList);
+            clone.ReplyToList = new List<Tuple<long, string>>(this.ReplyToList);
             clone.Media = new List<MediaInfo>(this.Media);
             clone.QuoteStatusIds = this.QuoteStatusIds.ToArray();
             clone.ExpandedUrls = this.ExpandedUrls.Select(x => x.Clone()).ToArray();

--- a/OpenTween/OpenTween.csproj
+++ b/OpenTween/OpenTween.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Models\UserTimelineTabModel.cs" />
     <Compile Include="MouseWheelMessageFilter.cs" />
     <Compile Include="NotifyPropertyChangedBase.cs" />
+    <Compile Include="PostStatusOptions.cs" />
     <Compile Include="ReaderWriterLockTransaction.cs" />
     <Compile Include="SendErrorReportForm.cs">
       <SubType>Form</SubType>

--- a/OpenTween/PostStatusOptions.cs
+++ b/OpenTween/PostStatusOptions.cs
@@ -33,6 +33,7 @@ namespace OpenTween
         public string Text { get; set; }
         public long? InReplyToStatusId { get; set; }
         public IReadOnlyList<long> MediaIds { get; set; }
+        public bool AutoPopulateReplyMetadata { get; set; }
         public IReadOnlyList<long> ExcludeReplyUserIds { get; set; }
         public string AttachmentUrl { get; set; }
     }

--- a/OpenTween/PostStatusOptions.cs
+++ b/OpenTween/PostStatusOptions.cs
@@ -1,0 +1,39 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2016 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenTween.Connection;
+
+namespace OpenTween
+{
+    public class PostStatusParams
+    {
+        public string Text { get; set; }
+        public long? InReplyToStatusId { get; set; }
+        public IReadOnlyList<long> MediaIds { get; set; }
+        public IReadOnlyList<long> ExcludeReplyUserIds { get; set; }
+        public string AttachmentUrl { get; set; }
+    }
+}

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -319,6 +319,7 @@ namespace OpenTween
             public long? inReplyToId = null;
             public string inReplyToName = null;
             public long[] excludeReplyUserIds = null;
+            public string attachmentUrl = null;
             public string imageService = "";      //画像投稿サービス名
             public IMediaItem[] mediaItems = null;
             public PostingStatus()
@@ -2763,13 +2764,13 @@ namespace OpenTween
                 {
                     if (status.mediaItems == null || status.mediaItems.Length == 0)
                     {
-                        await this.tw.PostStatus(status.status, status.inReplyToId, excludeReplyUserIds: status.excludeReplyUserIds)
+                        await this.tw.PostStatus(status.status, status.inReplyToId, excludeReplyUserIds: status.excludeReplyUserIds, attachmentUrl: status.attachmentUrl)
                             .ConfigureAwait(false);
                     }
                     else
                     {
                         var service = ImageSelector.GetService(status.imageService);
-                        await service.PostStatusAsync(status.status, status.inReplyToId, status.mediaItems, status.excludeReplyUserIds)
+                        await service.PostStatusAsync(status.status, status.inReplyToId, status.mediaItems, status.excludeReplyUserIds, status.attachmentUrl)
                             .ConfigureAwait(false);
                     }
                 });

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -987,7 +987,7 @@ namespace OpenTween
             StatusLabel.AutoToolTip = false;
             StatusLabel.ToolTipText = "";
             //文字カウンタ初期化
-            lblLen.Text = this.GetRestStatusCount(this.FormatStatusText("")).ToString();
+            lblLen.Text = this.GetRestStatusCount("").ToString();
 
             this.JumpReadOpMenuItem.ShortcutKeyDisplayString = "Space";
             CopySTOTMenuItem.ShortcutKeyDisplayString = "Ctrl+C";
@@ -2122,7 +2122,10 @@ namespace OpenTween
             StatusText.SelectionStart = StatusText.Text.Length;
             CheckReplyTo(StatusText.Text);
 
-            var statusText = this.FormatStatusText(this.StatusText.Text);
+            long[] autoPopulatedUserIds;
+
+            var statusText = this.RemoveAutoPopuratedMentions(this.StatusText.Text, out autoPopulatedUserIds);
+            statusText = this.FormatStatusText(statusText);
 
             if (this.GetRestStatusCount(statusText) < 0)
             {
@@ -2137,6 +2140,15 @@ namespace OpenTween
 
             status.inReplyToId = this.inReplyTo?.Item1;
             status.inReplyToName = this.inReplyTo?.Item2;
+
+            var replyToPost = this.inReplyTo != null ? this._statuses[this.inReplyTo.Item1] : null;
+            if (replyToPost != null)
+            {
+                // ReplyToList のうち autoPopulatedUserIds に含まれていないユーザー ID を抽出
+                status.excludeReplyUserIds = replyToPost.ReplyToList.Select(x => x.Item1).Except(autoPopulatedUserIds)
+                    .ToArray();
+            }
+
             if (ImageSelector.Visible)
             {
                 //画像投稿
@@ -4700,7 +4712,7 @@ namespace OpenTween
         private void StatusText_TextChanged(object sender, EventArgs e)
         {
             //文字数カウント
-            int pLen = this.GetRestStatusCount(this.FormatStatusText(this.StatusText.Text));
+            int pLen = this.GetRestStatusCount(this.StatusText.Text);
             lblLen.Text = pLen.ToString();
             if (pLen < 0)
             {
@@ -4717,6 +4729,36 @@ namespace OpenTween
             {
                 this.inReplyTo = null;
             }
+        }
+
+        /// <summary>
+        /// 投稿時に auto_populate_reply_metadata オプションによって自動で追加されるメンションを除去します
+        /// </summary>
+        private string RemoveAutoPopuratedMentions(string statusText, out long[] autoPopulatedUserIds)
+        {
+            List<long> _autoPopulatedUserIds = new List<long>();
+
+            var replyToPost = this.inReplyTo != null ? this._statuses[this.inReplyTo.Item1] : null;
+            if (replyToPost != null)
+            {
+                if (statusText.StartsWith($"@{replyToPost.ScreenName} ", StringComparison.Ordinal))
+                {
+                    statusText = statusText.Substring(replyToPost.ScreenName.Length + 2);
+
+                    foreach (var reply in replyToPost.ReplyToList)
+                    {
+                        if (statusText.StartsWith($"@{reply.Item2} ", StringComparison.Ordinal))
+                        {
+                            statusText = statusText.Substring(reply.Item2.Length + 2);
+                            _autoPopulatedUserIds.Add(reply.Item1);
+                        }
+                    }
+                }
+            }
+
+            autoPopulatedUserIds = _autoPopulatedUserIds.ToArray();
+
+            return statusText;
         }
 
         /// <summary>
@@ -4818,7 +4860,11 @@ namespace OpenTween
         /// </summary>
         private int GetRestStatusCount(string statusText)
         {
-            //文字数カウント
+            long[] autoPopulatedUserIds;
+            statusText = this.RemoveAutoPopuratedMentions(statusText, out autoPopulatedUserIds);
+
+            statusText = this.FormatStatusText(statusText);
+
             var remainCount = this.tw.GetTextLengthRemain(statusText);
 
             var uploadService = this.GetSelectedImageService();

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -318,6 +318,7 @@ namespace OpenTween
             public string status = "";
             public long? inReplyToId = null;
             public string inReplyToName = null;
+            public long[] excludeReplyUserIds = null;
             public string imageService = "";      //画像投稿サービス名
             public IMediaItem[] mediaItems = null;
             public PostingStatus()
@@ -2750,13 +2751,13 @@ namespace OpenTween
                 {
                     if (status.mediaItems == null || status.mediaItems.Length == 0)
                     {
-                        await this.tw.PostStatus(status.status, status.inReplyToId)
+                        await this.tw.PostStatus(status.status, status.inReplyToId, excludeReplyUserIds: status.excludeReplyUserIds)
                             .ConfigureAwait(false);
                     }
                     else
                     {
                         var service = ImageSelector.GetService(status.imageService);
-                        await service.PostStatusAsync(status.status, status.inReplyToId, status.mediaItems)
+                        await service.PostStatusAsync(status.status, status.inReplyToId, status.mediaItems, status.excludeReplyUserIds)
                             .ConfigureAwait(false);
                     }
                 });

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -4753,6 +4753,7 @@ namespace OpenTween
                 if (statusText.StartsWith($"@{replyToPost.ScreenName} ", StringComparison.Ordinal))
                 {
                     statusText = statusText.Substring(replyToPost.ScreenName.Length + 2);
+                    _autoPopulatedUserIds.Add(replyToPost.UserId);
 
                     foreach (var reply in replyToPost.ReplyToList)
                     {

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -4784,12 +4784,15 @@ namespace OpenTween
         /// </summary>
         private string RemoveAttachmentUrl(string statusText, out string attachmentUrl)
         {
+            attachmentUrl = null;
+
+            // attachment_url は media_id と同時に使用できない
+            if (this.ImageSelector.Visible && this.ImageSelector.SelectedService is TwitterPhoto)
+                return statusText;
+
             var match = Twitter.AttachmentUrlRegex.Match(statusText);
             if (!match.Success)
-            {
-                attachmentUrl = null;
                 return statusText;
-            }
 
             attachmentUrl = match.Value;
 

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -2055,10 +2055,10 @@ namespace OpenTween
             else if (TargetPost.IsReply)
                 //自分宛返信
                 cl = _clAtSelf;
-            else if (BasePost.ReplyToList.Contains(TargetPost.ScreenName.ToLowerInvariant()))
+            else if (BasePost.ReplyToList.Any(x => x.Item1 == TargetPost.UserId))
                 //返信先
                 cl = _clAtFromTarget;
-            else if (TargetPost.ReplyToList.Contains(BasePost.ScreenName.ToLowerInvariant()))
+            else if (TargetPost.ReplyToList.Any(x => x.Item1 == BasePost.UserId))
                 //その人への返信
                 cl = _clAtTarget;
             else if (TargetPost.ScreenName.Equals(BasePost.ScreenName, StringComparison.OrdinalIgnoreCase))
@@ -6714,10 +6714,10 @@ namespace OpenTween
                     post.RetweetedBy == _anchorPost.ScreenName ||
                     post.ScreenName == _anchorPost.RetweetedBy ||
                     (!string.IsNullOrEmpty(post.RetweetedBy) && post.RetweetedBy == _anchorPost.RetweetedBy) ||
-                    _anchorPost.ReplyToList.Contains(post.ScreenName.ToLowerInvariant()) ||
-                    _anchorPost.ReplyToList.Contains(post.RetweetedBy.ToLowerInvariant()) ||
-                    post.ReplyToList.Contains(_anchorPost.ScreenName.ToLowerInvariant()) ||
-                    post.ReplyToList.Contains(_anchorPost.RetweetedBy.ToLowerInvariant()))
+                    _anchorPost.ReplyToList.Any(x => x.Item1 == post.UserId) ||
+                    _anchorPost.ReplyToList.Any(x => x.Item1 == post.RetweetedByUserId) ||
+                    post.ReplyToList.Any(x => x.Item1 == _anchorPost.UserId) ||
+                    post.ReplyToList.Any(x => x.Item1 == _anchorPost.RetweetedByUserId))
                 {
                     SelectListItem(_curList, idx);
                     _curList.EnsureVisible(idx);
@@ -7758,7 +7758,7 @@ namespace OpenTween
                                 }
                                 if (isAll)
                                 {
-                                    foreach (string nm in post.ReplyToList)
+                                    foreach (string nm in post.ReplyToList.Select(x => x.Item2))
                                     {
                                         if (!ids.Contains("@" + nm + " ") &&
                                             !nm.Equals(tw.Username, StringComparison.CurrentCultureIgnoreCase))
@@ -7814,7 +7814,7 @@ namespace OpenTween
                             {
                                 ids += "@" + post.ScreenName + " ";
                             }
-                            foreach (string nm in post.ReplyToList)
+                            foreach (string nm in post.ReplyToList.Select(x => x.Item2))
                             {
                                 if (!ids.Contains("@" + nm + " ") &&
                                     !nm.Equals(tw.Username, StringComparison.CurrentCultureIgnoreCase))

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -165,7 +165,7 @@ namespace OpenTween
         private PostClass _anchorPost;
         private bool _anchorFlag;        //true:関連発言移動中（関連移動以外のオペレーションをするとfalseへ。trueだとリスト背景色をアンカー発言選択中として描画）
 
-        private List<PostingStatus> _history = new List<PostingStatus>();   //発言履歴
+        private List<StatusTextHistory> _history = new List<StatusTextHistory>();   //発言履歴
         private int _hisIdx;                  //発言履歴カレントインデックス
 
         //発言投稿時のAPI引数（発言編集時に設定。手書きreplyでは設定されない）
@@ -311,6 +311,24 @@ namespace OpenTween
             DialogSearch,
             NextSearch,
             PrevSearch,
+        }
+
+        private class StatusTextHistory
+        {
+            public string status = "";
+            public long? inReplyToId = null;
+            public string inReplyToName = null;
+            public string imageService = "";      //画像投稿サービス名
+            public IMediaItem[] mediaItems = null;
+            public StatusTextHistory()
+            {
+            }
+            public StatusTextHistory(string status, long? replyToId, string replyToName)
+            {
+                this.status = status;
+                this.inReplyToId = replyToId;
+                this.inReplyToName = replyToName;
+            }
         }
 
         private class PostingStatus
@@ -903,7 +921,7 @@ namespace OpenTween
             //Regex statregex = new Regex("^0*");
             this.recommendedStatusFooter = " [TWNv" + Regex.Replace(MyCommon.FileVersion.Replace(".", ""), "^0*", "") + "]";
 
-            _history.Add(new PostingStatus());
+            _history.Add(new StatusTextHistory());
             _hisIdx = 0;
             this.inReplyTo = null;
 
@@ -2103,7 +2121,7 @@ namespace OpenTween
 
             var inReplyToStatusId = this.inReplyTo?.Item1;
             var inReplyToScreenName = this.inReplyTo?.Item2;
-            _history[_history.Count - 1] = new PostingStatus(StatusText.Text, inReplyToStatusId, inReplyToScreenName);
+            _history[_history.Count - 1] = new StatusTextHistory(StatusText.Text, inReplyToStatusId, inReplyToScreenName);
 
             if (SettingManager.Common.Nicoms)
             {
@@ -2164,7 +2182,7 @@ namespace OpenTween
 
             this.inReplyTo = null;
             StatusText.Text = "";
-            _history.Add(new PostingStatus());
+            _history.Add(new StatusTextHistory());
             _hisIdx = _history.Count - 1;
             if (!SettingManager.Common.FocusLockToStatusText)
                 ((Control)ListTab.SelectedTab.Tag).Focus();
@@ -6157,7 +6175,7 @@ namespace OpenTween
                         {
                             var inReplyToStatusId = this.inReplyTo?.Item1;
                             var inReplyToScreenName = this.inReplyTo?.Item2;
-                            _history[_hisIdx] = new PostingStatus(StatusText.Text, inReplyToStatusId, inReplyToScreenName);
+                            _history[_hisIdx] = new StatusTextHistory(StatusText.Text, inReplyToStatusId, inReplyToScreenName);
                         }
                         _hisIdx -= 1;
                         if (_hisIdx < 0) _hisIdx = 0;
@@ -6178,7 +6196,7 @@ namespace OpenTween
                         {
                             var inReplyToStatusId = this.inReplyTo?.Item1;
                             var inReplyToScreenName = this.inReplyTo?.Item2;
-                            _history[_hisIdx] = new PostingStatus(StatusText.Text, inReplyToStatusId, inReplyToScreenName);
+                            _history[_hisIdx] = new StatusTextHistory(StatusText.Text, inReplyToStatusId, inReplyToScreenName);
                         }
                         _hisIdx += 1;
                         if (_hisIdx > _history.Count - 1) _hisIdx = _history.Count - 1;

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -2124,8 +2124,11 @@ namespace OpenTween
             CheckReplyTo(StatusText.Text);
 
             long[] autoPopulatedUserIds;
-
             var statusText = this.RemoveAutoPopuratedMentions(this.StatusText.Text, out autoPopulatedUserIds);
+
+            string attachmentUrl;
+            statusText = this.RemoveAttachmentUrl(statusText, out attachmentUrl);
+
             statusText = this.FormatStatusText(statusText);
 
             if (this.GetRestStatusCount(statusText) < 0)
@@ -2149,6 +2152,8 @@ namespace OpenTween
                 status.excludeReplyUserIds = replyToPost.ReplyToList.Select(x => x.Item1).Except(autoPopulatedUserIds)
                     .ToArray();
             }
+
+            status.attachmentUrl = attachmentUrl;
 
             if (ImageSelector.Visible)
             {
@@ -4763,6 +4768,27 @@ namespace OpenTween
         }
 
         /// <summary>
+        /// attachment_url に指定可能な URL が含まれていれば除去
+        /// </summary>
+        private string RemoveAttachmentUrl(string statusText, out string attachmentUrl)
+        {
+            var match = Twitter.AttachmentUrlRegex.Match(statusText);
+            if (!match.Success)
+            {
+                attachmentUrl = null;
+                return statusText;
+            }
+
+            attachmentUrl = match.Value;
+
+            // マッチした URL を空白に置換
+            statusText = statusText.Substring(0, match.Index);
+
+            // テキストと URL の間にスペースが含まれていれば除去
+            return statusText.TrimEnd(' ');
+        }
+
+        /// <summary>
         /// ツイート投稿前のフッター付与などの前処理を行います
         /// </summary>
         private string FormatStatusText(string statusText)
@@ -4863,6 +4889,9 @@ namespace OpenTween
         {
             long[] autoPopulatedUserIds;
             statusText = this.RemoveAutoPopuratedMentions(statusText, out autoPopulatedUserIds);
+
+            string attachmentUrl;
+            statusText = this.RemoveAttachmentUrl(statusText, out attachmentUrl);
 
             statusText = this.FormatStatusText(statusText);
 

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -6133,12 +6133,12 @@ namespace OpenTween
                         if (_hisIdx < 0) _hisIdx = 0;
 
                         var historyItem = this._history[this._hisIdx];
-                        StatusText.Text = historyItem.status;
-                        StatusText.SelectionStart = StatusText.Text.Length;
                         if (historyItem.inReplyToId != null)
                             this.inReplyTo = Tuple.Create(historyItem.inReplyToId.Value, historyItem.inReplyToName);
                         else
                             this.inReplyTo = null;
+                        StatusText.Text = historyItem.status;
+                        StatusText.SelectionStart = StatusText.Text.Length;
                     }),
 
                 ShortcutCommand.Create(Keys.Control | Keys.Down)
@@ -6154,12 +6154,12 @@ namespace OpenTween
                         if (_hisIdx > _history.Count - 1) _hisIdx = _history.Count - 1;
 
                         var historyItem = this._history[this._hisIdx];
-                        StatusText.Text = historyItem.status;
-                        StatusText.SelectionStart = StatusText.Text.Length;
                         if (historyItem.inReplyToId != null)
                             this.inReplyTo = Tuple.Create(historyItem.inReplyToId.Value, historyItem.inReplyToName);
                         else
                             this.inReplyTo = null;
+                        StatusText.Text = historyItem.status;
+                        StatusText.SelectionStart = StatusText.Text.Length;
                     }),
 
                 ShortcutCommand.Create(Keys.Control | Keys.PageUp, Keys.Control | Keys.P)
@@ -7662,22 +7662,21 @@ namespace OpenTween
                     if ((_statuses.Tabs[ListTab.SelectedTab.Text].TabType == MyCommon.TabUsageType.DirectMessage && isAuto) || (!isAuto && !isReply))
                     {
                         // ダイレクトメッセージ
+                        this.inReplyTo = null;
                         StatusText.Text = "D " + _curPost.ScreenName + " " + StatusText.Text;
                         StatusText.SelectionStart = StatusText.Text.Length;
                         StatusText.Focus();
-                        this.inReplyTo = null;
                         return;
                     }
                     if (string.IsNullOrEmpty(StatusText.Text))
                     {
                         //空の場合
-
-                        // ステータステキストが入力されていない場合先頭に@ユーザー名を追加する
-                        StatusText.Text = "@" + _curPost.ScreenName + " ";
-
                         var inReplyToStatusId = this._curPost.RetweetedId ?? this._curPost.StatusId;
                         var inReplyToScreenName = this._curPost.ScreenName;
                         this.inReplyTo = Tuple.Create(inReplyToStatusId, inReplyToScreenName);
+
+                        // ステータステキストが入力されていない場合先頭に@ユーザー名を追加する
+                        StatusText.Text = "@" + _curPost.ScreenName + " ";
                     }
                     else
                     {
@@ -7703,25 +7702,25 @@ namespace OpenTween
                                 if (StatusText.Text.StartsWith(". ", StringComparison.Ordinal))
                                 {
                                     // 複数リプライ
-                                    StatusText.Text = StatusText.Text.Insert(2, "@" + _curPost.ScreenName + " ");
                                     this.inReplyTo = null;
+                                    StatusText.Text = StatusText.Text.Insert(2, "@" + _curPost.ScreenName + " ");
                                 }
                                 else
                                 {
                                     // 単独リプライ
-                                    StatusText.Text = "@" + _curPost.ScreenName + " " + StatusText.Text;
                                     var inReplyToStatusId = this._curPost.RetweetedId ?? this._curPost.StatusId;
                                     var inReplyToScreenName = this._curPost.ScreenName;
                                     this.inReplyTo = Tuple.Create(inReplyToStatusId, inReplyToScreenName);
+                                    StatusText.Text = "@" + _curPost.ScreenName + " " + StatusText.Text;
                                 }
                             }
                             else
                             {
                                 //文頭＠
                                 // 複数リプライ
+                                this.inReplyTo = null;
                                 StatusText.Text = ". @" + _curPost.ScreenName + " " + StatusText.Text;
                                 //StatusText.Text = "@" + _curPost.ScreenName + " " + StatusText.Text;
-                                this.inReplyTo = null;
                             }
                         }
                         else
@@ -7822,9 +7821,9 @@ namespace OpenTween
                             if (ids.Length == 0) return;
                             if (!StatusText.Text.StartsWith(". ", StringComparison.Ordinal))
                             {
+                                this.inReplyTo = null;
                                 StatusText.Text = ". " + StatusText.Text;
                                 sidx += 2;
-                                this.inReplyTo = null;
                             }
                             if (sidx > 0)
                             {
@@ -7885,13 +7884,13 @@ namespace OpenTween
                             if (string.IsNullOrEmpty(StatusText.Text))
                             {
                                 //未入力の場合のみ返信先付加
-                                StatusText.Text = ids;
-                                StatusText.SelectionStart = ids.Length;
-                                StatusText.Focus();
-
                                 var inReplyToStatusId = this._curPost.RetweetedId ?? this._curPost.StatusId;
                                 var inReplyToScreenName = this._curPost.ScreenName;
                                 this.inReplyTo = Tuple.Create(inReplyToStatusId, inReplyToScreenName);
+
+                                StatusText.Text = ids;
+                                StatusText.SelectionStart = ids.Length;
+                                StatusText.Focus();
                                 return;
                             }
 
@@ -10657,9 +10656,9 @@ namespace OpenTween
 
                 var selection = (this.StatusText.SelectionStart, this.StatusText.SelectionLength);
 
-                StatusText.Text += " " + MyCommon.GetStatusUrl(_curPost);
-
                 this.inReplyTo = null;
+
+                StatusText.Text += " " + MyCommon.GetStatusUrl(_curPost);
 
                 (this.StatusText.SelectionStart, this.StatusText.SelectionLength) = selection;
                 StatusText.Focus();
@@ -10684,12 +10683,12 @@ namespace OpenTween
 
                 var selection = (this.StatusText.SelectionStart, this.StatusText.SelectionLength);
 
-                StatusText.Text += " RT @" + _curPost.ScreenName + ": " + rtdata;
-
                 // 投稿時に in_reply_to_status_id を付加する
                 var inReplyToStatusId = this._curPost.RetweetedId ?? this._curPost.StatusId;
                 var inReplyToScreenName = this._curPost.ScreenName;
                 this.inReplyTo = Tuple.Create(inReplyToStatusId, inReplyToScreenName);
+
+                StatusText.Text += " RT @" + _curPost.ScreenName + ": " + rtdata;
 
                 (this.StatusText.SelectionStart, this.StatusText.SelectionLength) = selection;
                 StatusText.Focus();

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -2142,8 +2142,10 @@ namespace OpenTween
             };
 
             var replyToPost = this.inReplyTo != null ? this._statuses[this.inReplyTo.Item1] : null;
-            if (replyToPost != null)
+            if (replyToPost != null && !status.Text.Contains("RT @"))
             {
+                status.AutoPopulateReplyMetadata = true;
+
                 // ReplyToList のうち autoPopulatedUserIds に含まれていないユーザー ID を抽出
                 status.ExcludeReplyUserIds = replyToPost.ReplyToList.Select(x => x.Item1).Except(autoPopulatedUserIds)
                     .ToArray();

--- a/OpenTween/TweetDetailsView.cs
+++ b/OpenTween/TweetDetailsView.cs
@@ -148,7 +148,7 @@ namespace OpenTween
                 sb.AppendFormat("IsRead         : {0}<br>", post.IsRead);
                 sb.AppendFormat("IsReply        : {0}<br>", post.IsReply);
 
-                foreach (string nm in post.ReplyToList)
+                foreach (string nm in post.ReplyToList.Select(x => x.Item2))
                 {
                     sb.AppendFormat("ReplyToList    : {0}<br>", nm);
                 }

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -278,7 +278,8 @@ namespace OpenTween
             return orgData;
         }
 
-        public async Task PostStatus(string postStr, long? reply_to, IReadOnlyList<long> mediaIds = null)
+        public async Task PostStatus(string postStr, long? reply_to, IReadOnlyList<long> mediaIds = null,
+            IReadOnlyList<long> excludeReplyUserIds = null)
         {
             this.CheckAccountState();
 
@@ -289,7 +290,8 @@ namespace OpenTween
                 return;
             }
 
-            var response = await this.Api.StatusesUpdate(postStr, reply_to, mediaIds)
+            var response = await this.Api.StatusesUpdate(postStr, reply_to, mediaIds,
+                    autoPopulateReplyMetadata: true, excludeReplyUserIds: excludeReplyUserIds)
                 .ConfigureAwait(false);
 
             var status = await response.LoadJsonAsync()

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -133,6 +133,15 @@ namespace OpenTween
         public static readonly Regex StatusUrlRegex = new Regex(@"https?://([^.]+\.)?twitter\.com/(#!/)?(?<ScreenName>[a-zA-Z0-9_]+)/status(es)?/(?<StatusId>[0-9]+)(/photo)?", RegexOptions.IgnoreCase);
 
         /// <summary>
+        /// attachment_url に指定可能な URL を判定する正規表現
+        /// </summary>
+        public static readonly Regex AttachmentUrlRegex = new Regex(@"https?://(
+   twitter\.com/[0-9A-Za-z]+/status/[0-9]+
+ | mobile\.twitter\.com/[0-9A-Za-z]+/status/[0-9]+
+ | twitter\.com/messages/compose\?recipient_id=[0-9]+(&.+)?
+)$", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+
+        /// <summary>
         /// FavstarやaclogなどTwitter関連サービスのパーマリンクURLからステータスIDを抽出する正規表現
         /// </summary>
         public static readonly Regex ThirdPartyStatusUrlRegex = new Regex(@"https?://(?:[^.]+\.)?(?:

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -298,12 +298,8 @@ namespace OpenTween
                 return;
             }
 
-            var autoPopulateReplyMetadata = false;
-            if (param.InReplyToStatusId != null && !param.Text.Contains("RT @"))
-                autoPopulateReplyMetadata = true;
-
             var response = await this.Api.StatusesUpdate(param.Text, param.InReplyToStatusId, param.MediaIds,
-                    autoPopulateReplyMetadata, param.ExcludeReplyUserIds, param.AttachmentUrl)
+                    param.AutoPopulateReplyMetadata, param.ExcludeReplyUserIds, param.AttachmentUrl)
                 .ConfigureAwait(false);
 
             var status = await response.LoadJsonAsync()

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -844,7 +844,7 @@ namespace OpenTween
             post.Source = string.Intern(sourceText);
             post.SourceUri = sourceUri;
 
-            post.IsReply = post.RetweetedId == null && post.ReplyToList.Contains(_uname);
+            post.IsReply = post.RetweetedId == null && post.ReplyToList.Any(x => x.Item1 == this.UserId);
             post.IsExcludeReply = false;
 
             if (post.IsMe)
@@ -1536,7 +1536,7 @@ namespace OpenTween
             }
         }
 
-        public string CreateHtmlAnchor(string text, List<string> AtList, TwitterEntities entities, List<MediaInfo> media)
+        public string CreateHtmlAnchor(string text, List<Tuple<long, string>> AtList, TwitterEntities entities, List<MediaInfo> media)
         {
             if (entities != null)
             {
@@ -1551,9 +1551,7 @@ namespace OpenTween
                 {
                     foreach (var ent in entities.UserMentions)
                     {
-                        var screenName = ent.ScreenName.ToLowerInvariant();
-                        if (!AtList.Contains(screenName))
-                            AtList.Add(screenName);
+                        AtList.Add(Tuple.Create(ent.Id, ent.ScreenName));
                     }
                 }
                 if (entities.Media != null)

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -290,8 +290,12 @@ namespace OpenTween
                 return;
             }
 
+            var autoPopulateReplyMetadata = false;
+            if (reply_to != null && !postStr.Contains("RT @"))
+                autoPopulateReplyMetadata = true;
+
             var response = await this.Api.StatusesUpdate(postStr, reply_to, mediaIds,
-                    autoPopulateReplyMetadata: true, excludeReplyUserIds: excludeReplyUserIds)
+                    autoPopulateReplyMetadata, excludeReplyUserIds)
                 .ConfigureAwait(false);
 
             var status = await response.LoadJsonAsync()

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -287,24 +287,23 @@ namespace OpenTween
             return orgData;
         }
 
-        public async Task PostStatus(string postStr, long? reply_to, IReadOnlyList<long> mediaIds = null,
-            IReadOnlyList<long> excludeReplyUserIds = null, string attachmentUrl = null)
+        public async Task PostStatus(PostStatusParams param)
         {
             this.CheckAccountState();
 
-            if (Twitter.DMSendTextRegex.IsMatch(postStr))
+            if (Twitter.DMSendTextRegex.IsMatch(param.Text))
             {
-                await this.SendDirectMessage(postStr)
+                await this.SendDirectMessage(param.Text)
                     .ConfigureAwait(false);
                 return;
             }
 
             var autoPopulateReplyMetadata = false;
-            if (reply_to != null && !postStr.Contains("RT @"))
+            if (param.InReplyToStatusId != null && !param.Text.Contains("RT @"))
                 autoPopulateReplyMetadata = true;
 
-            var response = await this.Api.StatusesUpdate(postStr, reply_to, mediaIds,
-                    autoPopulateReplyMetadata, excludeReplyUserIds, attachmentUrl)
+            var response = await this.Api.StatusesUpdate(param.Text, param.InReplyToStatusId, param.MediaIds,
+                    autoPopulateReplyMetadata, param.ExcludeReplyUserIds, param.AttachmentUrl)
                 .ConfigureAwait(false);
 
             var status = await response.LoadJsonAsync()

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -279,7 +279,7 @@ namespace OpenTween
         }
 
         public async Task PostStatus(string postStr, long? reply_to, IReadOnlyList<long> mediaIds = null,
-            IReadOnlyList<long> excludeReplyUserIds = null)
+            IReadOnlyList<long> excludeReplyUserIds = null, string attachmentUrl = null)
         {
             this.CheckAccountState();
 
@@ -295,7 +295,7 @@ namespace OpenTween
                 autoPopulateReplyMetadata = true;
 
             var response = await this.Api.StatusesUpdate(postStr, reply_to, mediaIds,
-                    autoPopulateReplyMetadata, excludeReplyUserIds)
+                    autoPopulateReplyMetadata, excludeReplyUserIds, attachmentUrl)
                 .ConfigureAwait(false);
 
             var status = await response.LoadJsonAsync()

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -136,8 +136,8 @@ namespace OpenTween
         /// attachment_url に指定可能な URL を判定する正規表現
         /// </summary>
         public static readonly Regex AttachmentUrlRegex = new Regex(@"https?://(
-   twitter\.com/[0-9A-Za-z]+/status/[0-9]+
- | mobile\.twitter\.com/[0-9A-Za-z]+/status/[0-9]+
+   twitter\.com/[0-9A-Za-z_]+/status/[0-9]+
+ | mobile\.twitter\.com/[0-9A-Za-z_]+/status/[0-9]+
  | twitter\.com/messages/compose\?recipient_id=[0-9]+(&.+)?
 )$", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 


### PR DESCRIPTION
### 試しに使ってみたい人向け

`auto-populate-metadata` ブランチのビルドを下記 URL からダウンロードできます。
（最新の OpenTween より古いバージョンから分岐しているため注意して下さい）
https://ci.appveyor.com/project/upsilon/opentween/branch/auto-populate-metadata/artifacts

---

- [x] ツイートに添付する画像の URL (pic.twitter.com) を文字数カウントから除外
  - v1.3.5 でリリース済み
- [x] `auto_populate_reply_metadata` を有効にする
- [x] `text` パラメータには自動で付加されるメンションを事前に除去したテキストを渡す
  - `auto_populate_reply_metadata` によって自動でメンションが付加されるため、その分のメンションを `text` パラメータから除去する必要がある
  - 投稿された結果のツイート本文には、投稿欄に入力されたものと同じ内容のテキストが忠実に反映されるように考慮する
- [x] 非公式RTに `in_reply_to_status_id` を付与する場合は `auto_populate_reply_metadata` を `true` にしない
- [x] `attachment_url` に対応する
- [x] `attachment_url` と `media_ids` は排他的なオプションらしいのでそれを考慮する  
  https://twittercommunity.com/t/74725
- [x] `Twitter.PostStatus` メソッドの引数がどんどん増えていくのを何とかする
- [x] 投稿するツイートが140文字を越える場合にのみ `auto_populate_reply_metadata` および `attachment_url` を有効にする
- [x] `auto_populate_reply_metadata` が正式にリリースされるまで様子を見る  
    https://twittercommunity.com/t/74877/2
  - `POST /statuses/update` のドキュメントに記載されたので正式リリースされたものとして扱う
    https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update
- [x] 写真にタグ付けされているユーザーがいると巻き込みリプライが起きる？
    https://twittercommunity.com/t/76132
  - twitter.com は現在もリプライ対象になるが、`auto_populate_reply_metadata` の対象からは外れたようなので解決
