### PR TITLE
Mastodonクライアントの実装

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           $altCoverPath = "$($env:NUGET_PACKAGES)\altcover\$($altCoverVersion)\tools\$($targetFramework)\AltCover.exe"
           $xunitPath = "$($env:NUGET_PACKAGES)\xunit.runner.console\$($xunitVersion)\tools\$($targetFramework)\xunit.console.exe"
 
-          Start-Process `
+          $p = Start-Process `
             -FilePath $altCoverPath `
             -ArgumentList (
               '--inputDirectory',
@@ -105,9 +105,14 @@ jobs:
               '--visibleBranches'
             ) `
             -NoNewWindow `
+            -PassThru `
             -Wait
 
-          Start-Process `
+          if ($p.ExitCode -ne 0) {
+            exit $p.ExitCode
+          }
+
+          $p = Start-Process `
             -FilePath $altCoverPath `
             -ArgumentList (
               'runner',
@@ -119,7 +124,12 @@ jobs:
               '.\__Instrumented\OpenTween.Tests.dll'
             ) `
             -NoNewWindow `
+            -PassThru `
             -Wait
+
+          if ($p.ExitCode -ne 0) {
+            exit $p.ExitCode
+          }
 
       - name: Upload test results to codecov
         shell: pwsh

--- a/OpenTween.Tests/Models/PostClassTest.cs
+++ b/OpenTween.Tests/Models/PostClassTest.cs
@@ -144,9 +144,10 @@ namespace OpenTween.Models
             {
                 IsProtect = protect,
                 IsMark = mark,
-                InReplyToStatusId = reply ? (long?)100L : null,
                 PostGeo = geo ? new PostClass.StatusGeo(-126.716667, -47.15) : (PostClass.StatusGeo?)null,
             };
+            if (reply)
+                post.InReplyToStatusId = 100L;
 
             Assert.Equal(expected, post.StateIndex);
         }
@@ -213,9 +214,7 @@ namespace OpenTween.Models
 
             post.IsDeleted = true;
 
-            Assert.Null(post.InReplyToStatusId);
-            Assert.Equal("", post.InReplyToUser);
-            Assert.Null(post.InReplyToUserId);
+            Assert.False(post.HasInReplyTo);
             Assert.False(post.IsReply);
             Assert.Empty(post.ReplyToList);
             Assert.Equal(-1, post.StateIndex);

--- a/OpenTween.Tests/Models/PostClassTest.cs
+++ b/OpenTween.Tests/Models/PostClassTest.cs
@@ -57,7 +57,7 @@ namespace OpenTween.Models
             {
                 get
                 {
-                    var retweetedId = this.RetweetedId!.Value;
+                    var retweetedId = this.RetweetedId;
                     var group = this.Group;
                     if (group == null)
                         throw new InvalidOperationException("TestPostClass needs group");
@@ -115,8 +115,8 @@ namespace OpenTween.Models
             post.IsFav = isFav;
             Assert.Equal(isFav, post.IsFav);
 
-            if (post.RetweetedId != null)
-                Assert.Equal(isFav, this.postGroup[post.RetweetedId.Value].IsFav);
+            if (post.IsRetweet)
+                Assert.Equal(isFav, this.postGroup[post.RetweetedId].IsFav);
         }
 
 #pragma warning disable SA1008 // Opening parenthesis should be spaced correctly
@@ -274,6 +274,7 @@ namespace OpenTween.Models
         {
             var post = new TestPostClass
             {
+                RetweetedId = 100L,
                 RetweetedByUserId = 111L, // 自分がリツイートした
                 UserId = 222L, // 他人のツイート
             };
@@ -286,6 +287,7 @@ namespace OpenTween.Models
         {
             var post = new TestPostClass
             {
+                RetweetedId = 100L,
                 RetweetedByUserId = 333L, // 他人がリツイートした
                 UserId = 222L, // 他人のツイート
             };
@@ -298,6 +300,7 @@ namespace OpenTween.Models
         {
             var post = new TestPostClass
             {
+                RetweetedId = 100L,
                 RetweetedByUserId = 222L, // 他人がリツイートした
                 UserId = 111L, // 自分のツイート
             };
@@ -386,9 +389,7 @@ namespace OpenTween.Models
             Assert.Equal("@aaa", originalPost.ScreenName);
             Assert.Equal(1L, originalPost.UserId);
 
-            Assert.Null(originalPost.RetweetedId);
-            Assert.Equal("", originalPost.RetweetedBy);
-            Assert.Null(originalPost.RetweetedByUserId);
+            Assert.False(originalPost.IsRetweet);
             Assert.Equal(1, originalPost.RetweetedCount);
         }
 
@@ -396,7 +397,7 @@ namespace OpenTween.Models
         public void ConvertToOriginalPost_ErrorTest()
         {
             // 公式 RT でないツイート
-            var post = new PostClass { StatusId = 100L, RetweetedId = null };
+            var post = new PostClass { StatusId = 100L };
 
             Assert.Throws<InvalidOperationException>(() => post.ConvertToOriginalPost());
         }

--- a/OpenTween.Tests/Models/PostFilterRuleTest.cs
+++ b/OpenTween.Tests/Models/PostFilterRuleTest.cs
@@ -171,10 +171,10 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // FilterName は RetweetedBy にもマッチする
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // FilterName は完全一致 (UseRegex = false の場合)
@@ -209,10 +209,10 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // ExFilterName は RetweetedBy にもマッチする
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // ExFilterName は完全一致 (ExUseRegex = false の場合)
@@ -248,10 +248,10 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // FilterName は RetweetedBy にもマッチする
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // FilterName は部分一致 (UseRegex = true の場合)
@@ -287,10 +287,10 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // ExFilterName は RetweetedBy にもマッチする
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "hogehoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar" };
+            post = new PostClass { ScreenName = "foo", RetweetedBy = "bar", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // ExFilterName は部分一致 (ExUseRegex = true の場合)
@@ -645,11 +645,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // TextFromApi と RetweetedBy に FilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // ScreenName に対しては完全一致 (UseRegex = false の場合)
@@ -666,7 +666,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -675,7 +675,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
         }
 
@@ -710,11 +710,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // TextFromApi と RetweetedBy に ExFilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // ScreenName に対しては完全一致 (ExUseRegex = false の場合)
@@ -731,7 +731,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -740,7 +740,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
         }
 
@@ -776,11 +776,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // TextFromApi と RetweetedBy に FilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // ScreenName に対しても部分一致 (UseRegex = true の場合)
@@ -797,7 +797,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -806,7 +806,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
         }
 
@@ -842,11 +842,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // TextFromApi と RetweetedBy に ExFilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "bbb", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", TextFromApi = "bbb", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // ScreenName に対しても部分一致 (ExUseRegex = true の場合)
@@ -863,7 +863,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -872,7 +872,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", TextFromApi = "Bbb" };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", TextFromApi = "Bbb", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
         }
 
@@ -910,11 +910,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // Text と ScreenName に FilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // ScreenName に対しては完全一致 (UseRegex = false の場合)
@@ -931,7 +931,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -940,7 +940,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
         }
 
@@ -978,11 +978,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // Text と ScreenName に ExFilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // ScreenName に対しては完全一致 (ExUseRegex = false の場合)
@@ -999,7 +999,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -1008,7 +1008,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
         }
 
@@ -1047,11 +1047,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // Text と ScreenName に FilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
             // ScreenName に対しても部分一致 (UseRegex = true の場合)
@@ -1068,7 +1068,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -1077,7 +1077,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.CopyAndMark, filter.ExecFilter(post));
         }
 
@@ -1116,11 +1116,11 @@ namespace OpenTween.Models
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // Text と ScreenName に ExFilterBody の文字列がそれぞれ含まれている
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // RetweetedBy が null でなくても依然として ScreenName にはマッチする
-            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge" };
+            post = new PostClass { ScreenName = "aaa", Text = "<a href='http://example.com/bbb'>t.co/hoge</a>", RetweetedBy = "hoge", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
             // ScreenName に対しても部分一致 (ExUseRegex = true の場合)
@@ -1137,7 +1137,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.None, filter.ExecFilter(post));
 
             // 大小文字を区別しない
@@ -1146,7 +1146,7 @@ namespace OpenTween.Models
             post = new PostClass { ScreenName = "Aaa", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>" };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
 
-            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa" };
+            post = new PostClass { ScreenName = "hoge", Text = "<a href='http://example.com/Bbb'>t.co/hoge</a>", RetweetedBy = "Aaa", RetweetedId = 100L };
             Assert.Equal(MyCommon.HITRESULT.Exclude, filter.ExecFilter(post));
         }
 

--- a/OpenTween.Tests/Models/TabInformationTest.cs
+++ b/OpenTween.Tests/Models/TabInformationTest.cs
@@ -260,6 +260,7 @@ namespace OpenTween.Models
             var post = new PostClass
             {
                 UserId = 11111L,
+                RetweetedId = 100L,
                 RetweetedByUserId = 12345L,
                 Text = "hogehoge",
             };
@@ -274,6 +275,7 @@ namespace OpenTween.Models
             var post = new PostClass
             {
                 UserId = 11111L,
+                RetweetedId = 100L,
                 RetweetedByUserId = 22222L,
                 Text = "hogehoge",
             };

--- a/OpenTween.Tests/Models/TabModelTest.cs
+++ b/OpenTween.Tests/Models/TabModelTest.cs
@@ -729,6 +729,42 @@ namespace OpenTween.Models
 
             Assert.Throws<ArgumentException>(() => tab[2, 0]); // 範囲内だが startIndex > endIndex
         }
+
+        public static TheoryData<bool, TabModel> IsDistributableTabTypeFixtures = new TheoryData<bool, TabModel>
+        {
+            { false, new HomeTabModel("Recent") },
+            { true,  new MentionsTabModel("Reply") },
+            { false, new DirectMessagesTabModel("Direct") },
+            { false, new FavoritesTabModel("Favorite") },
+            { true,  new FilterTabModel("Filter") },
+            { false, new ListTimelineTabModel("List", new ListElement()) },
+            { false, new UserTimelineTabModel("User", "twitterapi") },
+            { false, new PublicSearchTabModel("Search") },
+            { false, new RelatedPostsTabModel("Related", new PostClass()) },
+        };
+
+        [Theory]
+        [MemberData(nameof(IsDistributableTabTypeFixtures))]
+        public void IsDistributableTabType_Test(bool expected, TabModel tab)
+            => Assert.Equal(expected, tab.IsDistributableTabType);
+
+        public static TheoryData<bool, TabModel> IsInnerStorageTabTypeFixtures = new TheoryData<bool, TabModel>
+        {
+            { false, new HomeTabModel("Recent") },
+            { false, new MentionsTabModel("Reply") },
+            { true,  new DirectMessagesTabModel("Direct") },
+            { false, new FavoritesTabModel("Favorite") },
+            { false, new FilterTabModel("Filter") },
+            { true,  new ListTimelineTabModel("List", new ListElement()) },
+            { true,  new UserTimelineTabModel("User", "twitterapi") },
+            { true,  new PublicSearchTabModel("Search") },
+            { true,  new RelatedPostsTabModel("Related", new PostClass()) },
+        };
+
+        [Theory]
+        [MemberData(nameof(IsInnerStorageTabTypeFixtures))]
+        public void IsInnerStorageTabType_Test(bool expected, TabModel tab)
+            => Assert.Equal(expected, tab.IsInnerStorageTabType);
     }
 
     public class TabUsageTypeExtTest
@@ -745,31 +781,5 @@ namespace OpenTween.Models
         [InlineData(MyCommon.TabUsageType.Related,       false)]
         public void IsDefault_Test(MyCommon.TabUsageType tabType, bool expected)
             => Assert.Equal(expected, tabType.IsDefault());
-
-        [Theory]
-        [InlineData(MyCommon.TabUsageType.Home,          false)]
-        [InlineData(MyCommon.TabUsageType.Mentions,      true)]
-        [InlineData(MyCommon.TabUsageType.DirectMessage, false)]
-        [InlineData(MyCommon.TabUsageType.Favorites,     false)]
-        [InlineData(MyCommon.TabUsageType.UserDefined,   true)]
-        [InlineData(MyCommon.TabUsageType.Lists,         false)]
-        [InlineData(MyCommon.TabUsageType.UserTimeline,  false)]
-        [InlineData(MyCommon.TabUsageType.PublicSearch,  false)]
-        [InlineData(MyCommon.TabUsageType.Related,       false)]
-        public void IsDistributable_Test(MyCommon.TabUsageType tabType, bool expected)
-            => Assert.Equal(expected, tabType.IsDistributable());
-
-        [Theory]
-        [InlineData(MyCommon.TabUsageType.Home,          false)]
-        [InlineData(MyCommon.TabUsageType.Mentions,      false)]
-        [InlineData(MyCommon.TabUsageType.DirectMessage, true)]
-        [InlineData(MyCommon.TabUsageType.Favorites,     false)]
-        [InlineData(MyCommon.TabUsageType.UserDefined,   false)]
-        [InlineData(MyCommon.TabUsageType.Lists,         true)]
-        [InlineData(MyCommon.TabUsageType.UserTimeline,  true)]
-        [InlineData(MyCommon.TabUsageType.PublicSearch,  true)]
-        [InlineData(MyCommon.TabUsageType.Related,       true)]
-        public void IsInnerStorage_Test(MyCommon.TabUsageType tabType, bool expected)
-            => Assert.Equal(expected, tabType.IsInnerStorage());
     }
 }

--- a/OpenTween.Tests/Models/TwitterPostFactoryTest.cs
+++ b/OpenTween.Tests/Models/TwitterPostFactoryTest.cs
@@ -108,10 +108,7 @@ namespace OpenTween.Models
             Assert.Null(post.InReplyToStatusId);
             Assert.Null(post.InReplyToUserId);
             Assert.Null(post.InReplyToUser);
-
-            Assert.Null(post.RetweetedId);
-            Assert.Null(post.RetweetedBy);
-            Assert.Null(post.RetweetedByUserId);
+            Assert.False(post.IsRetweet);
 
             Assert.Equal(status.User.Id, post.UserId);
             Assert.Equal("tetete", post.ScreenName);
@@ -267,10 +264,7 @@ namespace OpenTween.Models
             Assert.Null(post.InReplyToStatusId);
             Assert.Null(post.InReplyToUserId);
             Assert.Null(post.InReplyToUser);
-
-            Assert.Null(post.RetweetedId);
-            Assert.Null(post.RetweetedBy);
-            Assert.Null(post.RetweetedByUserId);
+            Assert.False(post.IsRetweet);
 
             Assert.Equal(otherUser.Id, post.UserId);
             Assert.Equal("tetete", post.ScreenName);

--- a/OpenTween.Tests/Models/TwitterPostFactoryTest.cs
+++ b/OpenTween.Tests/Models/TwitterPostFactoryTest.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenTween.Api;
 using OpenTween.Api.DataModel;
 using Xunit;
 
@@ -75,9 +76,11 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_Test()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
             var status = this.CreateStatus();
-            var post = factory.CreateFromStatus(status, selfUserId: 20000L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 20000L, followerIds: EmptyIdSet);
 
             Assert.Equal(status.Id, post.StatusId);
             Assert.Equal(new DateTimeUtc(2022, 1, 1, 0, 0, 0), post.CreatedAt);
@@ -122,10 +125,12 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_AuthorTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
             var status = this.CreateStatus();
             var selfUserId = status.User.Id;
-            var post = factory.CreateFromStatus(status, selfUserId, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId, followerIds: EmptyIdSet);
 
             Assert.True(post.IsMe);
         }
@@ -133,10 +138,12 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_FollowerTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
             var status = this.CreateStatus();
             var followerIds = new HashSet<long> { status.User.Id };
-            var post = factory.CreateFromStatus(status, selfUserId: 20000L, followerIds);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 20000L, followerIds);
 
             Assert.False(post.IsOwl);
         }
@@ -144,10 +151,12 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_NotFollowerTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
             var status = this.CreateStatus();
             var followerIds = new HashSet<long> { 30000L };
-            var post = factory.CreateFromStatus(status, selfUserId: 20000L, followerIds);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 20000L, followerIds);
 
             Assert.True(post.IsOwl);
         }
@@ -155,6 +164,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_RetweetTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
             var originalStatus = this.CreateStatus();
 
@@ -162,7 +173,7 @@ namespace OpenTween.Models
             retweetStatus.RetweetedStatus = originalStatus;
             retweetStatus.Source = "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>";
 
-            var post = factory.CreateFromStatus(retweetStatus, selfUserId: 20000L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, retweetStatus, selfUserId: 20000L, followerIds: EmptyIdSet);
 
             Assert.Equal(retweetStatus.Id, post.StatusId);
             Assert.Equal(retweetStatus.User.Id, post.RetweetedByUserId);
@@ -215,6 +226,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromDirectMessageEvent_Test()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var selfUser = this.CreateUser();
@@ -226,7 +239,7 @@ namespace OpenTween.Models
                 [otherUser.IdStr] = otherUser,
             };
             var apps = this.CreateApps();
-            var post = factory.CreateFromDirectMessageEvent(eventItem, users, apps, selfUserId: selfUser.Id);
+            var post = factory.CreateFromDirectMessageEvent(twitter, eventItem, users, apps, selfUserId: selfUser.Id);
 
             Assert.Equal(long.Parse(eventItem.Id), post.StatusId);
             Assert.Equal(new DateTimeUtc(2022, 1, 1, 0, 0, 0), post.CreatedAt);
@@ -271,6 +284,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromDirectMessageEvent_SenderTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var selfUser = this.CreateUser();
@@ -282,7 +297,7 @@ namespace OpenTween.Models
                 [otherUser.IdStr] = otherUser,
             };
             var apps = this.CreateApps();
-            var post = factory.CreateFromDirectMessageEvent(eventItem, users, apps, selfUserId: selfUser.Id);
+            var post = factory.CreateFromDirectMessageEvent(twitter, eventItem, users, apps, selfUserId: selfUser.Id);
 
             Assert.Equal(otherUser.Id, post.UserId);
             Assert.False(post.IsOwl);
@@ -292,6 +307,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_MediaAltTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var status = this.CreateStatus();
@@ -311,7 +328,7 @@ namespace OpenTween.Models
                 },
             };
 
-            var post = factory.CreateFromStatus(status, selfUserId: 100L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 100L, followerIds: EmptyIdSet);
 
             var accessibleText = string.Format(Properties.Resources.ImageAltText, "代替テキスト");
             Assert.Equal(accessibleText, post.AccessibleText);
@@ -323,6 +340,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_MediaNoAltTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var status = this.CreateStatus();
@@ -342,7 +361,7 @@ namespace OpenTween.Models
                 },
             };
 
-            var post = factory.CreateFromStatus(status, selfUserId: 100L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 100L, followerIds: EmptyIdSet);
 
             Assert.Equal("pic.twitter.com/hoge", post.AccessibleText);
             Assert.Equal("<a href=\"https://t.co/hoge\" title=\"https://twitter.com/hoge/status/1234567890/photo/1\">pic.twitter.com/hoge</a>", post.Text);
@@ -353,6 +372,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_QuotedUrlTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var status = this.CreateStatus();
@@ -383,7 +404,7 @@ namespace OpenTween.Models
                 FullText = "test",
             };
 
-            var post = factory.CreateFromStatus(status, selfUserId: 100L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 100L, followerIds: EmptyIdSet);
 
             var accessibleText = string.Format(Properties.Resources.QuoteStatus_AccessibleText, "foo", "test");
             Assert.Equal(accessibleText, post.AccessibleText);
@@ -395,6 +416,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_QuotedUrlWithPermelinkTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var status = this.CreateStatus();
@@ -418,7 +441,7 @@ namespace OpenTween.Models
                 Expanded = "https://twitter.com/hoge/status/1234567890",
             };
 
-            var post = factory.CreateFromStatus(status, selfUserId: 100L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 100L, followerIds: EmptyIdSet);
 
             var accessibleText = "hoge " + string.Format(Properties.Resources.QuoteStatus_AccessibleText, "foo", "test");
             Assert.Equal(accessibleText, post.AccessibleText);
@@ -430,6 +453,8 @@ namespace OpenTween.Models
         [Fact]
         public void CreateFromStatus_QuotedUrlNoReferenceTest()
         {
+            using var twitterApi = new TwitterApi(ApiKey.Create("fake_consumer_key"), ApiKey.Create("fake_consumer_secret"));
+            using var twitter = new Twitter(twitterApi);
             var factory = new TwitterPostFactory(this.CreateTabinfo());
 
             var status = this.CreateStatus();
@@ -449,7 +474,7 @@ namespace OpenTween.Models
             };
             status.QuotedStatus = null;
 
-            var post = factory.CreateFromStatus(status, selfUserId: 100L, followerIds: EmptyIdSet);
+            var post = factory.CreateFromStatus(twitter, status, selfUserId: 100L, followerIds: EmptyIdSet);
 
             var accessibleText = "twitter.com/hoge/status/1…";
             Assert.Equal(accessibleText, post.AccessibleText);

--- a/OpenTween.Tests/Models/TwitterPostFactoryTest.cs
+++ b/OpenTween.Tests/Models/TwitterPostFactoryTest.cs
@@ -105,9 +105,7 @@ namespace OpenTween.Models
             Assert.False(post.IsMark);
 
             Assert.False(post.IsReply);
-            Assert.Null(post.InReplyToStatusId);
-            Assert.Null(post.InReplyToUserId);
-            Assert.Null(post.InReplyToUser);
+            Assert.False(post.HasInReplyTo);
             Assert.False(post.IsRetweet);
 
             Assert.Equal(status.User.Id, post.UserId);
@@ -261,9 +259,7 @@ namespace OpenTween.Models
             Assert.False(post.IsMark);
 
             Assert.False(post.IsReply);
-            Assert.Null(post.InReplyToStatusId);
-            Assert.Null(post.InReplyToUserId);
-            Assert.Null(post.InReplyToUser);
+            Assert.False(post.HasInReplyTo);
             Assert.False(post.IsRetweet);
 
             Assert.Equal(otherUser.Id, post.UserId);

--- a/OpenTween.Tests/MyCommonTest.cs
+++ b/OpenTween.Tests/MyCommonTest.cs
@@ -176,13 +176,13 @@ namespace OpenTween
             => Assert.Equal(excepted, MyCommon.ReplaceAppName(str, "OpenTween"));
 
         [Theory]
-        [InlineData("1.0.0.0", "1.0.0")]
-        [InlineData("1.0.0.1", "1.0.1-dev")]
-        [InlineData("1.0.0.12", "1.0.1-dev+build.12")]
-        [InlineData("1.0.1.0", "1.0.1")]
-        [InlineData("1.0.9.1", "1.0.10-dev")]
-        [InlineData("1.1.0.0", "1.1.0")]
-        [InlineData("1.9.9.1", "1.9.10-dev")]
+        [InlineData("1.0.0.0", "1.0.0+mastodon")]
+        [InlineData("1.0.0.1", "1.0.1-dev+mastodon")]
+        [InlineData("1.0.0.12", "1.0.1-dev+mastodon+build.12")]
+        [InlineData("1.0.1.0", "1.0.1+mastodon")]
+        [InlineData("1.0.9.1", "1.0.10-dev+mastodon")]
+        [InlineData("1.1.0.0", "1.1.0+mastodon")]
+        [InlineData("1.9.9.1", "1.9.10-dev+mastodon")]
         public void GetReadableVersionTest(string fileVersion, string expected)
             => Assert.Equal(expected, MyCommon.GetReadableVersion(fileVersion));
 

--- a/OpenTween.Tests/MyCommonTest.cs
+++ b/OpenTween.Tests/MyCommonTest.cs
@@ -189,7 +189,7 @@ namespace OpenTween
         public static readonly TheoryData<PostClass, string> GetStatusUrlTest1TestCase = new()
         {
             {
-                new PostClass { StatusId = 249493863826350080L, ScreenName = "Favstar_LM", RetweetedId = null, RetweetedBy = null },
+                new PostClass { StatusId = 249493863826350080L, ScreenName = "Favstar_LM" },
                 "https://twitter.com/Favstar_LM/status/249493863826350080"
             },
             {

--- a/OpenTween.Tests/TwitterTest.cs
+++ b/OpenTween.Tests/TwitterTest.cs
@@ -88,7 +88,7 @@ namespace OpenTween
         {
             var posts = new Dictionary<long, PostClass>
             {
-                [950L] = new PostClass { StatusId = 950L, InReplyToStatusId = null }, // このツイートが末端
+                [950L] = new PostClass { StatusId = 950L }, // このツイートが末端
                 [987L] = new PostClass { StatusId = 987L, InReplyToStatusId = 950L },
                 [999L] = new PostClass { StatusId = 999L, InReplyToStatusId = 987L },
                 [1000L] = new PostClass { StatusId = 1000L, InReplyToStatusId = 999L },

--- a/OpenTween/Api/DataModel/MastodonAccessToken.cs
+++ b/OpenTween/Api/DataModel/MastodonAccessToken.cs
@@ -1,0 +1,43 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonAccessToken
+    {
+        [DataMember(Name = "access_token")]
+        public string AccessToken { get; set; }
+
+        [DataMember(Name = "token_type")]
+        public string TokenType { get; set; }
+
+        [DataMember(Name = "scope")]
+        public string Scope { get; set; }
+
+        [DataMember(Name = "created_at")]
+        public long CreatedAt { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonAccount.cs
+++ b/OpenTween/Api/DataModel/MastodonAccount.cs
@@ -1,0 +1,76 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonAccount
+    {
+        [DataMember(Name = "id")]
+        public long Id { get; set; }
+
+        [DataMember(Name = "username")]
+        public string Username { get; set; }
+
+        [DataMember(Name = "acct")]
+        public string Acct { get; set; }
+
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
+
+        [DataMember(Name = "locked")]
+        public bool Locked { get; set; }
+
+        [DataMember(Name = "created_at")]
+        public string CreatedAt { get; set; }
+
+        [DataMember(Name = "followers_count")]
+        public int FollowersCount { get; set; }
+
+        [DataMember(Name = "following_count")]
+        public int FollowingCount { get; set; }
+
+        [DataMember(Name = "statuses_count")]
+        public int StatusesCount { get; set; }
+
+        [DataMember(Name = "note")]
+        public string Note { get; set; }
+
+        [DataMember(Name = "url")]
+        public string Url { get; set; }
+
+        [DataMember(Name = "avatar")]
+        public string Avatar { get; set; }
+
+        [DataMember(Name = "avatar_static")]
+        public string AvatarStatic { get; set; }
+
+        [DataMember(Name = "header")]
+        public string Header { get; set; }
+
+        [DataMember(Name = "header_static")]
+        public string HeaderStatic { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonApplication.cs
+++ b/OpenTween/Api/DataModel/MastodonApplication.cs
@@ -1,0 +1,37 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonApplication
+    {
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "website")]
+        public string? Website { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonAttachment.cs
+++ b/OpenTween/Api/DataModel/MastodonAttachment.cs
@@ -1,0 +1,49 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonAttachment
+    {
+        [DataMember(Name = "id")]
+        public long Id { get; set; }
+
+        [DataMember(Name = "type")]
+        public string Type { get; set; }
+
+        [DataMember(Name = "url")]
+        public string Url { get; set; }
+
+        [DataMember(Name = "remote_url")]
+        public string RemoteUrl { get; set; }
+
+        [DataMember(Name = "preview_url")]
+        public string PreviewUrl { get; set; }
+
+        [DataMember(Name = "text_url")]
+        public string TextUrl { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonError.cs
+++ b/OpenTween/Api/DataModel/MastodonError.cs
@@ -1,0 +1,34 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonError
+    {
+        [DataMember(Name = "error")]
+        public string Error { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonInstance.cs
+++ b/OpenTween/Api/DataModel/MastodonInstance.cs
@@ -1,0 +1,46 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonInstance
+    {
+        [DataMember(Name = "uri")]
+        public string Uri { get; set; }
+
+        [DataMember(Name = "title")]
+        public string Title { get; set; }
+
+        [DataMember(Name = "description")]
+        public string Description { get; set; }
+
+        [DataMember(Name = "email")]
+        public string Email { get; set; }
+
+        [DataMember(Name = "version")]
+        public string Version { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonMention.cs
+++ b/OpenTween/Api/DataModel/MastodonMention.cs
@@ -1,0 +1,43 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonMention
+    {
+        [DataMember(Name = "url")]
+        public string Url { get; set; }
+
+        [DataMember(Name = "username")]
+        public string Username { get; set; }
+
+        [DataMember(Name = "acct")]
+        public string Acct { get; set; }
+
+        [DataMember(Name = "id")]
+        public long Id { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonRegisteredApp.cs
+++ b/OpenTween/Api/DataModel/MastodonRegisteredApp.cs
@@ -1,0 +1,43 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonRegisteredApp
+    {
+        [DataMember(Name = "id")]
+        public string Id { get; set; }
+
+        [DataMember(Name = "redirect_uri")]
+        public string RedirectUri { get; set; }
+
+        [DataMember(Name = "client_id")]
+        public string ClientId { get; set; }
+
+        [DataMember(Name = "client_secret")]
+        public string ClientSecret { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonStatus.cs
+++ b/OpenTween/Api/DataModel/MastodonStatus.cs
@@ -1,0 +1,91 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonStatus
+    {
+        [DataMember(Name = "id")]
+        public long Id { get; set; }
+
+        [DataMember(Name = "uri")]
+        public string Uri { get; set; }
+
+        [DataMember(Name = "url")]
+        public string Url { get; set; }
+
+        [DataMember(Name = "account")]
+        public MastodonAccount Account { get; set; }
+
+        [DataMember(Name = "in_reply_to_id")]
+        public long? InReplyToId { get; set; }
+
+        [DataMember(Name = "in_reply_to_account_id")]
+        public long? InReplyToAccountId { get; set; }
+
+        [DataMember(Name = "reblog")]
+        public MastodonStatus Reblog { get; set; }
+
+        [DataMember(Name = "content")]
+        public string Content { get; set; }
+
+        [DataMember(Name = "created_at")]
+        public string CreatedAt { get; set; }
+
+        [DataMember(Name = "reblogs_count")]
+        public int ReblogsCount { get; set; }
+
+        [DataMember(Name = "favourites_count")]
+        public int FavouritesCount { get; set; }
+
+        [DataMember(Name = "reblogged")]
+        public bool? Reblogged { get; set; }
+
+        [DataMember(Name = "favourited")]
+        public bool? Favourited { get; set; }
+
+        [DataMember(Name = "sensitive")]
+        public bool? Sensitive { get; set; }
+
+        [DataMember(Name = "spoiler_text")]
+        public string SpoilerText { get; set; }
+
+        [DataMember(Name = "visibility")]
+        public string Visibility { get; set; }
+
+        [DataMember(Name = "media_attachments")]
+        public MastodonAttachment[] MediaAttachments { get; set; }
+
+        [DataMember(Name = "mentions")]
+        public MastodonMention[] Mentions { get; set; }
+
+        [DataMember(Name = "tags")]
+        public MastodonTag[] Tags { get; set; }
+
+        [DataMember(Name = "application")]
+        public MastodonApplication Application { get; set; }
+    }
+}

--- a/OpenTween/Api/DataModel/MastodonTag.cs
+++ b/OpenTween/Api/DataModel/MastodonTag.cs
@@ -1,0 +1,37 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable annotations
+
+using System.Runtime.Serialization;
+
+namespace OpenTween.Api.DataModel
+{
+    [DataContract]
+    public class MastodonTag
+    {
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "url")]
+        public string Url { get; set; }
+    }
+}

--- a/OpenTween/Api/MastodonApi.cs
+++ b/OpenTween/Api/MastodonApi.cs
@@ -56,6 +56,37 @@ namespace OpenTween.Api
             return this.Connection.GetAsync<MastodonStatus[]>(endpoint, param);
         }
 
+        public Task<LazyJson<MastodonStatus>> StatusesPost(
+            string status,
+            long? inReplyToId = null,
+            IReadOnlyList<long>? mediaIds = null,
+            bool? sensitive = null,
+            string? spoilerText = null,
+            string? visibility = null)
+        {
+            var endpoint = new Uri("/api/v1/statuses", UriKind.Relative);
+            var param = new Dictionary<string, string>
+            {
+                ["status"] = status,
+            };
+
+            if (inReplyToId != null)
+                param["in_reply_to_id"] = inReplyToId.ToString();
+            if (sensitive != null)
+                param["sensitive"] = sensitive.Value ? "true" : "false";
+            if (spoilerText != null)
+                param["spoiler_text"] = spoilerText;
+            if (visibility != null)
+                param["visibility"] = visibility;
+
+            var paramList = param.ToList();
+
+            foreach (var mediaId in mediaIds ?? Enumerable.Empty<long>())
+                paramList.Add(new KeyValuePair<string, string>("media_ids[]", mediaId.ToString()));
+
+            return this.Connection.PostLazyAsync<MastodonStatus>(endpoint, paramList);
+        }
+
         public Task StatusesDelete(long statusId)
         {
             var endpoint = new Uri($"/api/v1/statuses/{statusId}", UriKind.Relative);

--- a/OpenTween/Api/MastodonApi.cs
+++ b/OpenTween/Api/MastodonApi.cs
@@ -1,0 +1,62 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using OpenTween.Api.DataModel;
+using OpenTween.Connection;
+
+namespace OpenTween.Api
+{
+    public sealed class MastodonApi : IDisposable
+    {
+        public IMastodonApiConnection Connection { get; }
+
+        public MastodonApi(Uri instanceUri, string? accessToken)
+        {
+            this.Connection = new MastodonApiConnection(instanceUri, accessToken);
+        }
+
+        public Task<MastodonStatus[]> TimelinesHome(long? maxId = null, long? sinceId = null, int? limit = null)
+        {
+            var endpoint = new Uri("/api/v1/timelines/home", UriKind.Relative);
+            var param = new Dictionary<string, string>();
+
+            if (maxId != null)
+                param["max_id"] = maxId.ToString();
+            if (sinceId != null)
+                param["since_id"] = sinceId.ToString();
+            if (limit != null)
+                param["limit"] = limit.ToString();
+
+            return this.Connection.GetAsync<MastodonStatus[]>(endpoint, param);
+        }
+
+        public void Dispose()
+            => this.Connection.Dispose();
+    }
+}

--- a/OpenTween/Api/MastodonApi.cs
+++ b/OpenTween/Api/MastodonApi.cs
@@ -56,6 +56,41 @@ namespace OpenTween.Api
             return this.Connection.GetAsync<MastodonStatus[]>(endpoint, param);
         }
 
+        public Task StatusesDelete(long statusId)
+        {
+            var endpoint = new Uri($"/api/v1/statuses/{statusId}", UriKind.Relative);
+
+            return this.Connection.PostLazyAsync<object>(HttpMethod.Delete, endpoint, null).IgnoreResponse();
+        }
+
+        public Task<LazyJson<MastodonStatus>> StatusesFavourite(long statusId)
+        {
+            var endpoint = new Uri($"/api/v1/statuses/{statusId}/favourite", UriKind.Relative);
+
+            return this.Connection.PostLazyAsync<MastodonStatus>(endpoint, null);
+        }
+
+        public Task<LazyJson<MastodonStatus>> StatusesUnfavourite(long statusId)
+        {
+            var endpoint = new Uri($"/api/v1/statuses/{statusId}/unfavourite", UriKind.Relative);
+
+            return this.Connection.PostLazyAsync<MastodonStatus>(endpoint, null);
+        }
+
+        public Task<LazyJson<MastodonStatus>> StatusesReblog(long statusId)
+        {
+            var endpoint = new Uri($"/api/v1/statuses/{statusId}/reblog", UriKind.Relative);
+
+            return this.Connection.PostLazyAsync<MastodonStatus>(endpoint, null);
+        }
+
+        public Task<LazyJson<MastodonStatus>> StatusesUnreblog(long statusId)
+        {
+            var endpoint = new Uri($"/api/v1/statuses/{statusId}/unreblog", UriKind.Relative);
+
+            return this.Connection.PostLazyAsync<MastodonStatus>(endpoint, null);
+        }
+
         public void Dispose()
             => this.Connection.Dispose();
     }

--- a/OpenTween/AppendSettingDialog.cs
+++ b/OpenTween/AppendSettingDialog.cs
@@ -252,8 +252,7 @@ namespace OpenTween
 
             var pinPageUrl = TwitterApiConnection.GetAuthorizeUri(requestToken);
 
-            var browserPath = this.ActionPanel.BrowserPathText.Text;
-            var pin = AuthDialog.DoAuth(this, pinPageUrl, browserPath);
+            var pin = this.ShowAuthDialog(pinPageUrl);
             if (MyCommon.IsNullOrEmpty(pin))
                 return null; // キャンセルされた場合
 
@@ -266,6 +265,12 @@ namespace OpenTween
                 AccessToken = accessTokenResponse["oauth_token"],
                 AccessSecretPlain = accessTokenResponse["oauth_token_secret"],
             };
+        }
+
+        public string? ShowAuthDialog(Uri pinPageUrl)
+        {
+            var browserPath = this.ActionPanel.BrowserPathText.Text;
+            return AuthDialog.DoAuth(this, pinPageUrl, browserPath);
         }
 
         private void CheckPostAndGet_CheckedChanged(object sender, EventArgs e)

--- a/OpenTween/AppendSettingDialog.cs
+++ b/OpenTween/AppendSettingDialog.cs
@@ -263,8 +263,8 @@ namespace OpenTween
             {
                 Username = accessTokenResponse["screen_name"],
                 UserId = long.Parse(accessTokenResponse["user_id"]),
-                Token = accessTokenResponse["oauth_token"],
-                TokenSecret = accessTokenResponse["oauth_token_secret"],
+                AccessToken = accessTokenResponse["oauth_token"],
+                AccessSecretPlain = accessTokenResponse["oauth_token_secret"],
             };
         }
 

--- a/OpenTween/AppendSettingDialog.cs
+++ b/OpenTween/AppendSettingDialog.cs
@@ -121,7 +121,7 @@ namespace OpenTween
         {
             if (MyCommon.EndingFlag) return;
 
-            if (this.BasedPanel.AuthUserCombo.SelectedIndex == -1 && e.CloseReason == CloseReason.None)
+            if (this.BasedPanel.AuthUserCombo.SelectedIndex == -1 && !this.BasedPanel.HasMastodonCredential && e.CloseReason == CloseReason.None)
             {
                 if (MessageBox.Show(Properties.Resources.Setting_FormClosing1, "Confirm", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.Cancel)
                 {

--- a/OpenTween/ApplicationSettings.cs
+++ b/OpenTween/ApplicationSettings.cs
@@ -128,6 +128,20 @@ namespace OpenTween
         public static readonly ApiKey TwitterConsumerSecret = ApiKey.Create("%e%p93BdDzlwbYIC5Ych/47OQ==%xYZTCYaBxzS4An3o7Qcigjp9QMtu5vi5iEAW/sNgoOoAUyuHJRPP3Ovs20ZV2fAYKxUDiu76dxLfObwI7QjSRA==%YEruRDAQdbJzO+y6kn7+U/uIyIyNra/8Ulo+L6KJcWA=");
 
         // =====================================================================
+        // Mastodon
+
+        /// <summary>
+        /// Mastodon インスタンス毎に事前に発行した client_id, client_secret の組
+        /// </summary>
+        /// <remarks>
+        /// ここに含まれていないインスタンスでは <see cref="Api.MastodonApi.AppsRegister"/> によって
+        /// アプリケーションの登録を都度行います
+        /// </remarks>
+        public static readonly IReadOnlyDictionary<string, Tuple<string, string>> MastodonClientIds = new Dictionary<string, Tuple<string, string>>
+        {
+        };
+
+        // =====================================================================
         // Foursquare
         // https://developer.foursquare.com/ から取得できます。
 

--- a/OpenTween/ApplicationSettings.cs
+++ b/OpenTween/ApplicationSettings.cs
@@ -103,7 +103,7 @@ namespace OpenTween
         /// version.txt のフォーマットについては http://sourceforge.jp/projects/opentween/wiki/VersionTxt を参照。
         /// 派生プロジェクトなどでこの機能を無効にする場合は null をセットして下さい。
         /// </remarks>
-        public static readonly string VersionInfoUrl = "https://www.opentween.org/status/version.txt";
+        public static readonly string? VersionInfoUrl = null;
 
         // =====================================================================
         // 暗号化キー

--- a/OpenTween/Connection/IMastodonApiConnection.cs
+++ b/OpenTween/Connection/IMastodonApiConnection.cs
@@ -1,0 +1,42 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace OpenTween.Connection
+{
+    public interface IMastodonApiConnection : IDisposable
+    {
+        Task<T> GetAsync<T>(Uri uri, IEnumerable<KeyValuePair<string, string>>? param);
+
+        Task<LazyJson<T>> PostLazyAsync<T>(Uri uri, IEnumerable<KeyValuePair<string, string>>? param);
+
+        Task<LazyJson<T>> PostLazyAsync<T>(HttpMethod method, Uri uri, IEnumerable<KeyValuePair<string, string>>? param);
+
+        Task<Stream> GetStreamAsync(Uri uri, IEnumerable<KeyValuePair<string, string>>? param);
+    }
+}

--- a/OpenTween/Connection/MastodonApiConnection.cs
+++ b/OpenTween/Connection/MastodonApiConnection.cs
@@ -1,0 +1,200 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Cache;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+
+namespace OpenTween.Connection
+{
+    public sealed class MastodonApiConnection : IMastodonApiConnection
+    {
+        public Uri InstanceUri { get; }
+
+        public Uri WebsocketUri { get; }
+
+        public string? AccessToken { get; }
+
+        internal HttpClient Http = null!;
+
+        public MastodonApiConnection(Uri instanceUri)
+            : this(instanceUri, accessToken: null)
+        {
+        }
+
+        public MastodonApiConnection(Uri instanceUri, string? accessToken)
+        {
+            this.InstanceUri = instanceUri;
+            this.AccessToken = accessToken;
+
+            var websocketUri = new UriBuilder(this.InstanceUri);
+            websocketUri.Scheme = websocketUri.Scheme == "https" ? "wss" : "ws";
+            this.WebsocketUri = websocketUri.Uri;
+
+            this.InitializeHttpClient();
+            Networking.WebProxyChanged += this.Networking_WebProxyChanged;
+        }
+
+        public async Task<T> GetAsync<T>(Uri uri, IEnumerable<KeyValuePair<string, string>>? param)
+        {
+            var requestUri = new Uri(this.InstanceUri, uri);
+
+            if (param != null)
+                requestUri = new Uri(requestUri, "?" + MyCommon.BuildQueryString(param));
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                if (!MyCommon.IsNullOrEmpty(this.AccessToken))
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.AccessToken);
+
+                using var response = await this.Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+                    .ConfigureAwait(false);
+
+                response.EnsureSuccessStatusCode();
+
+                using var content = response.Content;
+                var responseText = await content.ReadAsStringAsync()
+                    .ConfigureAwait(false);
+
+                try
+                {
+                    return MyCommon.CreateDataFromJson<T>(responseText);
+                }
+                catch (SerializationException ex)
+                {
+                    throw new WebApiException("Invalid Response", responseText, ex);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new WebApiException(ex.InnerException?.Message ?? ex.Message, ex);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new WebApiException("Timeout", ex);
+            }
+        }
+
+        public async Task<Stream> GetStreamAsync(Uri uri, IEnumerable<KeyValuePair<string, string>>? param)
+        {
+            var requestUri = new Uri(this.InstanceUri, uri);
+
+            if (param != null)
+                requestUri = new Uri(requestUri, "?" + MyCommon.BuildQueryString(param));
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                if (!MyCommon.IsNullOrEmpty(this.AccessToken))
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.AccessToken);
+
+                using var response = await this.Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+                    .ConfigureAwait(false);
+
+                response.EnsureSuccessStatusCode();
+
+                return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new WebApiException(ex.InnerException?.Message ?? ex.Message, ex);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new WebApiException("Timeout", ex);
+            }
+        }
+
+        public Task<LazyJson<T>> PostLazyAsync<T>(Uri uri, IEnumerable<KeyValuePair<string, string>>? param)
+            => this.PostLazyAsync<T>(HttpMethod.Post, uri, param);
+
+        public async Task<LazyJson<T>> PostLazyAsync<T>(HttpMethod method, Uri uri, IEnumerable<KeyValuePair<string, string>>? param)
+        {
+            var requestUri = new Uri(this.InstanceUri, uri);
+
+            if (param == null)
+                param = Enumerable.Empty<KeyValuePair<string, string>>();
+
+            try
+            {
+                using var request = new HttpRequestMessage(method, requestUri);
+                using var postContent = new FormUrlEncodedContent(param);
+
+                if (!string.IsNullOrEmpty(this.AccessToken))
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.AccessToken);
+
+                request.Content = postContent;
+
+                HttpResponseMessage? response = null;
+                try
+                {
+                    response = await this.Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+                        .ConfigureAwait(false);
+
+                    response.EnsureSuccessStatusCode();
+
+                    var result = new LazyJson<T>(response);
+                    response = null;
+
+                    return result;
+                }
+                finally
+                {
+                    response?.Dispose();
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new WebApiException(ex.InnerException?.Message ?? ex.Message, ex);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new WebApiException("Timeout", ex);
+            }
+        }
+
+        public void Dispose()
+        {
+            Networking.WebProxyChanged -= this.Networking_WebProxyChanged;
+            this.Http.Dispose();
+        }
+
+        private void InitializeHttpClient()
+        {
+            var innerHandler = Networking.CreateHttpClientHandler();
+            innerHandler.CachePolicy = new RequestCachePolicy(RequestCacheLevel.BypassCache);
+
+            this.Http = Networking.CreateHttpClient(innerHandler);
+        }
+
+        private void Networking_WebProxyChanged(object sender, EventArgs e)
+            => this.InitializeHttpClient();
+    }
+}

--- a/OpenTween/Connection/Networking.cs
+++ b/OpenTween/Connection/Networking.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Cache;
 using System.Net.Http;
+using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -190,6 +191,14 @@ namespace OpenTween.Connection
             client.DefaultRequestHeaders.Add("User-Agent", Networking.GetUserAgentString());
 
             return client;
+        }
+
+        public static void SetWebSocketOptions(ClientWebSocketOptions options)
+        {
+            if (Networking.Proxy != null)
+                options.Proxy = Networking.Proxy;
+
+            options.SetRequestHeader("User-Agent", Networking.GetUserAgentString());
         }
 
         public static string GetUserAgentString(bool fakeMSIE = false)

--- a/OpenTween/Mastodon.cs
+++ b/OpenTween/Mastodon.cs
@@ -1,0 +1,151 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using OpenTween.Api;
+using OpenTween.Api.DataModel;
+using OpenTween.Models;
+
+namespace OpenTween
+{
+    public sealed class Mastodon : IDisposable
+    {
+        public long UserId { get; private set; }
+
+        public string Username { get; private set; } = "";
+
+        public MastodonApi Api => this.ApiInternal ?? throw new WebApiException("Unauthorized");
+
+        internal MastodonApi ApiInternal = null!;
+
+        public void Initialize(MastodonCredential account)
+        {
+            this.ApiInternal = new MastodonApi(new Uri(account.InstanceUri), account.AccessTokenPlain);
+
+            this.UserId = account.UserId;
+            this.Username = account.Username;
+        }
+
+        public async Task<PostClass[]> GetHomeTimelineAsync(MastodonHomeTab tab, bool backward)
+        {
+            MastodonStatus[] statuses;
+            if (backward)
+            {
+                statuses = await this.Api.TimelinesHome(maxId: tab.OldestId)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                statuses = await this.Api.TimelinesHome()
+                    .ConfigureAwait(false);
+            }
+
+            return statuses.Select(x => this.CreatePost(x)).ToArray();
+        }
+
+        public PostClass CreatePost(MastodonStatus status)
+        {
+            var post = new PostClass();
+            post.StatusId = status.Id; // TODO: Twitterの status_id と衝突する
+
+            if (status.Reblog != null)
+            {
+                var reblog = status.Reblog;
+                post.CreatedAt = this.ParseDateTime(reblog.CreatedAt);
+                post.RetweetedId = reblog.Id;
+                post.TextFromApi = Regex.Replace(reblog.Content, "<[^>]+>", "");
+                post.Text = reblog.Content;
+                post.IsFav = reblog.Favourited ?? false;
+
+                if (reblog.InReplyToId != null)
+                {
+                    post.InReplyToStatusId = reblog.InReplyToId.Value;
+                    post.InReplyToUserId = reblog.InReplyToAccountId!.Value;
+                    post.InReplyToUser = reblog.Mentions.FirstOrDefault()?.Acct ?? "";
+                }
+
+                post.UserId = reblog.Account.Id;
+                post.ScreenName = reblog.Account.Acct;
+                post.Nickname = reblog.Account.DisplayName;
+                post.ImageUrl = reblog.Account.AvatarStatic;
+                post.IsProtect = !(reblog.Visibility == "public" || reblog.Visibility == "unlisted");
+
+                post.RetweetedBy = status.Account.Acct;
+                post.RetweetedByUserId = status.Account.Id;
+                post.IsMe = status.Account.Id == this.UserId;
+            }
+            else // status.Reblog == null
+            {
+                post.CreatedAt = this.ParseDateTime(status.CreatedAt);
+                post.TextFromApi = Regex.Replace(status.Content, "<[^>]+>", "");
+                post.Text = status.Content;
+                post.IsFav = status.Favourited ?? false;
+
+                if (status.InReplyToId != null)
+                {
+                    post.InReplyToStatusId = status.InReplyToId.Value;
+                    post.InReplyToUserId = status.InReplyToAccountId!.Value;
+                    post.InReplyToUser = status.Mentions.FirstOrDefault()?.Acct ?? "";
+                }
+
+                post.UserId = status.Account.Id;
+                post.ScreenName = status.Account.Acct;
+                post.Nickname = status.Account.DisplayName;
+                post.ImageUrl = status.Account.AvatarStatic;
+                post.IsProtect = !(status.Visibility == "public" || status.Visibility == "unlisted");
+                post.IsMe = status.Account.Id == this.UserId;
+            }
+
+            post.TextFromApi = WebUtility.HtmlDecode(post.TextFromApi);
+            post.TextFromApi = post.TextFromApi.Replace("<3", "\u2661");
+            post.AccessibleText = post.TextFromApi;
+
+            post.QuoteStatusIds = new long[0];
+            post.ExpandedUrls = new PostClass.ExpandedUrlInfo[0];
+
+            var application = status.Application;
+            if (application != null)
+            {
+                post.Source = application.Name;
+                post.SourceUri = application.Website != null ? new Uri(application.Website) : null;
+            }
+            else
+            {
+                post.Source = "";
+            }
+
+            return post;
+        }
+
+        public DateTimeUtc ParseDateTime(string datetime)
+            => DateTimeUtc.Parse(datetime, DateTimeFormatInfo.InvariantInfo);
+
+        public void Dispose()
+            => this.ApiInternal?.Dispose();
+    }
+}

--- a/OpenTween/Mastodon.cs
+++ b/OpenTween/Mastodon.cs
@@ -51,6 +51,17 @@ namespace OpenTween
             this.Username = account.Username;
         }
 
+        public async Task<PostClass> PostStatusAsync(PostStatusParams param)
+        {
+            var response = await this.Api.StatusesPost(param.Text, param.InReplyToStatusId, param.MediaIds)
+                .ConfigureAwait(false);
+
+            var status = await response.LoadJsonAsync()
+                .ConfigureAwait(false);
+
+            return this.CreatePost(status);
+        }
+
         public async Task<PostClass[]> GetHomeTimelineAsync(MastodonHomeTab tab, bool backward)
         {
             MastodonStatus[] statuses;

--- a/OpenTween/Mastodon.cs
+++ b/OpenTween/Mastodon.cs
@@ -53,6 +53,15 @@ namespace OpenTween
 
         public static async Task<MastodonRegisteredApp> RegisterClientAsync(Uri instanceUri)
         {
+            if (ApplicationSettings.MastodonClientIds.TryGetValue(instanceUri.Host, out var client))
+            {
+                return new MastodonRegisteredApp
+                {
+                    ClientId = client.Item1,
+                    ClientSecret = client.Item2,
+                };
+            }
+
             using var api = new MastodonApi(instanceUri);
             var redirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob");
             var scope = "read write follow";

--- a/OpenTween/Mastodon.cs
+++ b/OpenTween/Mastodon.cs
@@ -100,6 +100,9 @@ namespace OpenTween
                     post.InReplyToUser = reblog.Mentions.FirstOrDefault()?.Acct ?? "";
                 }
 
+                post.Media = reblog.MediaAttachments
+                    .Select(x => new MediaInfo(x.PreviewUrl)).ToList();
+
                 post.UserId = reblog.Account.Id;
                 post.ScreenName = reblog.Account.Acct;
                 post.Nickname = reblog.Account.DisplayName;
@@ -123,6 +126,9 @@ namespace OpenTween
                     post.InReplyToUserId = status.InReplyToAccountId!.Value;
                     post.InReplyToUser = status.Mentions.FirstOrDefault()?.Acct ?? "";
                 }
+
+                post.Media = status.MediaAttachments
+                    .Select(x => new MediaInfo(x.PreviewUrl)).ToList();
 
                 post.UserId = status.Account.Id;
                 post.ScreenName = status.Account.Acct;

--- a/OpenTween/Mastodon.cs
+++ b/OpenTween/Mastodon.cs
@@ -70,7 +70,7 @@ namespace OpenTween
 
         public PostClass CreatePost(MastodonStatus status)
         {
-            var post = new PostClass();
+            var post = new MastodonPost(this);
             post.StatusId = status.Id; // TODO: Twitterの status_id と衝突する
 
             if (status.Reblog != null)

--- a/OpenTween/Models/MastodonHomeTab.cs
+++ b/OpenTween/Models/MastodonHomeTab.cs
@@ -1,0 +1,74 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using OpenTween.Setting;
+
+namespace OpenTween.Models
+{
+    public class MastodonHomeTab : InternalStorageTabModel
+    {
+        public override MyCommon.TabUsageType TabType
+            => MyCommon.TabUsageType.Undefined;
+
+        public override bool IsPermanentTabType => false;
+
+        private readonly Mastodon mastodon;
+
+        public MastodonHomeTab(Mastodon mastodon, string tabName)
+            : base(tabName)
+        {
+            this.mastodon = mastodon;
+            this.UnreadManage = true;
+        }
+
+        public async override Task RefreshAsync(Twitter tw, bool backward, bool startup, IProgress<string> progress)
+        {
+            bool read;
+            if (!SettingManager.Instance.Common.UnreadManage)
+                read = true;
+            else
+                read = startup && SettingManager.Instance.Common.Read;
+
+            progress.Report(string.Format(Properties.Resources.GetTimelineWorker_RunWorkerCompletedText5, backward ? -1 : 1));
+
+            var posts = await this.mastodon.GetHomeTimelineAsync(this, backward)
+                .ConfigureAwait(false);
+
+            long? minimumId = null;
+            foreach (var post in posts)
+            {
+                if (minimumId == null || minimumId.Value > post.StatusId)
+                    minimumId = post.StatusId;
+
+                this.AddPostQueue(post);
+            }
+
+            if (minimumId != null && minimumId.Value < this.OldestId)
+                this.OldestId = minimumId.Value;
+
+            progress.Report(Properties.Resources.GetTimelineWorker_RunWorkerCompletedText1);
+        }
+    }
+}

--- a/OpenTween/Models/MastodonPost.cs
+++ b/OpenTween/Models/MastodonPost.cs
@@ -1,0 +1,96 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using OpenTween.Connection;
+
+namespace OpenTween.Models
+{
+    public class MastodonPost : PostClass
+    {
+        private readonly Mastodon mastodon;
+
+        public MastodonPost(Mastodon mastodon)
+            => this.mastodon = mastodon;
+
+        public override async Task FavoriteAsync(SettingCommon settingCommon)
+        {
+            var statusId = this.IsRetweet ? this.RetweetedId : this.StatusId;
+
+            await this.mastodon.Api.StatusesFavourite(statusId)
+                .IgnoreResponse()
+                .ConfigureAwait(false);
+
+            this.IsFav = true;
+        }
+
+        public override async Task UnfavoriteAsync()
+        {
+            var statusId = this.IsRetweet ? this.RetweetedId : this.StatusId;
+
+            await this.mastodon.Api.StatusesUnfavourite(statusId)
+                .IgnoreResponse()
+                .ConfigureAwait(false);
+
+            this.IsFav = false;
+        }
+
+        public override async Task<PostClass?> RetweetAsync(SettingCommon settingCommon)
+        {
+            var statusId = this.IsRetweet ? this.RetweetedId : this.StatusId;
+
+            var response = await this.mastodon.Api.StatusesReblog(statusId)
+                .ConfigureAwait(false);
+
+            var status = await response.LoadJsonAsync()
+                .ConfigureAwait(false);
+
+            return this.mastodon.CreatePost(status);
+        }
+
+        public override Task DeleteAsync()
+        {
+            if (this.IsRetweet && this.RetweetedByUserId == this.mastodon.UserId)
+            {
+                // 自分がブーストしたトゥート (自分がブーストした自分のトゥートも含む)
+                //   => ブーストを取り消し
+                return this.mastodon.Api.StatusesUnreblog(this.StatusId);
+            }
+            else
+            {
+                if (this.UserId != this.mastodon.UserId)
+                    throw new InvalidOperationException();
+
+                if (this.IsRetweet)
+                    // 他人にブーストされた自分のトゥート
+                    //   => ブースト元の自分のトゥートを削除
+                    return this.mastodon.Api.StatusesDelete(this.RetweetedId);
+                else
+                    // 自分のトゥート
+                    //   => トゥートを削除
+                    return this.mastodon.Api.StatusesDelete(this.StatusId);
+            }
+        }
+    }
+}

--- a/OpenTween/Models/PostClass.cs
+++ b/OpenTween/Models/PostClass.cs
@@ -92,10 +92,6 @@ namespace OpenTween.Models
 
         private bool isMark;
 
-        public string? InReplyToUser { get; set; }
-
-        private long? inReplyToStatusId;
-
         public string Source { get; set; } = "";
 
         public Uri? SourceUri { get; set; }
@@ -114,8 +110,6 @@ namespace OpenTween.Models
         private StatusGeo? postGeo = null;
 
         public int RetweetedCount { get; set; }
-
-        public long? InReplyToUserId { get; set; }
 
         public List<MediaInfo> Media { get; set; }
 
@@ -181,9 +175,38 @@ namespace OpenTween.Models
 
         public int FavoritedCount { get; set; }
 
+        private long? inReplyToStatusId;
+        private long? inReplyToUserId;
+        private string? inReplyToUser;
+
         private long? retweetedId;
         private long? retweetedByUserId;
         private string? retweetedBy;
+
+        public bool HasInReplyTo
+            => this.inReplyToStatusId != null;
+
+        public long InReplyToStatusId
+        {
+            get => this.inReplyToStatusId ?? throw new InvalidOperationException();
+            set
+            {
+                this.states |= States.Reply;
+                this.inReplyToStatusId = value;
+            }
+        }
+
+        public long InReplyToUserId
+        {
+            get => this.inReplyToUserId ?? throw new InvalidOperationException();
+            set => this.inReplyToUserId = value;
+        }
+
+        public string InReplyToUser
+        {
+            get => this.inReplyToUser ?? throw new InvalidOperationException();
+            set => this.inReplyToUser = value;
+        }
 
         public bool IsRetweet
         {
@@ -299,20 +322,6 @@ namespace OpenTween.Models
             }
         }
 
-        public long? InReplyToStatusId
-        {
-            get => this.inReplyToStatusId;
-            set
-            {
-                if (value != null)
-                    this.states |= States.Reply;
-                else
-                    this.states &= ~States.Reply;
-
-                this.inReplyToStatusId = value;
-            }
-        }
-
         public bool IsDeleted
         {
             get => this.isDeleted;
@@ -320,9 +329,9 @@ namespace OpenTween.Models
             {
                 if (value)
                 {
-                    this.InReplyToStatusId = null;
-                    this.InReplyToUser = "";
-                    this.InReplyToUserId = null;
+                    this.inReplyToStatusId = null;
+                    this.inReplyToUser = "";
+                    this.inReplyToUserId = null;
                     this.IsReply = false;
                     this.ReplyToList = new List<(long, string)>();
                     this.states = States.None;
@@ -515,8 +524,9 @@ namespace OpenTween.Models
                     (this.IsProtect == other.IsProtect) &&
                     (this.IsOwl == other.IsOwl) &&
                     (this.IsMark == other.IsMark) &&
-                    (this.InReplyToUser == other.InReplyToUser) &&
-                    (this.InReplyToStatusId == other.InReplyToStatusId) &&
+                    (this.inReplyToUser == other.inReplyToUser) &&
+                    (this.inReplyToUserId == other.inReplyToUserId) &&
+                    (this.inReplyToStatusId == other.inReplyToStatusId) &&
                     (this.Source == other.Source) &&
                     (this.SourceUri == other.SourceUri) &&
                     this.ReplyToList.SequenceEqual(other.ReplyToList) &&
@@ -526,8 +536,7 @@ namespace OpenTween.Models
                     (this.FilterHit == other.FilterHit) &&
                     (this.retweetedBy == other.retweetedBy) &&
                     (this.retweetedId == other.retweetedId) &&
-                    (this.IsDeleted == other.IsDeleted) &&
-                    (this.InReplyToUserId == other.InReplyToUserId);
+                    (this.IsDeleted == other.IsDeleted);
         }
 
         public override int GetHashCode()

--- a/OpenTween/Models/PostClass.cs
+++ b/OpenTween/Models/PostClass.cs
@@ -436,6 +436,18 @@ namespace OpenTween.Models
             return html;
         }
 
+        public virtual Task FavoriteAsync(SettingCommon settingCommon)
+            => Task.CompletedTask;
+
+        public virtual Task UnfavoriteAsync()
+            => Task.CompletedTask;
+
+        public virtual Task<PostClass?> RetweetAsync(SettingCommon settingCommon)
+            => throw new NotImplementedException();
+
+        public virtual Task DeleteAsync()
+            => Task.CompletedTask;
+
         public PostClass Clone()
         {
             var clone = (PostClass)this.MemberwiseClone();

--- a/OpenTween/Models/PostClass.cs
+++ b/OpenTween/Models/PostClass.cs
@@ -110,16 +110,10 @@ namespace OpenTween.Models
 
         public bool FilterHit { get; set; }
 
-        public string? RetweetedBy { get; set; }
-
-        public long? RetweetedId { get; set; }
-
         private bool isDeleted = false;
         private StatusGeo? postGeo = null;
 
         public int RetweetedCount { get; set; }
-
-        public long? RetweetedByUserId { get; set; }
 
         public long? InReplyToUserId { get; set; }
 
@@ -187,6 +181,42 @@ namespace OpenTween.Models
 
         public int FavoritedCount { get; set; }
 
+        private long? retweetedId;
+        private long? retweetedByUserId;
+        private string? retweetedBy;
+
+        public bool IsRetweet
+        {
+            get => this.retweetedId != null;
+            set
+            {
+                if (value)
+                    throw new InvalidOperationException();
+
+                this.retweetedId = null;
+                this.retweetedBy = null;
+                this.retweetedByUserId = null;
+            }
+        }
+
+        public long RetweetedId
+        {
+            get => this.retweetedId ?? throw new InvalidOperationException();
+            set => this.retweetedId = value;
+        }
+
+        public long RetweetedByUserId
+        {
+            get => this.retweetedByUserId ?? throw new InvalidOperationException();
+            set => this.retweetedByUserId = value;
+        }
+
+        public string RetweetedBy
+        {
+            get => this.retweetedBy ?? throw new InvalidOperationException();
+            set => this.retweetedBy = value;
+        }
+
         private States states = States.None;
         private bool expandComplatedAll = false;
 
@@ -215,7 +245,7 @@ namespace OpenTween.Models
         {
             get
             {
-                if (this.RetweetedId != null)
+                if (this.IsRetweet)
                 {
                     var post = this.RetweetSource;
                     if (post != null)
@@ -230,7 +260,7 @@ namespace OpenTween.Models
             set
             {
                 this.isFav = value;
-                if (this.RetweetedId != null)
+                if (this.IsRetweet)
                 {
                     var post = this.RetweetSource;
                     if (post != null)
@@ -302,7 +332,7 @@ namespace OpenTween.Models
         }
 
         protected virtual PostClass? RetweetSource
-            => this.RetweetedId != null ? TabInformations.GetInstance().RetweetSource(this.RetweetedId.Value) : null;
+            => this.IsRetweet ? TabInformations.GetInstance().RetweetSource(this.RetweetedId) : null;
 
         public StatusGeo? PostGeo
         {
@@ -355,7 +385,7 @@ namespace OpenTween.Models
                 return true;
 
             // 自分が RT したツイート
-            if (this.RetweetedByUserId == selfUserId)
+            if (this.IsRetweet && this.RetweetedByUserId == selfUserId)
                 return true;
 
             return false;
@@ -381,15 +411,15 @@ namespace OpenTween.Models
 
         public PostClass ConvertToOriginalPost()
         {
-            if (this.RetweetedId == null)
+            if (!this.IsRetweet)
                 throw new InvalidOperationException();
 
             var originalPost = this.Clone();
 
-            originalPost.StatusId = this.RetweetedId.Value;
-            originalPost.RetweetedId = null;
-            originalPost.RetweetedBy = "";
-            originalPost.RetweetedByUserId = null;
+            originalPost.retweetedId = null;
+            originalPost.retweetedBy = "";
+            originalPost.retweetedByUserId = null;
+            originalPost.StatusId = this.RetweetedId;
             originalPost.RetweetedCount = 1;
 
             return originalPost;
@@ -494,8 +524,8 @@ namespace OpenTween.Models
                     (this.IsDm == other.IsDm) &&
                     (this.UserId == other.UserId) &&
                     (this.FilterHit == other.FilterHit) &&
-                    (this.RetweetedBy == other.RetweetedBy) &&
-                    (this.RetweetedId == other.RetweetedId) &&
+                    (this.retweetedBy == other.retweetedBy) &&
+                    (this.retweetedId == other.retweetedId) &&
                     (this.IsDeleted == other.IsDeleted) &&
                     (this.InReplyToUserId == other.InReplyToUserId);
         }

--- a/OpenTween/Models/TabInformations.cs
+++ b/OpenTween/Models/TabInformations.cs
@@ -566,7 +566,7 @@ namespace OpenTween.Models
                 {
                     if (item.IsFav)
                     {
-                        if (item.RetweetedId == null)
+                        if (!item.IsRetweet)
                         {
                             status.IsFav = true;
                         }
@@ -582,10 +582,10 @@ namespace OpenTween.Models
                 }
                 else
                 {
-                    if (item.IsFav && item.RetweetedId != null) item.IsFav = false;
+                    if (item.IsFav && item.IsRetweet) item.IsFav = false;
 
                     // 既に持っている公式RTは捨てる
-                    if (item.RetweetedId != null && SettingManager.Instance.Common.HideDuplicatedRetweets)
+                    if (item.IsRetweet && SettingManager.Instance.Common.HideDuplicatedRetweets)
                     {
                         var retweetCount = this.UpdateRetweetCount(item);
 
@@ -626,7 +626,7 @@ namespace OpenTween.Models
             if (this.MuteUserIds.Contains(post.UserId))
                 return true;
 
-            if (post.RetweetedByUserId != null && this.MuteUserIds.Contains(post.RetweetedByUserId.Value))
+            if (post.IsRetweet && this.MuteUserIds.Contains(post.RetweetedByUserId))
                 return true;
 
             return false;
@@ -634,10 +634,10 @@ namespace OpenTween.Models
 
         private int UpdateRetweetCount(PostClass retweetPost)
         {
-            if (retweetPost.RetweetedId == null)
+            if (!retweetPost.IsRetweet)
                 throw new InvalidOperationException();
 
-            var retweetedId = retweetPost.RetweetedId.Value;
+            var retweetedId = retweetPost.RetweetedId;
 
             return this.retweetsCount.AddOrUpdate(retweetedId, 1, (k, v) => v >= 10 ? 1 : v + 1);
         }

--- a/OpenTween/Models/TabModel.cs
+++ b/OpenTween/Models/TabModel.cs
@@ -68,11 +68,20 @@ namespace OpenTween.Models
 
         public long[] StatusIds => this.ids.ToArray();
 
+        /// <summary>
+        /// デフォルトタブかどうかを示す値を取得します。
+        /// </summary>
         public bool IsDefaultTabType => this.TabType.IsDefault();
 
-        public bool IsDistributableTabType => this.TabType.IsDistributable();
+        /// <summary>
+        /// 振り分け可能タブかどうかを示す値を取得します。
+        /// </summary>
+        public bool IsDistributableTabType => this is FilterTabModel;
 
-        public bool IsInnerStorageTabType => this.TabType.IsInnerStorage();
+        /// <summary>
+        /// 内部ストレージを使用するタブかどうかを示す値を取得します。
+        /// </summary>
+        public bool IsInnerStorageTabType => this is InternalStorageTabModel;
 
         /// <summary>
         /// 次回起動時にも保持されるタブか（SettingTabsに保存されるか）

--- a/OpenTween/Models/TabUsageTypeExt.cs
+++ b/OpenTween/Models/TabUsageTypeExt.cs
@@ -41,35 +41,10 @@ namespace OpenTween.Models
             MyCommon.TabUsageType.Favorites |
             MyCommon.TabUsageType.Mute;
 
-        private const MyCommon.TabUsageType DistributableTabTypeMask =
-            MyCommon.TabUsageType.Mentions |
-            MyCommon.TabUsageType.UserDefined |
-            MyCommon.TabUsageType.Mute;
-
-        private const MyCommon.TabUsageType InnerStorageTabTypeMask =
-            MyCommon.TabUsageType.DirectMessage |
-            MyCommon.TabUsageType.PublicSearch |
-            MyCommon.TabUsageType.Lists |
-            MyCommon.TabUsageType.UserTimeline |
-            MyCommon.TabUsageType.Related |
-            MyCommon.TabUsageType.SearchResults;
-
         /// <summary>
         /// デフォルトタブかどうかを示す値を取得します。
         /// </summary>
         public static bool IsDefault(this MyCommon.TabUsageType tabType)
             => (tabType & DefaultTabTypeMask) != 0;
-
-        /// <summary>
-        /// 振り分け可能タブかどうかを示す値を取得します。
-        /// </summary>
-        public static bool IsDistributable(this MyCommon.TabUsageType tabType)
-            => (tabType & DistributableTabTypeMask) != 0;
-
-        /// <summary>
-        /// 内部ストレージを使用するタブかどうかを示す値を取得します。
-        /// </summary>
-        public static bool IsInnerStorage(this MyCommon.TabUsageType tabType)
-            => (tabType & InnerStorageTabTypeMask) != 0;
     }
 }

--- a/OpenTween/Models/TwitterDmPost.cs
+++ b/OpenTween/Models/TwitterDmPost.cs
@@ -1,0 +1,39 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace OpenTween.Models
+{
+    public class TwitterDmPost : PostClass
+    {
+        private readonly Twitter twitter;
+
+        public TwitterDmPost(Twitter twitter)
+            => this.twitter = twitter;
+
+        public override Task DeleteAsync()
+            => this.twitter.Api.DirectMessagesEventsDestroy(this.StatusId.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/OpenTween/Models/TwitterPostFactory.cs
+++ b/OpenTween/Models/TwitterPostFactory.cs
@@ -188,7 +188,7 @@ namespace OpenTween.Models
             this.ExtractEntities(entities, post.ReplyToList, post.Media);
 
             post.QuoteStatusIds = GetQuoteTweetStatusIds(entities, quotedStatusLink)
-                .Where(x => x != post.StatusId && x != post.RetweetedId)
+                .Where(x => x != post.StatusId && !(post.IsRetweet && x == post.RetweetedId))
                 .Distinct().ToArray();
 
             post.ExpandedUrls = entities.OfType<TwitterEntityUrl>()
@@ -205,14 +205,15 @@ namespace OpenTween.Models
             post.ScreenName = string.Intern(post.ScreenName);
             post.Nickname = string.Intern(post.Nickname);
             post.ImageUrl = string.Intern(post.ImageUrl);
-            post.RetweetedBy = post.RetweetedBy != null ? string.Intern(post.RetweetedBy) : null;
+            if (post.IsRetweet)
+                post.RetweetedBy = string.Intern(post.RetweetedBy);
 
             // Source整形
             var (sourceText, sourceUri) = ParseSource(sourceHtml);
             post.Source = string.Intern(sourceText);
             post.SourceUri = sourceUri;
 
-            post.IsReply = post.RetweetedId == null && post.ReplyToList.Any(x => x.UserId == selfUserId);
+            post.IsReply = !post.IsRetweet && post.ReplyToList.Any(x => x.UserId == selfUserId);
             post.IsExcludeReply = false;
 
             if (post.IsMe)

--- a/OpenTween/Models/TwitterPostFactory.cs
+++ b/OpenTween/Models/TwitterPostFactory.cs
@@ -52,13 +52,14 @@ namespace OpenTween.Models
         }
 
         public PostClass CreateFromStatus(
+            Twitter twitter,
             TwitterStatus status,
             long selfUserId,
             ISet<long> followerIds,
             bool favTweet = false
         )
         {
-            var post = new PostClass();
+            var post = new TwitterStatusPost(twitter);
             TwitterEntities entities;
             string sourceHtml;
 
@@ -229,13 +230,14 @@ namespace OpenTween.Models
         }
 
         public PostClass CreateFromDirectMessageEvent(
+            Twitter twitter,
             TwitterMessageEvent eventItem,
             IReadOnlyDictionary<string, TwitterUser> users,
             IReadOnlyDictionary<string, TwitterMessageEventList.App> apps,
             long selfUserId
         )
         {
-            var post = new PostClass();
+            var post = new TwitterDmPost(twitter);
             post.StatusId = long.Parse(eventItem.Id);
 
             var timestamp = long.Parse(eventItem.CreatedTimestamp);

--- a/OpenTween/Models/TwitterPostFactory.cs
+++ b/OpenTween/Models/TwitterPostFactory.cs
@@ -77,9 +77,12 @@ namespace OpenTween.Models
                 entities = retweeted.MergedEntities;
                 sourceHtml = retweeted.Source;
                 // Reply先
-                post.InReplyToStatusId = retweeted.InReplyToStatusId;
-                post.InReplyToUser = retweeted.InReplyToScreenName;
-                post.InReplyToUserId = status.InReplyToUserId;
+                if (retweeted.InReplyToStatusId != null)
+                {
+                    post.InReplyToStatusId = retweeted.InReplyToStatusId.Value;
+                    post.InReplyToUser = retweeted.InReplyToScreenName!;
+                    post.InReplyToUserId = retweeted.InReplyToUserId!.Value;
+                }
 
                 if (favTweet)
                 {
@@ -132,9 +135,13 @@ namespace OpenTween.Models
                 post.TextFromApi = status.FullText;
                 entities = status.MergedEntities;
                 sourceHtml = status.Source;
-                post.InReplyToStatusId = status.InReplyToStatusId;
-                post.InReplyToUser = status.InReplyToScreenName;
-                post.InReplyToUserId = status.InReplyToUserId;
+
+                if (status.InReplyToStatusId != null)
+                {
+                    post.InReplyToStatusId = status.InReplyToStatusId.Value;
+                    post.InReplyToUser = status.InReplyToScreenName!;
+                    post.InReplyToUserId = status.InReplyToUserId!.Value;
+                }
 
                 if (favTweet)
                 {

--- a/OpenTween/Models/TwitterStatusPost.cs
+++ b/OpenTween/Models/TwitterStatusPost.cs
@@ -40,7 +40,7 @@ namespace OpenTween.Models
 
         public override async Task FavoriteAsync(SettingCommon settingCommon)
         {
-            var statusId = this.RetweetedId ?? this.StatusId;
+            var statusId = this.IsRetweet ? this.RetweetedId : this.StatusId;
 
             try
             {
@@ -68,7 +68,7 @@ namespace OpenTween.Models
 
         public override async Task UnfavoriteAsync()
         {
-            var statusId = this.RetweetedId ?? this.StatusId;
+            var statusId = this.IsRetweet ? this.RetweetedId : this.StatusId;
 
             await this.twitter.Api.FavoritesDestroy(statusId)
                 .IgnoreResponse()
@@ -79,7 +79,7 @@ namespace OpenTween.Models
 
         public override Task<PostClass?> RetweetAsync(SettingCommon settingCommon)
         {
-            var statusId = this.RetweetedId ?? this.StatusId;
+            var statusId = this.IsRetweet ? this.RetweetedId : this.StatusId;
 
             var read = !settingCommon.UnreadManage || settingCommon.Read;
 
@@ -88,7 +88,7 @@ namespace OpenTween.Models
 
         public override Task DeleteAsync()
         {
-            if (this.RetweetedByUserId == this.twitter.UserId)
+            if (this.IsRetweet && this.RetweetedByUserId == this.twitter.UserId)
             {
                 // 自分が RT したツイート (自分が RT した自分のツイートも含む)
                 //   => RT を取り消し
@@ -100,11 +100,11 @@ namespace OpenTween.Models
                 if (this.UserId != this.twitter.UserId)
                     throw new InvalidOperationException();
 
-                if (this.RetweetedId != null)
+                if (this.IsRetweet)
                 {
                     // 他人に RT された自分のツイート
                     //   => RT 元の自分のツイートを削除
-                    return this.twitter.Api.StatusesDestroy(this.RetweetedId.Value)
+                    return this.twitter.Api.StatusesDestroy(this.RetweetedId)
                         .IgnoreResponse();
                 }
                 else

--- a/OpenTween/Models/TwitterStatusPost.cs
+++ b/OpenTween/Models/TwitterStatusPost.cs
@@ -1,0 +1,120 @@
+﻿// OpenTween - Client of Twitter
+// Copyright (c) 2017 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// All rights reserved.
+//
+// This file is part of OpenTween.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>, or write to
+// the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+// Boston, MA 02110-1301, USA.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenTween.Api;
+using OpenTween.Api.DataModel;
+using OpenTween.Connection;
+using OpenTween.Setting;
+
+namespace OpenTween.Models
+{
+    public class TwitterStatusPost : PostClass
+    {
+        private readonly Twitter twitter;
+
+        public TwitterStatusPost(Twitter twitter)
+            => this.twitter = twitter;
+
+        public override async Task FavoriteAsync(SettingCommon settingCommon)
+        {
+            var statusId = this.RetweetedId ?? this.StatusId;
+
+            try
+            {
+                await this.twitter.Api.FavoritesCreate(statusId)
+                    .IgnoreResponse()
+                    .ConfigureAwait(false);
+            }
+            catch (TwitterApiException ex)
+                when (ex.Errors.All(x => x.Code == TwitterErrorCode.AlreadyFavorited))
+            {
+                // エラーコード 139 のみの場合は成功と見なす
+            }
+
+            if (settingCommon.RestrictFavCheck)
+            {
+                var status = await this.twitter.Api.StatusesShow(statusId)
+                    .ConfigureAwait(false);
+
+                if (status.Favorited != true)
+                    throw new WebApiException("NG(Restricted?)");
+            }
+
+            this.IsFav = true;
+        }
+
+        public override async Task UnfavoriteAsync()
+        {
+            var statusId = this.RetweetedId ?? this.StatusId;
+
+            await this.twitter.Api.FavoritesDestroy(statusId)
+                .IgnoreResponse()
+                .ConfigureAwait(false);
+
+            this.IsFav = false;
+        }
+
+        public override Task<PostClass?> RetweetAsync(SettingCommon settingCommon)
+        {
+            var statusId = this.RetweetedId ?? this.StatusId;
+
+            var read = !settingCommon.UnreadManage || settingCommon.Read;
+
+            return this.twitter.PostRetweet(statusId, read);
+        }
+
+        public override Task DeleteAsync()
+        {
+            if (this.RetweetedByUserId == this.twitter.UserId)
+            {
+                // 自分が RT したツイート (自分が RT した自分のツイートも含む)
+                //   => RT を取り消し
+                return this.twitter.Api.StatusesDestroy(this.StatusId)
+                    .IgnoreResponse();
+            }
+            else
+            {
+                if (this.UserId != this.twitter.UserId)
+                    throw new InvalidOperationException();
+
+                if (this.RetweetedId != null)
+                {
+                    // 他人に RT された自分のツイート
+                    //   => RT 元の自分のツイートを削除
+                    return this.twitter.Api.StatusesDestroy(this.RetweetedId.Value)
+                        .IgnoreResponse();
+                }
+                else
+                {
+                    // 自分のツイート
+                    //   => ツイートを削除
+                    return this.twitter.Api.StatusesDestroy(this.StatusId)
+                        .IgnoreResponse();
+                }
+            }
+        }
+    }
+}

--- a/OpenTween/MyCommon.cs
+++ b/OpenTween/MyCommon.cs
@@ -828,16 +828,16 @@ namespace OpenTween
 
             if (versionNum[3] == 0)
             {
-                return string.Format("{0}.{1}.{2}", versionNum[0], versionNum[1], versionNum[2]);
+                return string.Format("{0}.{1}.{2}+mastodon", versionNum[0], versionNum[1], versionNum[2]);
             }
             else
             {
                 versionNum[2] = versionNum[2] + 1;
 
                 if (versionNum[3] == 1)
-                    return string.Format("{0}.{1}.{2}-dev", versionNum[0], versionNum[1], versionNum[2]);
+                    return string.Format("{0}.{1}.{2}-dev+mastodon", versionNum[0], versionNum[1], versionNum[2]);
                 else
-                    return string.Format("{0}.{1}.{2}-dev+build.{3}", versionNum[0], versionNum[1], versionNum[2], versionNum[3]);
+                    return string.Format("{0}.{1}.{2}-dev+mastodon+build.{3}", versionNum[0], versionNum[1], versionNum[2], versionNum[3]);
             }
         }
 

--- a/OpenTween/MyCommon.cs
+++ b/OpenTween/MyCommon.cs
@@ -845,10 +845,10 @@ namespace OpenTween
 
         public static string GetStatusUrl(PostClass post)
         {
-            if (post.RetweetedId == null)
+            if (!post.IsRetweet)
                 return GetStatusUrl(post.ScreenName, post.StatusId);
             else
-                return GetStatusUrl(post.ScreenName, post.RetweetedId.Value);
+                return GetStatusUrl(post.ScreenName, post.RetweetedId);
         }
 
         public static string GetStatusUrl(string screenName, long statusId)

--- a/OpenTween/PostStatusParams.cs
+++ b/OpenTween/PostStatusParams.cs
@@ -43,5 +43,7 @@ namespace OpenTween
         public IReadOnlyList<long> ExcludeReplyUserIds { get; set; } = Array.Empty<long>();
 
         public string? AttachmentUrl { get; set; }
+
+        public bool PostToMastodon { get; set; } = false;
     }
 }

--- a/OpenTween/Setting/Panel/BasedPanel.Designer.cs
+++ b/OpenTween/Setting/Panel/BasedPanel.Designer.cs
@@ -35,6 +35,9 @@
             this.AuthClearButton = new System.Windows.Forms.Button();
             this.Label4 = new System.Windows.Forms.Label();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.buttonMastodonAuth = new System.Windows.Forms.Button();
+            this.labelMastodonAccount = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
             this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -76,8 +79,29 @@
             this.panel1.Controls.Add(this.StartAuthButton);
             this.panel1.Controls.Add(this.AuthClearButton);
             this.panel1.Controls.Add(this.Label4);
+            this.panel1.Controls.Add(this.buttonMastodonAuth);
+            this.panel1.Controls.Add(this.labelMastodonAccount);
+            this.panel1.Controls.Add(this.label1);
             resources.ApplyResources(this.panel1, "panel1");
             this.panel1.Name = "panel1";
+            // 
+            // buttonMastodonAuth
+            // 
+            resources.ApplyResources(this.buttonMastodonAuth, "buttonMastodonAuth");
+            this.buttonMastodonAuth.Name = "buttonMastodonAuth";
+            this.buttonMastodonAuth.UseVisualStyleBackColor = true;
+            this.buttonMastodonAuth.Click += new System.EventHandler(this.ButtonMastodonAuth_Click);
+            // 
+            // labelMastodonAccount
+            // 
+            this.labelMastodonAccount.AutoEllipsis = true;
+            resources.ApplyResources(this.labelMastodonAccount, "labelMastodonAccount");
+            this.labelMastodonAccount.Name = "labelMastodonAccount";
+            // 
+            // label1
+            // 
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
             // 
             // BasedPanel
             // 
@@ -99,5 +123,8 @@
         internal System.Windows.Forms.Button AuthClearButton;
         internal System.Windows.Forms.Label Label4;
         private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Button buttonMastodonAuth;
+        private System.Windows.Forms.Label labelMastodonAccount;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/OpenTween/Setting/Panel/BasedPanel.cs
+++ b/OpenTween/Setting/Panel/BasedPanel.cs
@@ -34,6 +34,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using OpenTween;
 
 namespace OpenTween.Setting.Panel
 {
@@ -44,15 +45,16 @@ namespace OpenTween.Setting.Panel
 
         public void LoadConfig(SettingCommon settingCommon)
         {
+            var accounts = settingCommon.UserAccounts;
+
             using (ControlTransaction.Update(this.AuthUserCombo))
             {
                 this.AuthUserCombo.Items.Clear();
-                this.AuthUserCombo.Items.AddRange(settingCommon.UserAccounts.ToArray());
+                this.AuthUserCombo.Items.AddRange(accounts.ToArray());
 
-                var selectedUserId = settingCommon.UserId;
-                var selectedAccount = settingCommon.UserAccounts.FirstOrDefault(x => x.UserId == selectedUserId);
-                if (selectedAccount != null)
-                    this.AuthUserCombo.SelectedItem = selectedAccount;
+                var primaryIndex = accounts.FindIndex(x => x.Primary);
+                if (primaryIndex != -1)
+                    this.AuthUserCombo.SelectedIndex = primaryIndex;
             }
         }
 
@@ -64,6 +66,9 @@ namespace OpenTween.Setting.Panel
             var selectedIndex = this.AuthUserCombo.SelectedIndex;
             if (selectedIndex != -1)
             {
+                foreach (var (account, index) in accounts.WithIndex())
+                    account.Primary = selectedIndex == index;
+
                 var selectedAccount = accounts[selectedIndex];
                 settingCommon.UserId = selectedAccount.UserId;
                 settingCommon.UserName = selectedAccount.Username;

--- a/OpenTween/Setting/Panel/BasedPanel.cs
+++ b/OpenTween/Setting/Panel/BasedPanel.cs
@@ -67,8 +67,8 @@ namespace OpenTween.Setting.Panel
                 var selectedAccount = accounts[selectedIndex];
                 settingCommon.UserId = selectedAccount.UserId;
                 settingCommon.UserName = selectedAccount.Username;
-                settingCommon.Token = selectedAccount.Token;
-                settingCommon.TokenSecret = selectedAccount.TokenSecret;
+                settingCommon.Token = selectedAccount.AccessToken;
+                settingCommon.TokenSecret = selectedAccount.AccessSecretPlain;
             }
             else
             {

--- a/OpenTween/Setting/Panel/BasedPanel.cs
+++ b/OpenTween/Setting/Panel/BasedPanel.cs
@@ -40,8 +40,13 @@ namespace OpenTween.Setting.Panel
 {
     public partial class BasedPanel : SettingPanelBase
     {
+        private MastodonCredential? mastodonCredential = null;
+
         public BasedPanel()
-            => this.InitializeComponent();
+        {
+            this.InitializeComponent();
+            this.RefreshMastodonCredential();
+        }
 
         public void LoadConfig(SettingCommon settingCommon)
         {
@@ -56,6 +61,9 @@ namespace OpenTween.Setting.Panel
                 if (primaryIndex != -1)
                     this.AuthUserCombo.SelectedIndex = primaryIndex;
             }
+
+            this.mastodonCredential = settingCommon.MastodonPrimaryAccount;
+            this.RefreshMastodonCredential();
         }
 
         public void SaveConfig(SettingCommon settingCommon)
@@ -82,6 +90,25 @@ namespace OpenTween.Setting.Panel
                 settingCommon.Token = "";
                 settingCommon.TokenSecret = "";
             }
+
+            var mastodonCredential = this.mastodonCredential;
+            if (mastodonCredential != null)
+            {
+                mastodonCredential.Primary = true;
+                settingCommon.MastodonAccounts = new[] { mastodonCredential };
+            }
+            else
+            {
+                settingCommon.MastodonAccounts = new MastodonCredential[0];
+            }
+        }
+
+        private void RefreshMastodonCredential()
+        {
+            if (this.mastodonCredential != null)
+                this.labelMastodonAccount.Text = this.mastodonCredential.Username;
+            else
+                this.labelMastodonAccount.Text = "(未設定)";
         }
 
         private void AuthClearButton_Click(object sender, EventArgs e)
@@ -100,8 +127,37 @@ namespace OpenTween.Setting.Panel
             }
         }
 
-        private void ButtonMastodonAuth_Click(object sender, EventArgs e)
+        private async void ButtonMastodonAuth_Click(object sender, EventArgs e)
         {
+            var ret = InputDialog.Show(this, "インスタンスのURL (例: https://mstdn.jp/)", ApplicationSettings.ApplicationName, out var instanceUriStr);
+            if (ret != DialogResult.OK)
+                return;
+
+            if (!Uri.TryCreate(instanceUriStr, UriKind.Absolute, out var instanceUri))
+                return;
+
+            try
+            {
+                var application = await Mastodon.RegisterClientAsync(instanceUri);
+
+                var authorizeUri = Mastodon.GetAuthorizeUri(instanceUri, application.ClientId);
+
+                var code = ((AppendSettingDialog)this.ParentForm).ShowAuthDialog(authorizeUri);
+                if (MyCommon.IsNullOrEmpty(code))
+                    return;
+
+                var accessToken = await Mastodon.GetAccessTokenAsync(instanceUri, application.ClientId, application.ClientSecret, code);
+
+                this.mastodonCredential = await Mastodon.VerifyCredentialAsync(instanceUri, accessToken);
+
+                this.RefreshMastodonCredential();
+            }
+            catch (WebApiException ex)
+            {
+                var message = Properties.Resources.AuthorizeButton_Click2 + Environment.NewLine + ex.Message;
+                MessageBox.Show(this, message, "Authenticate", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
         }
     }
 }

--- a/OpenTween/Setting/Panel/BasedPanel.cs
+++ b/OpenTween/Setting/Panel/BasedPanel.cs
@@ -40,6 +40,8 @@ namespace OpenTween.Setting.Panel
 {
     public partial class BasedPanel : SettingPanelBase
     {
+        public bool HasMastodonCredential => this.mastodonCredential != null;
+
         private MastodonCredential? mastodonCredential = null;
 
         public BasedPanel()

--- a/OpenTween/Setting/Panel/BasedPanel.cs
+++ b/OpenTween/Setting/Panel/BasedPanel.cs
@@ -99,5 +99,9 @@ namespace OpenTween.Setting.Panel
                 }
             }
         }
+
+        private void ButtonMastodonAuth_Click(object sender, EventArgs e)
+        {
+        }
     }
 }

--- a/OpenTween/Setting/Panel/BasedPanel.en.resx
+++ b/OpenTween/Setting/Panel/BasedPanel.en.resx
@@ -6,7 +6,10 @@
 	<assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 
 	<data name="AuthClearButton.Text"><value>Remove</value></data>
+	<data name="buttonMastodonAuth.Text"><value>Authorize</value></data>
 	<data name="CreateAccountButton.Text"><value>Sign up for Twitter account</value></data>
+	<data name="label1.Size" type="System.Drawing.Size, System.Drawing"><value>100, 12</value></data>
+	<data name="label1.Text"><value>Mastodon Account</value></data>
 	<data name="Label4.Size" type="System.Drawing.Size, System.Drawing"><value>47, 12</value></data>
 	<data name="Label4.Text"><value>Account</value></data>
 	<data name="StartAuthButton.Text"><value>Start Authentication</value></data>

--- a/OpenTween/Setting/Panel/BasedPanel.resx
+++ b/OpenTween/Setting/Panel/BasedPanel.resx
@@ -11,7 +11,7 @@
 	<metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"><value>True</value></metadata>
 	<data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms"><value>0, 0, 0, 0</value></data>
 	<data name="&gt;&gt;$this.Name"><value>BasedPanel</value></data>
-	<data name="&gt;&gt;$this.Type"><value>OpenTween.Setting.Panel.SettingPanelBase, OpenTween, Version=2.4.3.1, Culture=neutral, PublicKeyToken=null</value></data>
+	<data name="&gt;&gt;$this.Type"><value>OpenTween.Setting.Panel.SettingPanelBase, OpenTween, Version=2.7.1.1, Culture=neutral, PublicKeyToken=null</value></data>
 	<data name="&gt;&gt;AuthClearButton.Name"><value>AuthClearButton</value></data>
 	<data name="&gt;&gt;AuthClearButton.Parent"><value>panel1</value></data>
 	<data name="&gt;&gt;AuthClearButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
@@ -20,14 +20,26 @@
 	<data name="&gt;&gt;AuthUserCombo.Parent"><value>panel1</value></data>
 	<data name="&gt;&gt;AuthUserCombo.Type"><value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;AuthUserCombo.ZOrder"><value>0</value></data>
+	<data name="&gt;&gt;buttonMastodonAuth.Name"><value>buttonMastodonAuth</value></data>
+	<data name="&gt;&gt;buttonMastodonAuth.Parent"><value>panel1</value></data>
+	<data name="&gt;&gt;buttonMastodonAuth.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;buttonMastodonAuth.ZOrder"><value>5</value></data>
 	<data name="&gt;&gt;CreateAccountButton.Name"><value>CreateAccountButton</value></data>
 	<data name="&gt;&gt;CreateAccountButton.Parent"><value>panel1</value></data>
 	<data name="&gt;&gt;CreateAccountButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;CreateAccountButton.ZOrder"><value>1</value></data>
+	<data name="&gt;&gt;label1.Name"><value>label1</value></data>
+	<data name="&gt;&gt;label1.Parent"><value>panel1</value></data>
+	<data name="&gt;&gt;label1.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;label1.ZOrder"><value>7</value></data>
 	<data name="&gt;&gt;Label4.Name"><value>Label4</value></data>
 	<data name="&gt;&gt;Label4.Parent"><value>panel1</value></data>
 	<data name="&gt;&gt;Label4.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;Label4.ZOrder"><value>4</value></data>
+	<data name="&gt;&gt;labelMastodonAccount.Name"><value>labelMastodonAccount</value></data>
+	<data name="&gt;&gt;labelMastodonAccount.Parent"><value>panel1</value></data>
+	<data name="&gt;&gt;labelMastodonAccount.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;labelMastodonAccount.ZOrder"><value>6</value></data>
 	<data name="&gt;&gt;panel1.Name"><value>panel1</value></data>
 	<data name="&gt;&gt;panel1.Parent"><value>$this</value></data>
 	<data name="&gt;&gt;panel1.Type"><value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
@@ -45,19 +57,36 @@
 	<data name="AuthUserCombo.Location" type="System.Drawing.Point, System.Drawing"><value>111, 22</value></data>
 	<data name="AuthUserCombo.Size" type="System.Drawing.Size, System.Drawing"><value>160, 20</value></data>
 	<data name="AuthUserCombo.TabIndex" type="System.Int32, mscorlib"><value>1</value></data>
+	<data name="buttonMastodonAuth.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms"><value>NoControl</value></data>
+	<data name="buttonMastodonAuth.Location" type="System.Drawing.Point, System.Drawing"><value>401, 182</value></data>
+	<data name="buttonMastodonAuth.Size" type="System.Drawing.Size, System.Drawing"><value>75, 23</value></data>
+	<data name="buttonMastodonAuth.TabIndex" type="System.Int32, mscorlib"><value>17</value></data>
+	<data name="buttonMastodonAuth.Text"><value>認証</value></data>
 	<data name="CreateAccountButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms"><value>Bottom, Right</value></data>
 	<data name="CreateAccountButton.AutoSize" type="System.Boolean, mscorlib"><value>True</value></data>
 	<data name="CreateAccountButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms"><value>NoControl</value></data>
-	<data name="CreateAccountButton.Location" type="System.Drawing.Point, System.Drawing"><value>310, 320</value></data>
+	<data name="CreateAccountButton.Location" type="System.Drawing.Point, System.Drawing"><value>310, 123</value></data>
 	<data name="CreateAccountButton.Size" type="System.Drawing.Size, System.Drawing"><value>186, 25</value></data>
 	<data name="CreateAccountButton.TabIndex" type="System.Int32, mscorlib"><value>4</value></data>
 	<data name="CreateAccountButton.Text"><value>Twitter アカウントを作成する</value></data>
+	<data name="label1.AutoSize" type="System.Boolean, mscorlib"><value>True</value></data>
+	<data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms"><value>NoControl</value></data>
+	<data name="label1.Location" type="System.Drawing.Point, System.Drawing"><value>23, 187</value></data>
+	<data name="label1.Size" type="System.Drawing.Size, System.Drawing"><value>98, 12</value></data>
+	<data name="label1.TabIndex" type="System.Int32, mscorlib"><value>15</value></data>
+	<data name="label1.Text"><value>Mastodonアカウント</value></data>
 	<data name="Label4.AutoSize" type="System.Boolean, mscorlib"><value>True</value></data>
 	<data name="Label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms"><value>NoControl</value></data>
 	<data name="Label4.Location" type="System.Drawing.Point, System.Drawing"><value>23, 25</value></data>
 	<data name="Label4.Size" type="System.Drawing.Size, System.Drawing"><value>49, 12</value></data>
 	<data name="Label4.TabIndex" type="System.Int32, mscorlib"><value>0</value></data>
 	<data name="Label4.Text"><value>アカウント</value></data>
+	<data name="labelMastodonAccount.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms"><value>NoControl</value></data>
+	<data name="labelMastodonAccount.Location" type="System.Drawing.Point, System.Drawing"><value>138, 182</value></data>
+	<data name="labelMastodonAccount.Size" type="System.Drawing.Size, System.Drawing"><value>257, 23</value></data>
+	<data name="labelMastodonAccount.TabIndex" type="System.Int32, mscorlib"><value>16</value></data>
+	<data name="labelMastodonAccount.Text"><value>labelMastodonAccount</value></data>
+	<data name="labelMastodonAccount.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing"><value>MiddleLeft</value></data>
 	<data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms"><value>Fill</value></data>
 	<data name="panel1.Location" type="System.Drawing.Point, System.Drawing"><value>0, 0</value></data>
 	<data name="panel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms"><value>20, 20, 20, 20</value></data>

--- a/OpenTween/Setting/SettingCommon.cs
+++ b/OpenTween/Setting/SettingCommon.cs
@@ -329,53 +329,21 @@ namespace OpenTween
 
     public class UserAccount
     {
-        public string Username = "";
-        public long UserId = 0;
-        public string Token = "";
+        public string Username { get; set; } = "";
+
+        public long UserId { get; set; } = 0;
+
+        [XmlElement("Token")]
+        public string AccessToken { get; set; } = "";
+
+        [XmlElement("EncryptTokenSecret")]
+        public string AccessSecretEncrypted { get; set; } = "";
+
         [XmlIgnore]
-        public string TokenSecret = "";
-
-        public string EncryptTokenSecret
+        public string AccessSecretPlain
         {
-            get => this.Encrypt(this.TokenSecret);
-            set => this.TokenSecret = this.Decrypt(value);
-        }
-
-        private string Encrypt(string password)
-        {
-            if (MyCommon.IsNullOrEmpty(password)) password = "";
-            if (password.Length > 0)
-            {
-                try
-                {
-                    return MyCommon.EncryptString(password);
-                }
-                catch (Exception)
-                {
-                    return "";
-                }
-            }
-            else
-            {
-                return "";
-            }
-        }
-
-        private string Decrypt(string password)
-        {
-            if (MyCommon.IsNullOrEmpty(password)) password = "";
-            if (password.Length > 0)
-            {
-                try
-                {
-                    password = MyCommon.DecryptString(password);
-                }
-                catch (Exception)
-                {
-                    password = "";
-                }
-            }
-            return password;
+            get => MyCommon.IsNullOrEmpty(this.AccessSecretEncrypted) ? "" : MyCommon.DecryptString(this.AccessSecretEncrypted);
+            set => this.AccessSecretEncrypted = MyCommon.IsNullOrEmpty(value) ? "" : MyCommon.EncryptString(value);
         }
 
         public override string ToString()

--- a/OpenTween/Setting/SettingCommon.cs
+++ b/OpenTween/Setting/SettingCommon.cs
@@ -46,65 +46,20 @@ namespace OpenTween
         #endregion
 
         public List<UserAccount> UserAccounts = new();
+
+        public long UserId = 0;
         public string UserName = "";
-
-        [XmlIgnore]
-        public string Password = "";
-
-        public string EncryptPassword
-        {
-            get => this.Encrypt(this.Password);
-            set => this.Password = this.Decrypt(value);
-        }
-
         public string Token = "";
+
         [XmlIgnore]
         public string TokenSecret = "";
 
         public string EncryptTokenSecret
         {
-            get => this.Encrypt(this.TokenSecret);
-            set => this.TokenSecret = this.Decrypt(value);
+            get => string.IsNullOrEmpty(this.TokenSecret) ? "" : MyCommon.EncryptString(this.TokenSecret);
+            set => this.TokenSecret = string.IsNullOrEmpty(value) ? "" : MyCommon.DecryptString(value);
         }
 
-        private string Encrypt(string password)
-        {
-            if (MyCommon.IsNullOrEmpty(password)) password = "";
-            if (password.Length > 0)
-            {
-                try
-                {
-                    return MyCommon.EncryptString(password);
-                }
-                catch (Exception)
-                {
-                    return "";
-                }
-            }
-            else
-            {
-                return "";
-            }
-        }
-
-        private string Decrypt(string password)
-        {
-            if (MyCommon.IsNullOrEmpty(password)) password = "";
-            if (password.Length > 0)
-            {
-                try
-                {
-                    password = MyCommon.DecryptString(password);
-                }
-                catch (Exception)
-                {
-                    password = "";
-                }
-            }
-            return password;
-        }
-
-        public long UserId = 0;
         public List<string> TabList = new();
         public int TimelinePeriod = 90;
         public int ReplyPeriod = 180;

--- a/OpenTween/Setting/SettingCommon.cs
+++ b/OpenTween/Setting/SettingCommon.cs
@@ -73,6 +73,11 @@ namespace OpenTween
         [XmlIgnore]
         public UserAccount PrimaryAccount => this.UserAccounts.FirstOrDefault(x => x.Primary);
 
+        public MastodonCredential[] MastodonAccounts { get; set; } = new MastodonCredential[0];
+
+        [XmlIgnore]
+        public MastodonCredential MastodonPrimaryAccount => this.MastodonAccounts.FirstOrDefault(x => x.Primary);
+
         public long UserId = 0;
         public string UserName = "";
         public string Token = "";
@@ -331,5 +336,25 @@ namespace OpenTween
 
         public override string ToString()
             => this.Username;
+    }
+
+    public class MastodonCredential
+    {
+        public bool Primary { get; set; }
+
+        public string InstanceUri { get; set; } = "";
+
+        public string Username { get; set; } = "";
+
+        public long UserId { get; set; }
+
+        public string AccessTokenEncrypted { get; set; } = "";
+
+        [XmlIgnore]
+        public string AccessTokenPlain
+        {
+            get => MyCommon.IsNullOrEmpty(this.AccessTokenEncrypted) ? "" : MyCommon.DecryptString(this.AccessTokenEncrypted);
+            set => this.AccessTokenEncrypted = MyCommon.IsNullOrEmpty(value) ? "" : MyCommon.EncryptString(value);
+        }
     }
 }

--- a/OpenTween/Setting/SettingManager.cs
+++ b/OpenTween/Setting/SettingManager.cs
@@ -49,7 +49,7 @@ namespace OpenTween.Setting
 
         /// <summary>ユーザによる設定が必要な項目が残っているか</summary>
         public bool IsIncomplete
-            => MyCommon.IsNullOrEmpty(this.Common.UserName);
+            => this.Common.PrimaryAccount == null;
 
         public bool IsFirstRun { get; private set; } = false;
 

--- a/OpenTween/Setting/SettingManager.cs
+++ b/OpenTween/Setting/SettingManager.cs
@@ -49,7 +49,7 @@ namespace OpenTween.Setting
 
         /// <summary>ユーザによる設定が必要な項目が残っているか</summary>
         public bool IsIncomplete
-            => this.Common.PrimaryAccount == null;
+            => this.Common.PrimaryAccount == null && this.Common.MastodonPrimaryAccount == null;
 
         public bool IsFirstRun { get; private set; } = false;
 

--- a/OpenTween/Setting/SettingManager.cs
+++ b/OpenTween/Setting/SettingManager.cs
@@ -79,8 +79,8 @@ namespace OpenTween.Setting
                     {
                         Username = settings.UserName,
                         UserId = settings.UserId,
-                        Token = settings.Token,
-                        TokenSecret = settings.TokenSecret,
+                        AccessToken = settings.Token,
+                        AccessSecretPlain = settings.TokenSecret,
                     };
 
                     settings.UserAccounts.Add(account);

--- a/OpenTween/Thumbnail/ThumbnailGenerator.cs
+++ b/OpenTween/Thumbnail/ThumbnailGenerator.cs
@@ -70,7 +70,7 @@ namespace OpenTween.Thumbnail
                 new Vimeo(),
 
                 // DirectLink
-                new SimpleThumbnailService(@"^https?://.*(\.jpg|\.jpeg|\.gif|\.png|\.bmp)$", "${0}"),
+                new SimpleThumbnailService(@"^https?://.*(\.jpg|\.jpeg|\.gif|\.png|\.bmp)(\?[^#]+)?(#.+)?$", "${0}"),
 
                 // img.azyobuzi.net
                 this.ImgAzyobuziNet,

--- a/OpenTween/TimelineListViewCache.cs
+++ b/OpenTween/TimelineListViewCache.cs
@@ -143,7 +143,7 @@ namespace OpenTween
             if (post.FavoritedCount > 0) mk.Append("+" + post.FavoritedCount);
 
             ListViewItem itm;
-            if (post.RetweetedId == null)
+            if (!post.IsRetweet)
             {
                 string[] sitem =
                 {
@@ -333,7 +333,7 @@ namespace OpenTween
             if (post.IsFav)
                 return ListItemForeColor.Fav;
 
-            if (post.RetweetedId != null)
+            if (post.IsRetweet)
                 return ListItemForeColor.Retweet;
 
             if (post.IsOwl && (post.IsDm || this.settings.OneWayLove))

--- a/OpenTween/TimelineListViewCache.cs
+++ b/OpenTween/TimelineListViewCache.cs
@@ -301,7 +301,7 @@ namespace OpenTween
                 return ListItemBackColor.None;
 
             // @先
-            if (post.StatusId == basePost.InReplyToStatusId)
+            if (basePost.HasInReplyTo && post.StatusId == basePost.InReplyToStatusId)
                 return ListItemBackColor.AtTo;
 
             // 自分=発言者

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -522,7 +522,8 @@ namespace OpenTween
             var configScaleFactor = this.settings.Local.GetConfigScaleFactor(this.CurrentAutoScaleDimensions);
 
             // 認証関連
-            this.tw.Initialize(this.settings.Common.Token, this.settings.Common.TokenSecret, this.settings.Common.UserName, this.settings.Common.UserId);
+            var primaryAccount = this.settings.Common.PrimaryAccount;
+            this.tw.Initialize(primaryAccount.AccessToken, primaryAccount.AccessSecretPlain, primaryAccount.Username, primaryAccount.UserId);
 
             this.initial = true;
 
@@ -2576,10 +2577,17 @@ namespace OpenTween
                 {
                     this.settings.ApplySettings();
 
-                    if (MyCommon.IsNullOrEmpty(this.settings.Common.Token))
+                    var primaryAccount = this.settings.Common.PrimaryAccount;
+                    if (primaryAccount != null)
+                    {
+                        this.tw.Initialize(primaryAccount.AccessToken, primaryAccount.AccessSecretPlain, primaryAccount.Username, primaryAccount.UserId);
+                    }
+                    else
+                    {
                         this.tw.ClearAuthInfo();
+                        this.tw.Initialize("", "", "", 0);
+                    }
 
-                    this.tw.Initialize(this.settings.Common.Token, this.settings.Common.TokenSecret, this.settings.Common.UserName, this.settings.Common.UserId);
                     this.tw.RestrictFavCheck = this.settings.Common.RestrictFavCheck;
                     this.tw.ReadOwnPost = this.settings.Common.ReadOwnPost;
 

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -697,6 +697,16 @@ namespace OpenTween
 
             this.ListTabSelect(this.ListTab.SelectedTab);
 
+            TabModel firstSelectedTab;
+            if (this.settings.Common.PrimaryAccount == null && this.settings.Common.MastodonPrimaryAccount != null)
+                firstSelectedTab = this.statuses.GetTabByType<MastodonHomeTab>()!;
+            else
+                firstSelectedTab = this.statuses.Tabs[0];
+
+            var firstSelectedTabIndex = this.statuses.Tabs.IndexOf(firstSelectedTab);
+            this.ListTab.SelectedIndex = firstSelectedTabIndex;
+            this.ListTabSelect(this.ListTab.SelectedTab);
+
             // タブの位置を調整する
             this.SetTabAlignment();
 

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -1355,24 +1355,8 @@ namespace OpenTween
             this.BringToFront();
         }
 
-        private static int errorCount = 0;
-
         private static bool CheckAccountValid()
-        {
-            if (Twitter.AccountState != MyCommon.ACCOUNT_STATE.Valid)
-            {
-                errorCount += 1;
-                if (errorCount > 5)
-                {
-                    errorCount = 0;
-                    Twitter.AccountState = MyCommon.ACCOUNT_STATE.Valid;
-                    return true;
-                }
-                return false;
-            }
-            errorCount = 0;
-            return true;
-        }
+            => true;
 
         /// <summary>指定された型 <typeparamref name="T"/> に合致する全てのタブを更新します</summary>
         private Task RefreshTabAsync<T>()

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -524,8 +524,11 @@ namespace OpenTween
             var configScaleFactor = this.settings.Local.GetConfigScaleFactor(this.CurrentAutoScaleDimensions);
 
             // 認証関連
-            var primaryAccount = this.settings.Common.PrimaryAccount;
-            this.tw.Initialize(primaryAccount.AccessToken, primaryAccount.AccessSecretPlain, primaryAccount.Username, primaryAccount.UserId);
+            var twitterAccount = this.settings.Common.PrimaryAccount;
+            if (twitterAccount != null)
+                this.tw.Initialize(twitterAccount.AccessToken, twitterAccount.AccessSecretPlain, twitterAccount.Username, twitterAccount.UserId);
+            else
+                this.tw.Initialize("", "", "", 0L);
 
             var mastodonAccount = this.settings.Common.MastodonPrimaryAccount;
             if (mastodonAccount != null)
@@ -538,22 +541,6 @@ namespace OpenTween
 
             this.tw.RestrictFavCheck = this.settings.Common.RestrictFavCheck;
             this.tw.ReadOwnPost = this.settings.Common.ReadOwnPost;
-
-            // アクセストークンが有効であるか確認する
-            // ここが Twitter API への最初のアクセスになるようにすること
-            try
-            {
-                this.tw.VerifyCredentials();
-            }
-            catch (WebApiException ex)
-            {
-                MessageBox.Show(
-                    this,
-                    string.Format(Properties.Resources.StartupAuthError_Text, ex.Message),
-                    ApplicationSettings.ApplicationName,
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Warning);
-            }
 
             // サムネイル関連の初期化
             // プロキシ設定等の通信まわりの初期化が済んでから処理する

--- a/OpenTween/TweetDetailsView.cs
+++ b/OpenTween/TweetDetailsView.cs
@@ -169,8 +169,13 @@ namespace OpenTween
                 sb.AppendFormat("(PlainText)    : <xmp>{0}</xmp><br>", post.TextFromApi);
                 sb.AppendFormat("StatusId             : {0}<br>", post.StatusId);
                 sb.AppendFormat("ImageUrl       : {0}<br>", post.ImageUrl);
-                sb.AppendFormat("InReplyToStatusId    : {0}<br>", post.InReplyToStatusId);
-                sb.AppendFormat("InReplyToUser  : {0}<br>", post.InReplyToUser);
+
+                if (post.HasInReplyTo)
+                {
+                    sb.AppendFormat("InReplyToStatusId    : {0}<br>", post.InReplyToStatusId);
+                    sb.AppendFormat("InReplyToUser  : {0}<br>", post.InReplyToUser);
+                }
+
                 sb.AppendFormat("IsDM           : {0}<br>", post.IsDm);
                 sb.AppendFormat("IsFav          : {0}<br>", post.IsFav);
                 sb.AppendFormat("IsMark         : {0}<br>", post.IsMark);
@@ -322,15 +327,15 @@ namespace OpenTween
         private async Task AppendQuoteTweetAsync(PostClass post)
         {
             var quoteStatusIds = post.QuoteStatusIds;
-            if (quoteStatusIds.Length == 0 && post.InReplyToStatusId == null)
+            if (quoteStatusIds.Length == 0 && !post.HasInReplyTo)
                 return;
 
             // 「読み込み中」テキストを表示
             var loadingQuoteHtml = quoteStatusIds.Select(x => FormatQuoteTweetHtml(x, Properties.Resources.LoadingText, isReply: false));
 
             var loadingReplyHtml = string.Empty;
-            if (post.InReplyToStatusId != null)
-                loadingReplyHtml = FormatQuoteTweetHtml(post.InReplyToStatusId.Value, Properties.Resources.LoadingText, isReply: true);
+            if (post.HasInReplyTo)
+                loadingReplyHtml = FormatQuoteTweetHtml(post.InReplyToStatusId, Properties.Resources.LoadingText, isReply: true);
 
             var body = post.Text + string.Concat(loadingQuoteHtml) + loadingReplyHtml;
 
@@ -340,8 +345,8 @@ namespace OpenTween
             // 引用ツイートを読み込み
             var loadTweetTasks = quoteStatusIds.Select(x => this.CreateQuoteTweetHtml(x, isReply: false)).ToList();
 
-            if (post.InReplyToStatusId != null)
-                loadTweetTasks.Add(this.CreateQuoteTweetHtml(post.InReplyToStatusId.Value, isReply: true));
+            if (post.HasInReplyTo)
+                loadTweetTasks.Add(this.CreateQuoteTweetHtml(post.InReplyToStatusId, isReply: true));
 
             var quoteHtmls = await Task.WhenAll(loadTweetTasks);
 

--- a/OpenTween/TweetDetailsView.cs
+++ b/OpenTween/TweetDetailsView.cs
@@ -139,7 +139,7 @@ namespace OpenTween
                     nameText = "";
                 }
                 nameText += post.ScreenName + "/" + post.Nickname;
-                if (post.RetweetedId != null)
+                if (post.IsRetweet)
                     nameText += $" (RT:{post.RetweetedBy})";
 
                 this.NameLinkLabel.Text = nameText;
@@ -147,7 +147,7 @@ namespace OpenTween
                 var nameForeColor = SystemColors.ControlText;
                 if (post.IsOwl && (SettingManager.Instance.Common.OneWayLove || post.IsDm))
                     nameForeColor = this.Theme.ColorOWL;
-                if (post.RetweetedId != null)
+                if (post.IsRetweet)
                     nameForeColor = this.Theme.ColorRetweet;
                 if (post.IsFav)
                     nameForeColor = this.Theme.ColorFav;
@@ -193,8 +193,12 @@ namespace OpenTween
                 sb.AppendFormat("Source         : {0}<br>", post.Source);
                 sb.AppendFormat("UserId            : {0}<br>", post.UserId);
                 sb.AppendFormat("FilterHit      : {0}<br>", post.FilterHit);
-                sb.AppendFormat("RetweetedBy    : {0}<br>", post.RetweetedBy);
-                sb.AppendFormat("RetweetedId    : {0}<br>", post.RetweetedId);
+
+                if (post.IsRetweet)
+                {
+                    sb.AppendFormat("RetweetedBy    : {0}<br>", post.RetweetedBy);
+                    sb.AppendFormat("RetweetedId    : {0}<br>", post.RetweetedId);
+                }
 
                 sb.AppendFormat("Media.Count    : {0}<br>", post.Media.Count);
                 if (post.Media.Count > 0)

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -759,11 +759,11 @@ namespace OpenTween
                 throw new ArgumentException("startStatusId (" + startStatusId + ") が posts の中から見つかりませんでした。", nameof(startStatusId));
 
             var nextPost = posts[startStatusId];
-            while (nextPost.InReplyToStatusId != null)
+            while (nextPost.HasInReplyTo)
             {
-                if (!posts.ContainsKey(nextPost.InReplyToStatusId.Value))
+                if (!posts.ContainsKey(nextPost.InReplyToStatusId))
                     break;
-                nextPost = posts[nextPost.InReplyToStatusId.Value];
+                nextPost = posts[nextPost.InReplyToStatusId];
             }
 
             return nextPost;
@@ -782,11 +782,11 @@ namespace OpenTween
             }
 
             var relPosts = new Dictionary<long, PostClass>();
-            if (targetPost.TextFromApi.Contains("@") && targetPost.InReplyToStatusId == null)
+            if (targetPost.TextFromApi.Contains("@") && !targetPost.HasInReplyTo)
             {
                 // 検索結果対応
                 var p = TabInformations.GetInstance()[targetPost.StatusId];
-                if (p != null && p.InReplyToStatusId != null)
+                if (p != null && p.HasInReplyTo)
                 {
                     targetPost = p;
                 }
@@ -804,9 +804,9 @@ namespace OpenTween
             // in_reply_to_status_id を使用してリプライチェインを辿る
             var nextPost = FindTopOfReplyChain(relPosts, targetPost.StatusId);
             var loopCount = 1;
-            while (nextPost.InReplyToStatusId != null && loopCount++ <= 20)
+            while (nextPost.HasInReplyTo && loopCount++ <= 20)
             {
-                var inReplyToId = nextPost.InReplyToStatusId.Value;
+                var inReplyToId = nextPost.InReplyToStatusId;
 
                 var inReplyToPost = TabInformations.GetInstance()[inReplyToId];
                 if (inReplyToPost == null)
@@ -871,7 +871,7 @@ namespace OpenTween
                         continue;
 
                     // リプライチェーンが繋がらないツイートは除外
-                    if (post.InReplyToStatusId == null || !relPosts.ContainsKey(post.InReplyToStatusId.Value))
+                    if (!post.HasInReplyTo || !relPosts.ContainsKey(post.InReplyToStatusId))
                         continue;
 
                     relPosts.Add(post.StatusId, post);

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -632,7 +632,7 @@ namespace OpenTween
             => this.CreatePostsFromStatusData(status, favTweet: false);
 
         private PostClass CreatePostsFromStatusData(TwitterStatus status, bool favTweet)
-            => this.postFactory.CreateFromStatus(status, this.UserId, this.followerId, favTweet);
+            => this.postFactory.CreateFromStatus(this, status, this.UserId, this.followerId, favTweet);
 
         private long? CreatePostsFromJson(TwitterStatus[] items, MyCommon.WORKERTYPE gType, TabModel? tab, bool read)
         {
@@ -1010,7 +1010,7 @@ namespace OpenTween
 
             foreach (var eventItem in events)
             {
-                var post = this.postFactory.CreateFromDirectMessageEvent(eventItem, users, apps, this.UserId);
+                var post = this.postFactory.CreateFromDirectMessageEvent(this, eventItem, users, apps, this.UserId);
 
                 post.IsRead = read;
                 if (post.IsMe && !read && this.ReadOwnPost)

--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -357,7 +357,7 @@ namespace OpenTween
             if (post == null)
                 throw new WebApiException("Err:Target isn't found.");
 
-            var target = post.RetweetedId ?? id;  // 再RTの場合は元発言をRT
+            var target = post.IsRetweet ? post.RetweetedId : id; // 再RTの場合は元発言をRT
 
             var response = await this.Api.StatusesRetweet(target)
                 .ConfigureAwait(false);
@@ -773,12 +773,11 @@ namespace OpenTween
         {
             var targetPost = tab.TargetPost;
 
-            if (targetPost.RetweetedId != null)
+            if (targetPost.IsRetweet)
             {
                 var originalPost = targetPost.Clone();
-                originalPost.StatusId = targetPost.RetweetedId.Value;
-                originalPost.RetweetedId = null;
-                originalPost.RetweetedBy = null;
+                originalPost.StatusId = targetPost.RetweetedId;
+                originalPost.IsRetweet = false;
                 targetPost = originalPost;
             }
 


### PR DESCRIPTION
開発中の `upsilon:mastodon` ブランチの最新ビルドは下記URLからダウンロードできます。
設定ファイルを壊す可能性があるため、普段使用しているOpenTweenには上書きせず**必ず新しいフォルダに展開して**使用して下さい。
https://ci.appveyor.com/project/upsilon/opentween/builds/45549844/artifacts

The latest build of the `upsilon:mastodon` branch under development can be downloaded from the following URL.
This build may corrupt the setting file, **DO NOT overwrite the OpenTween folder that you usually use**.
https://ci.appveyor.com/project/upsilon/opentween/builds/45549844/artifacts

-----

- [x] SettingCommon.xml に Mastodon の認証情報の項目を追加
- [x] 設定ダイアログに Mastodon の認証画面を実装 (Authorization Code Grant)
- [x] ホームタイムライン
- [x] トゥート
- [x] ふぁぼ
- [x] ブースト
- [x] トゥートに添付された画像の表示
- [ ] PostClassでTwitterとMastodonのstatus_idを区別できる状態にする

ここから下は後回し

- [ ] CW が設定されたトゥートの表示切り替え
- [ ] NSFW が設定された画像の表示切り替え
- [ ] ユーザープロフィール表示
- [ ] ユーザータイムライン表示
- [ ] トゥート投稿時の公開範囲設定
- [ ] タイムライン振り分けタブ
- [ ] Streaming API を使用したタイムラインのリアルタイム受信