### PR TITLE
.NET4.6 に移行

### DIFF
--- a/OpenTween.Tests/Api/TwitterApiTest.cs
+++ b/OpenTween.Tests/Api/TwitterApiTest.cs
@@ -104,7 +104,7 @@ namespace OpenTween.Api
                         },
                         "/statuses/home_timeline")
                 )
-                .ReturnsAsync(new TwitterStatus[0]);
+                .ReturnsAsync(Array.Empty<TwitterStatus>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -134,7 +134,7 @@ namespace OpenTween.Api
                         },
                         "/statuses/mentions_timeline")
                 )
-                .ReturnsAsync(new TwitterStatus[0]);
+                .ReturnsAsync(Array.Empty<TwitterStatus>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -166,7 +166,7 @@ namespace OpenTween.Api
                         },
                         "/statuses/user_timeline")
                 )
-                .ReturnsAsync(new TwitterStatus[0]);
+                .ReturnsAsync(Array.Empty<TwitterStatus>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -261,7 +261,7 @@ namespace OpenTween.Api
 
                 twitterApi.apiConnection = mock.Object;
 
-                await twitterApi.StatusesUpdate("hogehoge", replyToId: null, mediaIds: null, excludeReplyUserIds: new long[0])
+                await twitterApi.StatusesUpdate("hogehoge", replyToId: null, mediaIds: null, excludeReplyUserIds: Array.Empty<long>())
                     .IgnoreResponse()
                     .ConfigureAwait(false);
 
@@ -536,7 +536,7 @@ namespace OpenTween.Api
                         },
                         "/lists/statuses")
                 )
-                .ReturnsAsync(new TwitterStatus[0]);
+                .ReturnsAsync(Array.Empty<TwitterStatus>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -682,7 +682,7 @@ namespace OpenTween.Api
                         },
                         "/direct_messages")
                 )
-                .ReturnsAsync(new TwitterDirectMessage[0]);
+                .ReturnsAsync(Array.Empty<TwitterDirectMessage>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -712,7 +712,7 @@ namespace OpenTween.Api
                         },
                         "/direct_messages/sent")
                 )
-                .ReturnsAsync(new TwitterDirectMessage[0]);
+                .ReturnsAsync(Array.Empty<TwitterDirectMessage>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -845,7 +845,7 @@ namespace OpenTween.Api
                         },
                         "/favorites/list")
                 )
-                .ReturnsAsync(new TwitterStatus[0]);
+                .ReturnsAsync(Array.Empty<TwitterStatus>());
 
                 twitterApi.apiConnection = mock.Object;
 
@@ -989,7 +989,7 @@ namespace OpenTween.Api
                         null,
                         "/friendships/no_retweets/ids")
                 )
-                .ReturnsAsync(new long[0]);
+                .ReturnsAsync(Array.Empty<long>());
 
                 twitterApi.apiConnection = mock.Object;
 

--- a/OpenTween.Tests/Api/TwitterApiTest.cs
+++ b/OpenTween.Tests/Api/TwitterApiTest.cs
@@ -1298,7 +1298,7 @@ namespace OpenTween.Api
                         new Uri("https://upload.twitter.com/1.1/media/metadata/create.json", UriKind.Absolute),
                         "{\"media_id\": \"12345\", \"alt_text\": {\"text\": \"hogehoge\"}}")
                 )
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
                 twitterApi.apiConnection = mock.Object;
 

--- a/OpenTween.Tests/Connection/OAuthUtilityTest.cs
+++ b/OpenTween.Tests/Connection/OAuthUtilityTest.cs
@@ -39,8 +39,7 @@ namespace OpenTween.Connection
             Assert.Equal("ConsumerKey", param["oauth_consumer_key"]);
             Assert.Equal("HMAC-SHA1", param["oauth_signature_method"]);
 
-            var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0);
-            var unixTimeNow = Math.Ceiling((DateTime.UtcNow - unixEpoch).TotalSeconds);
+            var unixTimeNow = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             Assert.InRange(long.Parse(param["oauth_timestamp"]), unixTimeNow - 5, unixTimeNow);
 
             Assert.NotEmpty(param["oauth_nonce"]);

--- a/OpenTween.Tests/HashtagManageTest.cs
+++ b/OpenTween.Tests/HashtagManageTest.cs
@@ -51,7 +51,7 @@ namespace OpenTween
         [Fact]
         public void InitHashtagHistory_EmptyTest()
         {
-            var hashtags = new string[0];
+            var hashtags = Array.Empty<string>();
 
             using (var atDialog = new AtIdSupplement())
             using (var hashDialog = new HashtagManage(atDialog, hashtags, "", false, false, false))
@@ -67,7 +67,7 @@ namespace OpenTween
         public void AddHashtag_Test()
         {
             using (var atDialog = new AtIdSupplement())
-            using (var hashDialog = new HashtagManage(atDialog, new string[0], "", false, false, false))
+            using (var hashDialog = new HashtagManage(atDialog, Array.Empty<string>(), "", false, false, false))
             {
                 hashDialog.RunSilent = true;
 
@@ -86,7 +86,7 @@ namespace OpenTween
         public void AddHashtag_FullWidthTest()
         {
             using (var atDialog = new AtIdSupplement())
-            using (var hashDialog = new HashtagManage(atDialog, new string[0], "", false, false, false))
+            using (var hashDialog = new HashtagManage(atDialog, Array.Empty<string>(), "", false, false, false))
             {
                 hashDialog.RunSilent = true;
 
@@ -107,7 +107,7 @@ namespace OpenTween
             // ハッシュタグを表す「#」の直後に結合文字 (濁点など) が続いた場合に対するテスト
 
             using (var atDialog = new AtIdSupplement())
-            using (var hashDialog = new HashtagManage(atDialog, new string[0], "", false, false, false))
+            using (var hashDialog = new HashtagManage(atDialog, Array.Empty<string>(), "", false, false, false))
             {
                 hashDialog.RunSilent = true;
 
@@ -127,7 +127,7 @@ namespace OpenTween
         public void AddHashtag_MultipleTest()
         {
             using (var atDialog = new AtIdSupplement())
-            using (var hashDialog = new HashtagManage(atDialog, new string[0], "", false, false, false))
+            using (var hashDialog = new HashtagManage(atDialog, Array.Empty<string>(), "", false, false, false))
             {
                 hashDialog.RunSilent = true;
 
@@ -146,7 +146,7 @@ namespace OpenTween
         public void AddHashtag_InvalidTest()
         {
             using (var atDialog = new AtIdSupplement())
-            using (var hashDialog = new HashtagManage(atDialog, new string[0], "", false, false, false))
+            using (var hashDialog = new HashtagManage(atDialog, Array.Empty<string>(), "", false, false, false))
             {
                 hashDialog.RunSilent = true;
 
@@ -265,7 +265,7 @@ namespace OpenTween
         public void EditModeSwitch_Test()
         {
             using (var atDialog = new AtIdSupplement())
-            using (var hashDialog = new HashtagManage(atDialog, new string[0], "", false, false, false))
+            using (var hashDialog = new HashtagManage(atDialog, Array.Empty<string>(), "", false, false, false))
             {
                 hashDialog.RunSilent = true;
 

--- a/OpenTween.Tests/OpenTween.Tests.csproj
+++ b/OpenTween.Tests/OpenTween.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenTween</RootNamespace>
     <AssemblyName>OpenTween.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>

--- a/OpenTween.Tests/TweenMainTest.cs
+++ b/OpenTween.Tests/TweenMainTest.cs
@@ -75,7 +75,7 @@ namespace OpenTween
         [Fact]
         public void GetUrlFromDataObject_UnknownFormatTest()
         {
-            using (var memstream = new MemoryStream(new byte[0]))
+            using (var memstream = new MemoryStream(Array.Empty<byte>()))
             {
                 var data = new DataObject("application/x-hogehoge", memstream);
 

--- a/OpenTween/Api/TwitterApiStatus.cs
+++ b/OpenTween/Api/TwitterApiStatus.cs
@@ -72,8 +72,8 @@ namespace OpenTween.Api
             if (limitCount == null || limitRemain == null || limitReset == null)
                 return null;
 
-            var limitResetDate = UnixEpoch.AddSeconds(limitReset.Value).ToLocalTime();
-            return new ApiLimit(limitCount.Value, limitRemain.Value, limitResetDate);
+            var limitResetDate = DateTimeOffset.FromUnixTimeSeconds(limitReset.Value).ToLocalTime();
+            return new ApiLimit(limitCount.Value, limitRemain.Value, limitResetDate.DateTime);
         }
 
         internal static TwitterApiAccessLevel? ParseAccessLevel(IDictionary<string, string> header, string headerName)
@@ -133,8 +133,6 @@ namespace OpenTween.Api
                 this.AccessLevel = accessLevel.Value;
         }
 
-        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         public void UpdateFromJson(TwitterRateLimits json)
         {
             var rateLimits =
@@ -145,7 +143,7 @@ namespace OpenTween.Api
                     Limit: new ApiLimit(
                         item.Value.Limit,
                         item.Value.Remaining,
-                        UnixEpoch.AddSeconds(item.Value.Reset).ToLocalTime()
+                        DateTimeOffset.FromUnixTimeSeconds(item.Value.Reset).ToLocalTime().DateTime
                     )
                 );
 

--- a/OpenTween/ApplicationEvents.cs
+++ b/OpenTween/ApplicationEvents.cs
@@ -65,7 +65,7 @@ namespace OpenTween
 
             if (!CheckRuntimeVersion())
             {
-                var message = string.Format(Properties.Resources.CheckRuntimeVersion_Error, ".NET Framework 4.5.1");
+                var message = string.Format(Properties.Resources.CheckRuntimeVersion_Error, ".NET Framework 4.6.2");
                 MessageBox.Show(message, Application.ProductName, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return 1;
             }
@@ -144,14 +144,14 @@ namespace OpenTween
             if (Type.GetType("Mono.Runtime", false) != null)
                 return true;
 
-            // .NET Framework 4.5.1 以降で動作しているかチェックする
+            // .NET Framework 4.6.2 以降で動作しているかチェックする
             // 参照: http://msdn.microsoft.com/en-us/library/hh925568%28v=vs.110%29.aspx
 
             using (var lmKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
             using (var ndpKey = lmKey.OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
             {
                 var releaseKey = (int)ndpKey.GetValue("Release");
-                return releaseKey >= 378675;
+                return releaseKey >= 394802;
             }
         }
 

--- a/OpenTween/Connection/OAuthUtility.cs
+++ b/OpenTween/Connection/OAuthUtility.cs
@@ -38,11 +38,6 @@ namespace OpenTween.Connection
     public static class OAuthUtility
     {
         /// <summary>
-        /// OAuth署名のoauth_timestamp算出用基準日付（1970/1/1 00:00:00）
-        /// </summary>
-        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
-
-        /// <summary>
         /// OAuth署名のoauth_nonce算出用乱数クラス
         /// </summary>
         private static readonly Random NonceRandom = new Random();
@@ -94,7 +89,7 @@ namespace OpenTween.Connection
             Dictionary<string, string> parameter = new Dictionary<string, string>();
             parameter.Add("oauth_consumer_key", consumerKey);
             parameter.Add("oauth_signature_method", "HMAC-SHA1");
-            parameter.Add("oauth_timestamp", Convert.ToInt64((DateTime.UtcNow - UnixEpoch).TotalSeconds).ToString()); // epoch秒
+            parameter.Add("oauth_timestamp", DateTimeOffset.Now.ToUnixTimeSeconds().ToString()); // epoch秒
             parameter.Add("oauth_nonce", NonceRandom.Next(123400, 9999999).ToString());
             parameter.Add("oauth_version", "1.0");
             if (!string.IsNullOrEmpty(token))

--- a/OpenTween/Models/LocalSearchTabModel.cs
+++ b/OpenTween/Models/LocalSearchTabModel.cs
@@ -39,6 +39,6 @@ namespace OpenTween.Models
         }
 
         public override Task RefreshAsync(Twitter tw, bool backward, bool startup, IProgress<string> progress)
-            => Task.FromResult(0); // 何もしない
+            => Task.CompletedTask; // 何もしない
     }
 }

--- a/OpenTween/Models/MuteTabModel.cs
+++ b/OpenTween/Models/MuteTabModel.cs
@@ -45,6 +45,6 @@ namespace OpenTween.Models
         }
 
         public override Task RefreshAsync(Twitter tw, bool backward, bool startup, IProgress<string> progress)
-            => Task.FromResult(0); // 何もしない
+            => Task.CompletedTask; // 何もしない
     }
 }

--- a/OpenTween/Models/PostClass.cs
+++ b/OpenTween/Models/PostClass.cs
@@ -153,7 +153,7 @@ namespace OpenTween.Models
                 if (deepExpand)
                     this.ExpandTask = this.DeepExpandAsync();
                 else
-                    this.ExpandTask = Task.FromResult(0);
+                    this.ExpandTask = Task.CompletedTask;
             }
 
             protected virtual async Task DeepExpandAsync()

--- a/OpenTween/Models/PostClass.cs
+++ b/OpenTween/Models/PostClass.cs
@@ -192,8 +192,8 @@ namespace OpenTween.Models
             RetweetedBy = "";
             Media = new List<MediaInfo>();
             ReplyToList = new List<Tuple<long, string>>();
-            QuoteStatusIds = new long[0];
-            ExpandedUrls = new ExpandedUrlInfo[0];
+            QuoteStatusIds = Array.Empty<long>();
+            ExpandedUrls = Array.Empty<ExpandedUrlInfo>();
         }
 
         public string TextSingleLine

--- a/OpenTween/Models/PostFilterRule.cs
+++ b/OpenTween/Models/PostFilterRule.cs
@@ -95,7 +95,7 @@ namespace OpenTween.Models
             get => this._FilterBody;
             set => this.SetProperty(ref this._FilterBody, value ?? throw new ArgumentNullException(nameof(value)));
         }
-        private string[] _FilterBody = new string[0];
+        private string[] _FilterBody = Array.Empty<string>();
 
         [XmlArray("ExBodyFilterArray")]
         public string[] ExFilterBody
@@ -103,7 +103,7 @@ namespace OpenTween.Models
             get => this._ExFilterBody;
             set => this.SetProperty(ref this._ExFilterBody, value ?? throw new ArgumentNullException(nameof(value)));
         }
-        private string[] _ExFilterBody = new string[0];
+        private string[] _ExFilterBody = Array.Empty<string>();
 
         [XmlElement("SearchBoth")]
         public bool UseNameField

--- a/OpenTween/Models/TabInformations.cs
+++ b/OpenTween/Models/TabInformations.cs
@@ -349,7 +349,7 @@ namespace OpenTween.Models
             lock (this.LockObj)
             {
                 soundFile = "";
-                notifyPosts = new PostClass[0];
+                notifyPosts = Array.Empty<PostClass>();
                 newMentionOrDm = false;
                 isDeletePost = false;
 

--- a/OpenTween/MyLists.cs
+++ b/OpenTween/MyLists.cs
@@ -45,10 +45,10 @@ namespace OpenTween
         private readonly string contextScreenName;
 
         /// <summary>自分が所有しているリスト</summary>
-        private ListElement[] ownedLists = new ListElement[0];
+        private ListElement[] ownedLists = Array.Empty<ListElement>();
 
         /// <summary>操作対象のユーザーが追加されているリストのID</summary>
-        private long[] addedListIds = new long[0];
+        private long[] addedListIds = Array.Empty<long>();
 
         public MyLists()
         {

--- a/OpenTween/OpenTween.csproj
+++ b/OpenTween/OpenTween.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenTween</RootNamespace>
     <AssemblyName>OpenTween</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/OpenTween/Setting/SettingTabs.cs
+++ b/OpenTween/Setting/SettingTabs.cs
@@ -80,7 +80,7 @@ namespace OpenTween
             /// <summary>
             /// 振り分けルール (<see cref="MyCommon.TabUsageType.UserDefined"/> で使用)
             /// </summary>
-            public PostFilterRule[] FilterArray { get; set; } = new PostFilterRule[0];
+            public PostFilterRule[] FilterArray { get; set; } = Array.Empty<PostFilterRule>();
 
             /// <summary>
             /// 表示するユーザーのスクリーンネーム (<see cref="MyCommon.TabUsageType.UserTimeline"/> で使用)

--- a/OpenTween/ShortcutCommand.cs
+++ b/OpenTween/ShortcutCommand.cs
@@ -83,7 +83,7 @@ namespace OpenTween
         private ShortcutCommand()
         {
             this.shortcuts = Array.Empty<Keys>();
-            this.command = () => Task.FromResult(0);
+            this.command = () => Task.CompletedTask;
             this.onlyWhen = () => true;
             this.focusedOn = FocusedControl.None;
             this.notFocusedOn = FocusedControl.None;
@@ -190,15 +190,12 @@ namespace OpenTween
                 return this.instance;
             }
 
-            /// <summary>何もしないタスク</summary>
-            private static Task noOpTask = Task.FromResult(0);
-
             /// <summary>
             /// Action を Func&lt;Task&gt; に変換します
             /// </summary>
             private static Func<Task> SynchronousTask(Action action)
             {
-                return () => { action(); return noOpTask; };
+                return () => { action(); return Task.CompletedTask; };
             }
         }
     }

--- a/OpenTween/ShortcutCommand.cs
+++ b/OpenTween/ShortcutCommand.cs
@@ -82,7 +82,7 @@ namespace OpenTween
 
         private ShortcutCommand()
         {
-            this.shortcuts = new Keys[0];
+            this.shortcuts = Array.Empty<Keys>();
             this.command = () => Task.FromResult(0);
             this.onlyWhen = () => true;
             this.focusedOn = FocusedControl.None;

--- a/OpenTween/Thumbnail/Services/Tumblr.cs
+++ b/OpenTween/Thumbnail/Services/Tumblr.cs
@@ -100,7 +100,7 @@ namespace OpenTween.Thumbnail.Services
 
                 var item = xElm.XPathSelectElement("/response/posts/item[1]");
                 if (item == null)
-                    return new ThumbnailInfo[0];
+                    return Array.Empty<ThumbnailInfo>();
 
                 var postUrlElm = item.Element("post_url");
 

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -1570,7 +1570,7 @@ namespace OpenTween
             {
                 return new ListViewSelection
                 {
-                    SelectedStatusIds = new long[0],
+                    SelectedStatusIds = Array.Empty<long>(),
                     SelectionMarkStatusId = null,
                     FocusedStatusId = null,
                 };
@@ -5932,7 +5932,7 @@ namespace OpenTween
             }
         }
 
-        private ShortcutCommand[] shortcutCommands = new ShortcutCommand[0];
+        private ShortcutCommand[] shortcutCommands = Array.Empty<ShortcutCommand>();
 
         private void InitializeShortcuts()
         {

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -164,7 +164,7 @@ namespace OpenTween
         private readonly object LockObj = new object();
         private ISet<long> followerId = new HashSet<long>();
         private bool _GetFollowerResult = false;
-        private long[] noRTId = new long[0];
+        private long[] noRTId = Array.Empty<long>();
         private bool _GetNoRetweetResult = false;
 
         //プロパティからアクセスされる共通情報

--- a/OpenTween/app.config
+++ b/OpenTween/app.config
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
   <appSettings>
     <add key="EnableWindowsFormsHighDpiAutoResizing" value="true"/>

--- a/OpenTween/app.manifest
+++ b/OpenTween/app.manifest
@@ -25,9 +25,6 @@
       <!--このアプリケーションが動作するように設計されている、Windows のすべてのバージョンの一覧。
       Windows は最も互換性の高い環境を自動的に選択します。-->
 
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
 


### PR DESCRIPTION
以下の条件が全て揃ったらマージする

- [x] Windows Vista の延長サポートが終了する (2017/04/11 米国時間)
  - .NET Framework 4.6.1 以上に移行することで容赦なくVistaを切り捨てる
- [x] AppVeyor が .NET Framework 4.6.2 のプロジェクトのビルドに対応する
- [ ] ~Travis CI (Mono) が .NET Framework 4.6.2 のプロジェクトのビルドに対応する~
  - C#7.0 への移行 (#44) のため Travis CI でのビルドを停止中