### PR TITLE
Reproducible build の不具合を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,174 @@
+name: Build
+
+on:
+  push:
+    branches: ['develop', 'release']
+  pull_request:
+
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Set configuration env
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -eq 'refs/heads/release') {
+            echo 'CONFIGURATION=Release' >> $env:GITHUB_ENV
+          } else {
+            echo 'CONFIGURATION=Debug' >> $env:GITHUB_ENV
+          }
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: nuget-${{ hashFiles('*/*.csproj') }}
+          restore-keys: |
+            nuget-
+
+      - name: Build
+        shell: pwsh
+        run: |
+          msbuild /target:restore,build "/p:Configuration=$($env:CONFIGURATION)" /verbosity:minimal
+
+      - name: Upload build result
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: |
+            ./OpenTween/bin/
+            ./OpenTween/obj/
+            ./OpenTween.Tests/bin/
+          retention-days: 1
+
+  test:
+    runs-on: windows-2022
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Set configuration env
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -eq 'refs/heads/release') {
+            echo 'CONFIGURATION=Release' >> $env:GITHUB_ENV
+          } else {
+            echo 'CONFIGURATION=Debug' >> $env:GITHUB_ENV
+          }
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: nuget-${{ hashFiles('*/*.csproj') }}
+          restore-keys: |
+            nuget-
+
+      - name: Restore build result
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          $altCoverVersion = '8.2.837'
+          $xunitVersion = '2.4.1'
+          $targetFramework = 'net472'
+          $altCoverPath = "$($env:NUGET_PACKAGES)\altcover\$($altCoverVersion)\tools\$($targetFramework)\AltCover.exe"
+          $xunitPath = "$($env:NUGET_PACKAGES)\xunit.runner.console\$($xunitVersion)\tools\$($targetFramework)\xunit.console.exe"
+
+          Start-Process `
+            -FilePath $altCoverPath `
+            -ArgumentList (
+              '--inputDirectory',
+              ".\OpenTween.Tests\bin\$($env:CONFIGURATION)\$($targetFramework)",
+              '--outputDirectory',
+              '.\__Instrumented\',
+              '--assemblyFilter',
+              '?^OpenTween(?!\.Tests)',
+              '--typeFilter',
+              '?^OpenTween\.',
+              '--fileFilter',
+              '\.Designer\.cs',
+              '--visibleBranches'
+            ) `
+            -NoNewWindow `
+            -Wait
+
+          Start-Process `
+            -FilePath $altCoverPath `
+            -ArgumentList (
+              'runner',
+              '--recorderDirectory',
+              '.\__Instrumented\',
+              '--executable',
+              $xunitPath,
+              '--',
+              '.\__Instrumented\OpenTween.Tests.dll'
+            ) `
+            -NoNewWindow `
+            -Wait
+
+      - name: Upload test results to codecov
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+          .\codecov.exe -f coverage.xml
+
+  package:
+    runs-on: windows-2022
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Set configuration env
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -eq 'refs/heads/release') {
+            echo 'CONFIGURATION=Release' >> $env:GITHUB_ENV
+          } else {
+            echo 'CONFIGURATION=Debug' >> $env:GITHUB_ENV
+          }
+
+      - name: Restore build result
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+
+      - name: Build package
+        shell: powershell # runtime-versionを取得するため従来のPowershellを使用する
+        run: |
+          $env:PATH = $env:PATH + ';C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Msbuild\Current\Bin\Roslyn\'
+          $binDir = '.\OpenTween\bin\' + $env:CONFIGURATION + '\'
+          $objDir = '.\OpenTween\obj\' + $env:CONFIGURATION + '\'
+          $assemblyInfo = '.\OpenTween\Properties\AssemblyInfo.cs'
+          $destPath = 'OpenTween.zip'
+          $headCommit = '${{ github.event.pull_request.head.sha }}'
+          .\tools\build-zip-archive.ps1 -BinDir $binDir -ObjDir $objDir -AssemblyInfo $assemblyInfo -DestPath $destPath -HeadCommit $headCommit
+          Copy-Item ($binDir + 'OpenTween.pdb') -Destination '.\'
+
+      - name: Upload build result
+        uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: |
+            ./OpenTween.zip
+            ./OpenTween.pdb

--- a/OpenTween/HashtagManage.resx
+++ b/OpenTween/HashtagManage.resx
@@ -19,24 +19,16 @@
 	<data name="&gt;&gt;AddButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;AddButton.ZOrder"><value>7</value></data>
 	<data name="&gt;&gt;Cancel_Button.Name"><value>Cancel_Button</value></data>
-	<data name="&gt;&gt;Cancel_Button.Name"><value>Cancel_Button</value></data>
-	<data name="&gt;&gt;Cancel_Button.Parent"><value>TableLayoutButtons</value></data>
 	<data name="&gt;&gt;Cancel_Button.Parent"><value>TableLayoutButtons</value></data>
 	<data name="&gt;&gt;Cancel_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Cancel_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Cancel_Button.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;Cancel_Button.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;CheckNotAddToAtReply.Name"><value>CheckNotAddToAtReply</value></data>
 	<data name="&gt;&gt;CheckNotAddToAtReply.Parent"><value>$this</value></data>
 	<data name="&gt;&gt;CheckNotAddToAtReply.Type"><value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;CheckNotAddToAtReply.ZOrder"><value>2</value></data>
 	<data name="&gt;&gt;CheckPermanent.Name"><value>CheckPermanent</value></data>
-	<data name="&gt;&gt;CheckPermanent.Name"><value>CheckPermanent</value></data>
-	<data name="&gt;&gt;CheckPermanent.Parent"><value>GroupHashtag</value></data>
 	<data name="&gt;&gt;CheckPermanent.Parent"><value>GroupHashtag</value></data>
 	<data name="&gt;&gt;CheckPermanent.Type"><value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;CheckPermanent.Type"><value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;CheckPermanent.ZOrder"><value>8</value></data>
 	<data name="&gt;&gt;CheckPermanent.ZOrder"><value>8</value></data>
 	<data name="&gt;&gt;DeleteButton.Name"><value>DeleteButton</value></data>
 	<data name="&gt;&gt;DeleteButton.Parent"><value>GroupHashtag</value></data>
@@ -59,24 +51,16 @@
 	<data name="&gt;&gt;HistoryHashList.Type"><value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;HistoryHashList.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;Label1.Name"><value>Label1</value></data>
-	<data name="&gt;&gt;Label1.Name"><value>Label1</value></data>
-	<data name="&gt;&gt;Label1.Parent"><value>GroupDetail</value></data>
 	<data name="&gt;&gt;Label1.Parent"><value>GroupDetail</value></data>
 	<data name="&gt;&gt;Label1.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label1.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label1.ZOrder"><value>2</value></data>
 	<data name="&gt;&gt;Label1.ZOrder"><value>2</value></data>
 	<data name="&gt;&gt;Label3.Name"><value>Label3</value></data>
 	<data name="&gt;&gt;Label3.Parent"><value>GroupHashtag</value></data>
 	<data name="&gt;&gt;Label3.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;Label3.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;OK_Button.Name"><value>OK_Button</value></data>
-	<data name="&gt;&gt;OK_Button.Name"><value>OK_Button</value></data>
-	<data name="&gt;&gt;OK_Button.Parent"><value>TableLayoutButtons</value></data>
 	<data name="&gt;&gt;OK_Button.Parent"><value>TableLayoutButtons</value></data>
 	<data name="&gt;&gt;OK_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;OK_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;OK_Button.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;OK_Button.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;PermCancel_Button.Name"><value>PermCancel_Button</value></data>
 	<data name="&gt;&gt;PermCancel_Button.Parent"><value>TableLayoutPanel2</value></data>
@@ -107,12 +91,8 @@
 	<data name="&gt;&gt;UnSelectButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;UnSelectButton.ZOrder"><value>2</value></data>
 	<data name="&gt;&gt;UseHashText.Name"><value>UseHashText</value></data>
-	<data name="&gt;&gt;UseHashText.Name"><value>UseHashText</value></data>
-	<data name="&gt;&gt;UseHashText.Parent"><value>GroupDetail</value></data>
 	<data name="&gt;&gt;UseHashText.Parent"><value>GroupDetail</value></data>
 	<data name="&gt;&gt;UseHashText.Type"><value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;UseHashText.Type"><value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;UseHashText.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;UseHashText.ZOrder"><value>1</value></data>
 	<data name="AddButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms"><value>NoControl</value></data>
 	<data name="AddButton.Location" type="System.Drawing.Point, System.Drawing"><value>240, 18</value></data>

--- a/OpenTween/ListAvailable.resx
+++ b/OpenTween/ListAvailable.resx
@@ -15,12 +15,8 @@
 	<data name="&gt;&gt;$this.Name"><value>ListAvailable</value></data>
 	<data name="&gt;&gt;$this.Type"><value>OpenTween.OTBaseForm, OpenTween, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</value></data>
 	<data name="&gt;&gt;Cancel_Button.Name"><value>Cancel_Button</value></data>
-	<data name="&gt;&gt;Cancel_Button.Name"><value>Cancel_Button</value></data>
-	<data name="&gt;&gt;Cancel_Button.Parent"><value>TableLayoutPanel1</value></data>
 	<data name="&gt;&gt;Cancel_Button.Parent"><value>TableLayoutPanel1</value></data>
 	<data name="&gt;&gt;Cancel_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Cancel_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Cancel_Button.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;Cancel_Button.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;DescriptionText.Name"><value>DescriptionText</value></data>
 	<data name="&gt;&gt;DescriptionText.Parent"><value>$this</value></data>
@@ -63,12 +59,8 @@
 	<data name="&gt;&gt;NameLabel.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;NameLabel.ZOrder"><value>10</value></data>
 	<data name="&gt;&gt;OK_Button.Name"><value>OK_Button</value></data>
-	<data name="&gt;&gt;OK_Button.Name"><value>OK_Button</value></data>
-	<data name="&gt;&gt;OK_Button.Parent"><value>TableLayoutPanel1</value></data>
 	<data name="&gt;&gt;OK_Button.Parent"><value>TableLayoutPanel1</value></data>
 	<data name="&gt;&gt;OK_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;OK_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;OK_Button.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;OK_Button.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;RefreshButton.Name"><value>RefreshButton</value></data>
 	<data name="&gt;&gt;RefreshButton.Parent"><value>$this</value></data>

--- a/OpenTween/ListManage.resx
+++ b/OpenTween/ListManage.resx
@@ -19,12 +19,8 @@
 	<data name="&gt;&gt;AddListButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;AddListButton.ZOrder"><value>7</value></data>
 	<data name="&gt;&gt;CancelEditButton.Name"><value>CancelEditButton</value></data>
-	<data name="&gt;&gt;CancelEditButton.Name"><value>CancelEditButton</value></data>
-	<data name="&gt;&gt;CancelEditButton.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;CancelEditButton.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;CancelEditButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;CancelEditButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;CancelEditButton.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;CancelEditButton.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;CloseButton.Name"><value>CloseButton</value></data>
 	<data name="&gt;&gt;CloseButton.Parent"><value>$this</value></data>
@@ -39,52 +35,32 @@
 	<data name="&gt;&gt;DeleteUserButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;DeleteUserButton.ZOrder"><value>4</value></data>
 	<data name="&gt;&gt;DescriptionText.Name"><value>DescriptionText</value></data>
-	<data name="&gt;&gt;DescriptionText.Name"><value>DescriptionText</value></data>
-	<data name="&gt;&gt;DescriptionText.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;DescriptionText.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;DescriptionText.Type"><value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;DescriptionText.Type"><value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;DescriptionText.ZOrder"><value>11</value></data>
 	<data name="&gt;&gt;DescriptionText.ZOrder"><value>11</value></data>
 	<data name="&gt;&gt;EditCheckBox.Name"><value>EditCheckBox</value></data>
 	<data name="&gt;&gt;EditCheckBox.Parent"><value>$this</value></data>
 	<data name="&gt;&gt;EditCheckBox.Type"><value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;EditCheckBox.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;GetMoreUsersButton.Name"><value>GetMoreUsersButton</value></data>
-	<data name="&gt;&gt;GetMoreUsersButton.Name"><value>GetMoreUsersButton</value></data>
-	<data name="&gt;&gt;GetMoreUsersButton.Parent"><value>MemberGroup</value></data>
 	<data name="&gt;&gt;GetMoreUsersButton.Parent"><value>MemberGroup</value></data>
 	<data name="&gt;&gt;GetMoreUsersButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;GetMoreUsersButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;GetMoreUsersButton.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;GetMoreUsersButton.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;GroupBox2.Name"><value>GroupBox2</value></data>
 	<data name="&gt;&gt;GroupBox2.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;GroupBox2.Type"><value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;GroupBox2.ZOrder"><value>2</value></data>
 	<data name="&gt;&gt;Label1.Name"><value>Label1</value></data>
-	<data name="&gt;&gt;Label1.Name"><value>Label1</value></data>
-	<data name="&gt;&gt;Label1.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label1.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label1.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label1.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label1.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;Label1.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;Label10.Name"><value>Label10</value></data>
-	<data name="&gt;&gt;Label10.Name"><value>Label10</value></data>
-	<data name="&gt;&gt;Label10.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label10.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label10.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label10.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label10.ZOrder"><value>10</value></data>
 	<data name="&gt;&gt;Label10.ZOrder"><value>10</value></data>
 	<data name="&gt;&gt;Label12.Name"><value>Label12</value></data>
-	<data name="&gt;&gt;Label12.Name"><value>Label12</value></data>
-	<data name="&gt;&gt;Label12.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label12.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label12.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label12.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label12.ZOrder"><value>12</value></data>
 	<data name="&gt;&gt;Label12.ZOrder"><value>12</value></data>
 	<data name="&gt;&gt;Label13.Name"><value>Label13</value></data>
 	<data name="&gt;&gt;Label13.Parent"><value>UserGroup</value></data>
@@ -107,28 +83,16 @@
 	<data name="&gt;&gt;Label3.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;Label3.ZOrder"><value>3</value></data>
 	<data name="&gt;&gt;Label4.Name"><value>Label4</value></data>
-	<data name="&gt;&gt;Label4.Name"><value>Label4</value></data>
-	<data name="&gt;&gt;Label4.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label4.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label4.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label4.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label4.ZOrder"><value>8</value></data>
 	<data name="&gt;&gt;Label4.ZOrder"><value>8</value></data>
 	<data name="&gt;&gt;Label5.Name"><value>Label5</value></data>
-	<data name="&gt;&gt;Label5.Name"><value>Label5</value></data>
-	<data name="&gt;&gt;Label5.Parent"><value>UserGroup</value></data>
 	<data name="&gt;&gt;Label5.Parent"><value>UserGroup</value></data>
 	<data name="&gt;&gt;Label5.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label5.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label5.ZOrder"><value>16</value></data>
 	<data name="&gt;&gt;Label5.ZOrder"><value>16</value></data>
 	<data name="&gt;&gt;Label6.Name"><value>Label6</value></data>
-	<data name="&gt;&gt;Label6.Name"><value>Label6</value></data>
-	<data name="&gt;&gt;Label6.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label6.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;Label6.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label6.Type"><value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Label6.ZOrder"><value>9</value></data>
 	<data name="&gt;&gt;Label6.ZOrder"><value>9</value></data>
 	<data name="&gt;&gt;Label8.Name"><value>Label8</value></data>
 	<data name="&gt;&gt;Label8.Parent"><value>UserGroup</value></data>
@@ -155,32 +119,20 @@
 	<data name="&gt;&gt;MemberGroup.Type"><value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;MemberGroup.ZOrder"><value>6</value></data>
 	<data name="&gt;&gt;NameTextBox.Name"><value>NameTextBox</value></data>
-	<data name="&gt;&gt;NameTextBox.Name"><value>NameTextBox</value></data>
-	<data name="&gt;&gt;NameTextBox.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;NameTextBox.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;NameTextBox.Type"><value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;NameTextBox.Type"><value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;NameTextBox.ZOrder"><value>7</value></data>
 	<data name="&gt;&gt;NameTextBox.ZOrder"><value>7</value></data>
 	<data name="&gt;&gt;OKEditButton.Name"><value>OKEditButton</value></data>
-	<data name="&gt;&gt;OKEditButton.Name"><value>OKEditButton</value></data>
-	<data name="&gt;&gt;OKEditButton.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;OKEditButton.Parent"><value>ListGroup</value></data>
 	<data name="&gt;&gt;OKEditButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;OKEditButton.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;OKEditButton.ZOrder"><value>3</value></data>
 	<data name="&gt;&gt;OKEditButton.ZOrder"><value>3</value></data>
 	<data name="&gt;&gt;PrivateRadioButton.Name"><value>PrivateRadioButton</value></data>
 	<data name="&gt;&gt;PrivateRadioButton.Parent"><value>GroupBox2</value></data>
 	<data name="&gt;&gt;PrivateRadioButton.Type"><value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
 	<data name="&gt;&gt;PrivateRadioButton.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;PublicRadioButton.Name"><value>PublicRadioButton</value></data>
-	<data name="&gt;&gt;PublicRadioButton.Name"><value>PublicRadioButton</value></data>
-	<data name="&gt;&gt;PublicRadioButton.Parent"><value>GroupBox2</value></data>
 	<data name="&gt;&gt;PublicRadioButton.Parent"><value>GroupBox2</value></data>
 	<data name="&gt;&gt;PublicRadioButton.Type"><value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;PublicRadioButton.Type"><value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;PublicRadioButton.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;PublicRadioButton.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;RefreshListsButton.Name"><value>RefreshListsButton</value></data>
 	<data name="&gt;&gt;RefreshListsButton.Parent"><value>$this</value></data>
@@ -211,12 +163,8 @@
 	<data name="&gt;&gt;UserIcon.Type"><value>OpenTween.OTPictureBox, OpenTween, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</value></data>
 	<data name="&gt;&gt;UserIcon.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;UserList.Name"><value>UserList</value></data>
-	<data name="&gt;&gt;UserList.Name"><value>UserList</value></data>
-	<data name="&gt;&gt;UserList.Parent"><value>MemberGroup</value></data>
 	<data name="&gt;&gt;UserList.Parent"><value>MemberGroup</value></data>
 	<data name="&gt;&gt;UserList.Type"><value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;UserList.Type"><value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;UserList.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;UserList.ZOrder"><value>0</value></data>
 	<data name="&gt;&gt;UserLocation.Name"><value>UserLocation</value></data>
 	<data name="&gt;&gt;UserLocation.Parent"><value>UserGroup</value></data>

--- a/OpenTween/OpenTween.csproj
+++ b/OpenTween/OpenTween.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
@@ -27,7 +27,7 @@
     <CodeAnalysisRuleSet>OpenTween.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/OpenTween/OpenURL.resx
+++ b/OpenTween/OpenURL.resx
@@ -17,12 +17,8 @@
 	<data name="&gt;&gt;$this.Name"><value>OpenURL</value></data>
 	<data name="&gt;&gt;$this.Type"><value>OpenTween.OTBaseForm, OpenTween, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null</value></data>
 	<data name="&gt;&gt;Cancel_Button.Name"><value>Cancel_Button</value></data>
-	<data name="&gt;&gt;Cancel_Button.Name"><value>Cancel_Button</value></data>
-	<data name="&gt;&gt;Cancel_Button.Parent"><value>TableLayoutPanel1</value></data>
 	<data name="&gt;&gt;Cancel_Button.Parent"><value>TableLayoutPanel1</value></data>
 	<data name="&gt;&gt;Cancel_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Cancel_Button.Type"><value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></data>
-	<data name="&gt;&gt;Cancel_Button.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;Cancel_Button.ZOrder"><value>1</value></data>
 	<data name="&gt;&gt;OK_Button.Name"><value>OK_Button</value></data>
 	<data name="&gt;&gt;OK_Button.Parent"><value>TableLayoutPanel1</value></data>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,8 @@ for:
     artifacts:
       - name: OpenTween.zip
         path: OpenTween_dev-$(APPVEYOR_BUILD_NUMBER).zip
+      - name: OpenTween.pdb
+        path: OpenTween.pdb
   - # for release build
     matrix:
       only:
@@ -44,6 +46,8 @@ for:
     artifacts:
       - name: OpenTween.zip
         path: $(APPVEYOR_REPO_TAG_NAME).zip
+      - name: OpenTween.pdb
+        path: OpenTween.pdb
 
 build:
   project: OpenTween.sln
@@ -89,5 +93,6 @@ after_test:
         $headCommit = 'HEAD'
       }
       .\tools\build-zip-archive.ps1 -BinDir $binDir -ObjDir $objDir -AssemblyInfo $assemblyInfo -DestPath $destPath -HeadCommit $headCommit
+      Copy-Item ($binDir + 'OpenTween.pdb') -Destination '.\'
 
 # vim: et fenc=utf-8 sts=2 sw=2 ts=2

--- a/tools/build-zip-archive.ps1
+++ b/tools/build-zip-archive.ps1
@@ -82,6 +82,16 @@ Function Get-CommandVersion([String] $Name) {
   Get-Command -Name $Name | Select -Property Name, @{Name='ProductVersion'; Expression={$_.FileVersionInfo.ProductVersion}}
 }
 
+Function Get-RuntimeVersion() {
+  return [PSCustomObject]@{
+    Name = 'RuntimeVersion'
+    Value = [Attribute]::GetCustomAttribute(
+      [Object].Assembly,
+      [System.Reflection.AssemblyInformationalVersionAttribute]
+    ).InformationalVersion
+  }
+}
+
 Build-SateliteAssembly -Culture en
 
 $includePaths = $includeFiles | % { Join-Path $BinDir $_ }
@@ -95,6 +105,7 @@ Write-Host "Build success!"
 @(
   Get-CommandVersion 'msbuild.exe'
   Get-CommandVersion 'csc.exe'
+  Get-RuntimeVersion
   [PSCustomObject]@{
     Name = 'SOURCE_DATE_EPOCH'
     Value = $timestamp

--- a/tools/build-zip-archive.ps1
+++ b/tools/build-zip-archive.ps1
@@ -40,6 +40,7 @@ $ErrorActionPreference = 'Stop'
 $assemblyName = "OpenTween"
 
 $exePath = Join-Path $BinDir "${assemblyName}.exe"
+$pdbPath = Join-Path $BinDir "${assemblyName}.pdb"
 $includeFiles = @(
   "en\",
   "Icons\",
@@ -111,4 +112,5 @@ Write-Host "Build success!"
     Value = $timestamp
   }
   Get-FileHash -Algorithm SHA256 $destPath
+  Get-FileHash -Algorithm SHA256 $pdbPath
 ) | Format-List


### PR DESCRIPTION
.NET Framework 4.8.1 がインストールされた環境でビルドした場合と AppVeyor でのビルド結果で `OpenTween.exe` のハッシュ値が一致しない問題の対応

- 現在の AppVeyor にインストールされているのは .NET Framework 4.8 （4.8.1 ではない）
- ビルド時に使用した .NET Framework ランタイムのバージョン番号は `OpenTween.pdb` に埋め込まれる
    - `xxd ./OpenTween/bin/Debug/OpenTween.pdb` で確認すると `runtime-version` が `4.8.9105.0` と記録されている
        ```
        0002f8e0: 7300 706c 6174 666f 726d 0041 6e79 4370  s.platform.AnyCp
        0002f8f0: 7500 7275 6e74 696d 652d 7665 7273 696f  u.runtime-versio
        0002f900: 6e00 342e 382e 3931 3035 2e30 006c 616e  n.4.8.9105.0.lan
        0002f910: 6775 6167 652d 7665 7273 696f 6e00 3130  guage-version.10
        0002f920: 2e30 0064 6566 696e 6500 5452 4143 452c  .0.define.TRACE,
        ```
    - Portable PDB の仕様
        - https://github.com/dotnet/runtime/blob/v7.0.0/docs/design/specs/PortablePdb-Metadata.md#CompilationOptions
    - Roslyn の実装では `typeof(object).Assembly` からバージョンを取得している
        - https://github.com/dotnet/roslyn/blob/Visual-Studio-2022-Version-17.4/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs#L918-L919
- `OpenTween.pdb` の内容が一致しないと `OpenTween.exe` も一致しなくなる
    - `dumpbin /Headers ./OpenTween/bin/Debug/OpenTween.exe` の出力を見ると pdb ファイルのハッシュ値を含んでいることが分かる
        ```
          Debug Directories

                Time Type        Size      RVA  Pointer
            -------- ------- -------- -------- --------
            81344687 cv            32 002F3984   2F1B84    Format: RSDS, {9CD32AFC-4E3C-4C59-BE5D-9A4B549E2E02}, 1, .\obj\Debug\OpenTween.pdb
            00000000 pdbhash       27 002F39B6   2F1BB6    SHA256: FC 2A D3 9C 3C 4E 59 AC 3E 5D 9A 4B 54 9E 2E 02 87 46 34 81 1D 91 AE E6 F1 5C 40 11 CB F3 68 05
            00000000 repro          0 00000000        0
        ```
- AppVeyor にインストールされている .NET Framework をアップデートできればよかったが、上手く行かなかったため GitHub Action の `windows-2022` イメージ上でビルドして `OpenTween.exe` のハッシュ値が一致することを確認した