### PR TITLE
「プロフィール表示」「ユーザーのタイムラインを表示」のメニュー項目を再度追加

### DIFF
--- a/OpenTween/Tween.Designer.cs
+++ b/OpenTween/Tween.Designer.cs
@@ -104,7 +104,9 @@
             this.FavoriteRetweetUnofficialMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.UnFavOpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripSeparator38 = new System.Windows.Forms.ToolStripSeparator();
+            this.ShowProfileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ShowRelatedStatusesMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.ShowUserTimelineMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AuthorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AuthorShowProfileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AuthorShowUserTimelineMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -241,7 +243,9 @@
             this.FavoriteRetweetUnofficialContextMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.FavRemoveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.ShowProfileContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ShowRelatedStatusesMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ShowUserTimelineContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AuthorContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AuthorShowProfileContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AuthorShowUserTimelineContextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -919,7 +923,9 @@
             this.FavoriteRetweetUnofficialMenuItem,
             this.UnFavOpMenuItem,
             this.ToolStripSeparator38,
+            this.ShowProfileMenuItem,
             this.ShowRelatedStatusesMenuItem2,
+            this.ShowUserTimelineMenuItem,
             this.AuthorMenuItem,
             this.RetweetedByMenuItem,
             this.OpenOpMenuItem,
@@ -1006,11 +1012,23 @@
             this.ToolStripSeparator38.Name = "ToolStripSeparator38";
             resources.ApplyResources(this.ToolStripSeparator38, "ToolStripSeparator38");
             // 
+            // ShowProfileMenuItem
+            // 
+            this.ShowProfileMenuItem.Name = "ShowProfileMenuItem";
+            resources.ApplyResources(this.ShowProfileMenuItem, "ShowProfileMenuItem");
+            this.ShowProfileMenuItem.Click += new System.EventHandler(this.AuthorShowProfileMenuItem_Click);
+            // 
             // ShowRelatedStatusesMenuItem2
             // 
             this.ShowRelatedStatusesMenuItem2.Name = "ShowRelatedStatusesMenuItem2";
             resources.ApplyResources(this.ShowRelatedStatusesMenuItem2, "ShowRelatedStatusesMenuItem2");
             this.ShowRelatedStatusesMenuItem2.Click += new System.EventHandler(this.ShowRelatedStatusesMenuItem_Click);
+            // 
+            // ShowUserTimelineMenuItem
+            // 
+            this.ShowUserTimelineMenuItem.Name = "ShowUserTimelineMenuItem";
+            resources.ApplyResources(this.ShowUserTimelineMenuItem, "ShowUserTimelineMenuItem");
+            this.ShowUserTimelineMenuItem.Click += new System.EventHandler(this.AuthorShowUserTimelineMenuItem_Click);
             // 
             // AuthorMenuItem
             // 
@@ -1857,7 +1875,9 @@
             this.FavoriteRetweetUnofficialContextMenu,
             this.FavRemoveToolStripMenuItem,
             this.ToolStripSeparator2,
+            this.ShowProfileContextMenuItem,
             this.ShowRelatedStatusesMenuItem,
+            this.ShowUserTimelineContextMenuItem,
             this.AuthorContextMenuItem,
             this.RetweetedByContextMenuItem,
             this.ToolStripMenuItem6,
@@ -1945,11 +1965,23 @@
             this.ToolStripSeparator2.Name = "ToolStripSeparator2";
             resources.ApplyResources(this.ToolStripSeparator2, "ToolStripSeparator2");
             // 
+            // ShowProfileContextMenuItem
+            // 
+            this.ShowProfileContextMenuItem.Name = "ShowProfileContextMenuItem";
+            resources.ApplyResources(this.ShowProfileContextMenuItem, "ShowProfileContextMenuItem");
+            this.ShowProfileContextMenuItem.Click += new System.EventHandler(this.AuthorShowProfileMenuItem_Click);
+            // 
             // ShowRelatedStatusesMenuItem
             // 
             this.ShowRelatedStatusesMenuItem.Name = "ShowRelatedStatusesMenuItem";
             resources.ApplyResources(this.ShowRelatedStatusesMenuItem, "ShowRelatedStatusesMenuItem");
             this.ShowRelatedStatusesMenuItem.Click += new System.EventHandler(this.ShowRelatedStatusesMenuItem_Click);
+            // 
+            // ShowUserTimelineContextMenuItem
+            // 
+            this.ShowUserTimelineContextMenuItem.Name = "ShowUserTimelineContextMenuItem";
+            resources.ApplyResources(this.ShowUserTimelineContextMenuItem, "ShowUserTimelineContextMenuItem");
+            this.ShowUserTimelineContextMenuItem.Click += new System.EventHandler(this.AuthorShowUserTimelineMenuItem_Click);
             // 
             // AuthorContextMenuItem
             // 
@@ -2397,5 +2429,9 @@
         private System.Windows.Forms.ToolStripMenuItem RetweetedByShowUserTimelineContextMenuItem;
         private System.Windows.Forms.ToolStripMenuItem RetweetedByListManageContextMenuItem;
         private System.Windows.Forms.ToolStripMenuItem RetweetedByOpenInBrowserContextMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ShowProfileMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ShowUserTimelineMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ShowProfileContextMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ShowUserTimelineContextMenuItem;
     }
 }

--- a/OpenTween/Tween.en.resx
+++ b/OpenTween/Tween.en.resx
@@ -427,10 +427,18 @@
 	<data name="SettingStripMenuItem.Text"><value>Settings (&amp;O)...</value></data>
 	<data name="ShortcutKeyListMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>278, 24</value></data>
 	<data name="ShortcutKeyListMenuItem.Text"><value>Shortcut keys</value></data>
+	<data name="ShowProfileContextMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>199, 22</value></data>
+	<data name="ShowProfileContextMenuItem.Text"><value>User &amp;Profile</value></data>
+	<data name="ShowProfileMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>259, 22</value></data>
+	<data name="ShowProfileMenuItem.Text"><value>User &amp;Profile</value></data>
 	<data name="ShowRelatedStatusesMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>258, 24</value></data>
 	<data name="ShowRelatedStatusesMenuItem.Text"><value>Related Posts (&amp;G)</value></data>
 	<data name="ShowRelatedStatusesMenuItem2.Size" type="System.Drawing.Size, System.Drawing"><value>347, 24</value></data>
 	<data name="ShowRelatedStatusesMenuItem2.Text"><value>Related Posts (&amp;G)</value></data>
+	<data name="ShowUserTimelineContextMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>199, 22</value></data>
+	<data name="ShowUserTimelineContextMenuItem.Text"><value>User's updates</value></data>
+	<data name="ShowUserTimelineMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>259, 22</value></data>
+	<data name="ShowUserTimelineMenuItem.Text"><value>User's updates</value></data>
 	<data name="SoundFileComboBox.ToolTipText"><value>Select a wav file.</value></data>
 	<data name="SourceRuleMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>122, 22</value></data>
 	<data name="SourceRuleMenuItem.Text"><value>&amp;Source</value></data>

--- a/OpenTween/Tween.resx
+++ b/OpenTween/Tween.resx
@@ -344,10 +344,18 @@
 	<data name="&gt;&gt;SettingStripMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;ShortcutKeyListMenuItem.Name"><value>ShortcutKeyListMenuItem</value></data>
 	<data name="&gt;&gt;ShortcutKeyListMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;ShowProfileContextMenuItem.Name"><value>ShowProfileContextMenuItem</value></data>
+	<data name="&gt;&gt;ShowProfileContextMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;ShowProfileMenuItem.Name"><value>ShowProfileMenuItem</value></data>
+	<data name="&gt;&gt;ShowProfileMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;ShowRelatedStatusesMenuItem.Name"><value>ShowRelatedStatusesMenuItem</value></data>
 	<data name="&gt;&gt;ShowRelatedStatusesMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;ShowRelatedStatusesMenuItem2.Name"><value>ShowRelatedStatusesMenuItem2</value></data>
 	<data name="&gt;&gt;ShowRelatedStatusesMenuItem2.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;ShowUserTimelineContextMenuItem.Name"><value>ShowUserTimelineContextMenuItem</value></data>
+	<data name="&gt;&gt;ShowUserTimelineContextMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
+	<data name="&gt;&gt;ShowUserTimelineMenuItem.Name"><value>ShowUserTimelineMenuItem</value></data>
+	<data name="&gt;&gt;ShowUserTimelineMenuItem.Type"><value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;SoundFileComboBox.Name"><value>SoundFileComboBox</value></data>
 	<data name="&gt;&gt;SoundFileComboBox.Type"><value>System.Windows.Forms.ToolStripComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;SoundFileTbComboBox.Name"><value>SoundFileTbComboBox</value></data>
@@ -963,10 +971,18 @@
 	<data name="SettingStripMenuItem.Text"><value>設定(&amp;O)...</value></data>
 	<data name="ShortcutKeyListMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>251, 22</value></data>
 	<data name="ShortcutKeyListMenuItem.Text"><value>ショートカットキー一覧</value></data>
+	<data name="ShowProfileContextMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>223, 22</value></data>
+	<data name="ShowProfileContextMenuItem.Text"><value>プロフィール表示</value></data>
+	<data name="ShowProfileMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>243, 22</value></data>
+	<data name="ShowProfileMenuItem.Text"><value>プロフィール表示</value></data>
 	<data name="ShowRelatedStatusesMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>241, 22</value></data>
 	<data name="ShowRelatedStatusesMenuItem.Text"><value>関連発言表示(&amp;G)</value></data>
 	<data name="ShowRelatedStatusesMenuItem2.Size" type="System.Drawing.Size, System.Drawing"><value>313, 22</value></data>
 	<data name="ShowRelatedStatusesMenuItem2.Text"><value>関連発言表示(&amp;G)</value></data>
+	<data name="ShowUserTimelineContextMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>223, 22</value></data>
+	<data name="ShowUserTimelineContextMenuItem.Text"><value>ユーザーのタイムラインを表示</value></data>
+	<data name="ShowUserTimelineMenuItem.Size" type="System.Drawing.Size, System.Drawing"><value>243, 22</value></data>
+	<data name="ShowUserTimelineMenuItem.Text"><value>ユーザーのタイムラインを表示</value></data>
 	<data name="SoundFileComboBox.Size" type="System.Drawing.Size, System.Drawing"><value>121, 23</value></data>
 	<data name="SoundFileComboBox.ToolTipText"><value>再生するwavファイルを指定してください</value></data>
 	<data name="SoundFileTbComboBox.Size" type="System.Drawing.Size, System.Drawing"><value>121, 23</value></data>


### PR DESCRIPTION
#118 でのメニュー項目の整理でいくつかの項目をサブメニューに移動したが、利用頻度が高い「プロフィール表示」「ユーザーのタイムラインを表示」についてはサブメニューを展開する待ち時間が煩わしく（デフォルトで400msの遅延が入る）、冗長でもトップレベルに置かれていた方が使いやすかったため元に戻す。
