### PR TITLE
Cookieを使用してAPI v1.1のユーザータイムラインにアクセスする際に必要だった制限を削除

### DIFF
--- a/OpenTween/Twitter.cs
+++ b/OpenTween/Twitter.cs
@@ -666,10 +666,6 @@ namespace OpenTween
 
             var count = GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, more, false);
 
-            // Cookie を使用する場合のみ 99 件を超えて取得するとエラーが返る
-            if (this.Api.AppToken.AuthType == APIAuthType.TwitterComCookie)
-                count = Math.Min(count, 99);
-
             TwitterStatus[] statuses;
             if (this.Api.AppToken.AuthType == APIAuthType.TwitterComCookie)
             {


### PR DESCRIPTION
消し忘れ