### PR TITLE
検索タイムラインで誤って公式RTが除外される不具合を修正

### DIFF
--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -1052,11 +1052,7 @@ namespace OpenTween
                 var response = await request.Send(this.Api.Connection)
                     .ConfigureAwait(false);
 
-                var convertedStatuses = response.Tweets.Select(x => x.ToTwitterStatus());
-                if (!SettingManager.Instance.Common.IsListsIncludeRts)
-                    convertedStatuses = convertedStatuses.Where(x => x.RetweetedStatus == null);
-
-                statuses = convertedStatuses.ToArray();
+                statuses = response.Tweets.Select(x => x.ToTwitterStatus()).ToArray();
                 tab.CursorBottom = response.CursorBottom;
             }
             else


### PR DESCRIPTION
GetListStatus からコピペしてたらうっかり