### PR TITLE
動画のサムネイルを右クリックしてURLをコピーしようとするとエラーが発生していたのを修正

### DIFF
--- a/OpenTween/TweetThumbnail.cs
+++ b/OpenTween/TweetThumbnail.cs
@@ -293,7 +293,7 @@ namespace OpenTween
         {
             try
             {
-                Clipboard.SetText(this.Thumbnail.FullSizeImageUrl);
+                Clipboard.SetText(this.Thumbnail.FullSizeImageUrl ?? this.Thumbnail.MediaPageUrl);
             }
             catch (ExternalException ex)
             {


### PR DESCRIPTION
タイトルの通りです。
動画のサムネイル(公式・YouTubeほか)の右クリックで「URLをコピー(C)」を選ぶとArgumentNullExceptionしてました。