### PR TITLE
CIでのビルド時に *.pdb の生成を無効化する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         shell: pwsh
         run: |
-          msbuild /target:restore,build "/p:Configuration=$($env:CONFIGURATION)" /verbosity:minimal
+          msbuild /target:restore,build "/p:Configuration=$($env:CONFIGURATION)" /p:DebugType=None /verbosity:minimal
 
       - name: Upload build result
         uses: actions/upload-artifact@v3
@@ -171,7 +171,6 @@ jobs:
           $destPath = 'OpenTween.zip'
           $headCommit = '${{ github.event.pull_request.head.sha }}'
           .\tools\build-zip-archive.ps1 -BinDir $binDir -DestPath $destPath -HeadCommit $headCommit
-          Copy-Item ($binDir + 'OpenTween.pdb') -Destination '.\'
 
       - name: Upload build result
         uses: actions/upload-artifact@v3
@@ -179,4 +178,3 @@ jobs:
           name: package
           path: |
             ./OpenTween.zip
-            ./OpenTween.pdb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,6 @@ for:
     artifacts:
       - name: OpenTween.zip
         path: OpenTween_dev-$(APPVEYOR_BUILD_NUMBER).zip
-      - name: OpenTween.pdb
-        path: OpenTween.pdb
   - # for release build
     matrix:
       only:
@@ -46,8 +44,6 @@ for:
     artifacts:
       - name: OpenTween.zip
         path: $(APPVEYOR_REPO_TAG_NAME).zip
-      - name: OpenTween.pdb
-        path: OpenTween.pdb
 
 build:
   project: OpenTween.sln
@@ -91,6 +87,5 @@ after_test:
         $headCommit = 'HEAD'
       }
       .\tools\build-zip-archive.ps1 -BinDir $binDir -DestPath $destPath -HeadCommit $headCommit
-      Copy-Item ($binDir + 'OpenTween.pdb') -Destination '.\'
 
 # vim: et fenc=utf-8 sts=2 sw=2 ts=2

--- a/msbuild.rsp
+++ b/msbuild.rsp
@@ -1,3 +1,3 @@
 # MSBuild response file for AppVeyor build
 
-/warnaserror
+/warnaserror /p:DebugType=None

--- a/tools/build-zip-archive.ps1
+++ b/tools/build-zip-archive.ps1
@@ -102,5 +102,5 @@ Write-Host "Build success!"
     Value = $timestamp
   }
   Get-FileHash -Algorithm SHA256 $destPath
-  Get-FileHash -Algorithm SHA256 $pdbPath
+  # Get-FileHash -Algorithm SHA256 $pdbPath
 ) | Format-List


### PR DESCRIPTION
## 概要

CI でのビルド時 (GitHub Actions, AppVeyor) に `*.pdb` の生成を無効化する。
リリース時の Reproducible build のチェックもこれに準じるため、バイナリ配布用のビルドも DebugType=None で行われる。

## 背景

.NET アプリケーションで `*.pdb` を含めて Reproducible build を実現させる場合は、ビルドを実行する環境の `runtime-version` を含めて一致させる必要がある。これは Portable PDB の仕様により `runtime-version` の値が `*.pdb` に埋め込まれているためである。

参照: https://github.com/dotnet/runtime/blob/v8.0.0/docs/design/specs/PortablePdb-Metadata.md#compilation-options-c-and-vb-compilers

しかし、.NET Framework の場合は CI 環境（Windows Server 2022）と開発者の PC（Windows 11）で `runtime-version` を完全に一致させることが難しい場合があり、現時点 (2023/11/28) においても GitHub Actions では `4.8.9186.0` である一方で @upsilon の使用する開発環境では `4.8.9181.0` とバージョンに差異がある状態が続いている。

このようなバージョンの差異は今後の Windows Update によって解消する場合もあれば、逆に CI 環境の方が古い場合には Windows Update の履歴から特定のアップデートをアンインストールすることで一致する場合もあるが、いずれにせよ OS のアップデートと紐付く .NET Framework ランタイムの性質上バージョンが一致する環境を準備することは容易とは言えない。
そのため、今後のビルドでは `DebugType=None` でデバッグ情報の生成を行わないことで `runtime-version` が完全に一致しなくとも Reproducible build を実現できるようにする。