### PR TITLE
DeterministicSourcePathsオプションを有効化

### DIFF
--- a/OpenTween/OpenTween.csproj
+++ b/OpenTween/OpenTween.csproj
@@ -9,6 +9,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
     <PathMap>$(MSBuildProjectDirectory)=.</PathMap>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Roslyn 4.8.0 (?) から *.pdb ファイルの SourceLink にローカルのファイルパスと GitHub の URL が埋め込まれるようになり、ビルドの再現性が失われる問題が起きていた。

---

### 問題のある PDB に含まれていた情報

https://github.com/opentween/OpenTween/actions/runs/6983842016 でビルドされた OpenTween.pdb から抜粋。

```
00033130: 0128 0115 010b 0107 8093 7b22 646f 6375  .(........{"docu
00033140: 6d65 6e74 7322 3a7b 2244 3a5c 5c61 5c5c  ments":{"D:\\a\\
00033150: 4f70 656e 5477 6565 6e5c 5c4f 7065 6e54  OpenTween\\OpenT
00033160: 7765 656e 5c5c 2a22 3a22 6874 7470 733a  ween\\*":"https:
00033170: 2f2f 7261 772e 6769 7468 7562 7573 6572  //raw.githubuser
00033180: 636f 6e74 656e 742e 636f 6d2f 6f70 656e  content.com/open
00033190: 7477 6565 6e2f 4f70 656e 5477 6565 6e2f  tween/OpenTween/
000331a0: 3430 3937 6631 3461 6338 6631 6238 6661  4097f14ac8f1b8fa
000331b0: 6432 3561 6365 6133 6461 6466 6464 3636  d25acea3dadfdd66
000331c0: 6133 3037 3835 3165 2f2a 227d 7d81 f776  a307851e/*"}}..v
000331d0: 6572 7369 6f6e 0032 0063 6f6d 7069 6c65  ersion.2.compile
000331e0: 722d 7665 7273 696f 6e00 342e 382e 302d  r-version.4.8.0-
000331f0: 372e 3233 3535 382e 312b 6530 3931 3732  7.23558.1+e09172
00033200: 3836 3037 6361 3066 6339 6566 6361 3535  8607ca0fc9efca55
00033210: 6363 6662 3365 3539 3235 3963 3662 3561  ccfb3e59259c6b5a
00033220: 3061 006c 616e 6775 6167 6500 4323 0073  0a.language.C#.s
```

PDF ファイル内にローカルのファイルパスの `"D:\\a\\OpenTween\\OpenTween\\*"` という文字列が埋め込まれている。これによってビルド結果がローカルのソースコードのパスに依存して変化してしまい、Reproducible build の妨げとなっている。

このビルドに使用した csc.exe のバージョンは `4.8.0-7.23558.1+e091728607ca0fc9efca55ccfb3e59259c6b5a0a` となっている。

### 問題が起こる前の PDB

この問題が起きていない最後に確認できたビルドは https://github.com/opentween/OpenTween/actions/runs/6314744567 であり、この時の OpenTween.pdb には前述のような JSON は埋め込まれていなかった。

このビルドで使用した csc.exe のバージョンは `4.7.0-3.23416.8+43b0b05cc4f492fd5de00f6f6717409091df8daa` となっている。

### PDB に埋め込まれた JSON について

Portable PDB の仕様より、埋め込まれている JSON は SourceLink と呼ばれる情報らしい。
https://github.com/dotnet/runtime/blob/v8.0.0/docs/design/specs/PortablePdb-Metadata.md#source-link-c-and-vb-compilers

SourceLink については以下のドキュメントがあり、Deterministic build についても言及されている。
https://github.com/dotnet/sourcelink/blob/8.0.0/docs/README.md

最終的に、ドキュメントに記載されている DeterministicSourcePaths を有効化することでローカルのファイルパスに依存しない再現性のあるビルド結果を得ることができた。

### 修正後の PDB ファイル

```
00033230: 797b 2264 6f63 756d 656e 7473 223a 7b22  y{"documents":{"
00033240: 2f5f 2f2a 223a 2268 7474 7073 3a2f 2f72  /_/*":"https://r
00033250: 6177 2e67 6974 6875 6275 7365 7263 6f6e  aw.githubusercon
00033260: 7465 6e74 2e63 6f6d 2f6f 7065 6e74 7765  tent.com/opentwe
00033270: 656e 2f4f 7065 6e54 7765 656e 2f62 3036  en/OpenTween/b06
00033280: 6362 3735 3438 3833 3965 6366 3563 6565  cb7548839ecf5cee
00033290: 3966 6439 6530 3235 3631 3830 6632 3338  9fd9e0256180f238
000332a0: 3136 3739 322f 2a22 7d7d 81f7 7665 7273  16792/*"}}..vers
000332b0: 696f 6e00 3200 636f 6d70 696c 6572 2d76  ion.2.compiler-v
```

修正前は `"D:\\a\\OpenTween\\OpenTween\\*"` となっていた箇所が、修正後には `"/_/*"` に置き換わっていることが確認できる。