### PR TITLE
Twitter関連のクラスの名前空間を移動

### DIFF
--- a/OpenTween.Tests/Api/GraphQL/CreateTweetRequestTest.cs
+++ b/OpenTween.Tests/Api/GraphQL/CreateTweetRequestTest.cs
@@ -22,7 +22,6 @@
 using System.Threading.Tasks;
 using Moq;
 using OpenTween.Connection;
-using OpenTween.Models;
 using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 

--- a/OpenTween.Tests/Api/GraphQL/TimelineTweetTest.cs
+++ b/OpenTween.Tests/Api/GraphQL/TimelineTweetTest.cs
@@ -19,17 +19,14 @@
 // the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 // Boston, MA 02110-1301, USA.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.Serialization.Json;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween.Api.GraphQL

--- a/OpenTween.Tests/Api/TwitterApiTest.cs
+++ b/OpenTween.Tests/Api/TwitterApiTest.cs
@@ -21,18 +21,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using Moq;
 using OpenTween.Api.DataModel;
 using OpenTween.Connection;
-using OpenTween.Models;
 using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 

--- a/OpenTween.Tests/ListManageTest.cs
+++ b/OpenTween.Tests/ListManageTest.cs
@@ -19,12 +19,8 @@
 // the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 // Boston, MA 02110-1301, USA.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using OpenTween.Api;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween
@@ -35,7 +31,7 @@ namespace OpenTween
         public void Initialize_Test()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
             using var dialog = new ListManage(twitter);
         }
     }

--- a/OpenTween.Tests/Models/PostClassTest.cs
+++ b/OpenTween.Tests/Models/PostClassTest.cs
@@ -20,13 +20,8 @@
 // Boston, MA 02110-1301, USA.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
-using Xunit.Extensions;
 
 namespace OpenTween.Models
 {

--- a/OpenTween.Tests/Models/PostFilterRuleTest.cs
+++ b/OpenTween.Tests/Models/PostFilterRuleTest.cs
@@ -20,11 +20,8 @@
 // Boston, MA 02110-1301, USA.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
-using Xunit.Extensions;
 
 namespace OpenTween.Models
 {

--- a/OpenTween.Tests/Models/QueryCursorTest.cs
+++ b/OpenTween.Tests/Models/QueryCursorTest.cs
@@ -20,6 +20,7 @@
 // Boston, MA 02110-1301, USA.
 
 using OpenTween.Api.GraphQL;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween.Models

--- a/OpenTween.Tests/Models/StatusTextHistoryTest.cs
+++ b/OpenTween.Tests/Models/StatusTextHistoryTest.cs
@@ -19,6 +19,7 @@
 // the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 // Boston, MA 02110-1301, USA.
 
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween.Models

--- a/OpenTween.Tests/Models/TabInformationTest.cs
+++ b/OpenTween.Tests/Models/TabInformationTest.cs
@@ -23,11 +23,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Windows.Forms;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
-using Xunit.Extensions;
 
 namespace OpenTween.Models
 {

--- a/OpenTween.Tests/Models/TabModelTest.cs
+++ b/OpenTween.Tests/Models/TabModelTest.cs
@@ -20,13 +20,10 @@
 // Boston, MA 02110-1301, USA.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
-using Xunit.Extensions;
 
 namespace OpenTween.Models
 {

--- a/OpenTween.Tests/MyCommonTest.cs
+++ b/OpenTween.Tests/MyCommonTest.cs
@@ -20,19 +20,14 @@
 // Boston, MA 02110-1301, USA.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Windows.Forms;
 using Moq;
-using OpenTween;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
-using Xunit.Extensions;
 
 namespace OpenTween
 {

--- a/OpenTween.Tests/SocialProtocol/Misskey/MisskeyPostFactoryTest.cs
+++ b/OpenTween.Tests/SocialProtocol/Misskey/MisskeyPostFactoryTest.cs
@@ -20,7 +20,7 @@
 // Boston, MA 02110-1301, USA.
 
 using OpenTween.Api.Misskey;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween.SocialProtocol.Misskey

--- a/OpenTween.Tests/SocialProtocol/Twitter/TwitterLegacyTest.cs
+++ b/OpenTween.Tests/SocialProtocol/Twitter/TwitterLegacyTest.cs
@@ -21,17 +21,14 @@
 
 using System;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using OpenTween.Api;
-using OpenTween.Models;
 using OpenTween.Setting;
 using Xunit;
-using Xunit.Extensions;
 
-namespace OpenTween
+namespace OpenTween.SocialProtocol.Twitter
 {
-    public class TwitterTest
+    public class TwitterLegacyTest
     {
         [Theory]
         [InlineData("https://twitter.com/twitterapi/status/22634515958",
@@ -49,7 +46,7 @@ namespace OpenTween
             new[] { "22634515958" })]
         public void StatusUrlRegexTest(string url, string[] expected)
         {
-            var results = Twitter.StatusUrlRegex.Matches(url).Cast<Match>()
+            var results = TwitterLegacy.StatusUrlRegex.Matches(url).Cast<Match>()
                 .Select(x => x.Groups["StatusId"].Value).ToArray();
 
             Assert.Equal(expected, results);
@@ -70,7 +67,7 @@ namespace OpenTween
         [InlineData("https://mobile.x.com/twitterapi/status/22634515958", true)]
         [InlineData("https://x.com/messages/compose?recipient_id=514241801", false)] // DM は twitter.com のみ通る
         public void AttachmentUrlRegexTest(string url, bool isMatch)
-            => Assert.Equal(isMatch, Twitter.AttachmentUrlRegex.IsMatch(url));
+            => Assert.Equal(isMatch, TwitterLegacy.AttachmentUrlRegex.IsMatch(url));
 
         [Theory]
         [InlineData("http://favstar.fm/users/twitterapi/status/22634515958", new[] { "22634515958" })]
@@ -80,7 +77,7 @@ namespace OpenTween
         [InlineData("http://frtrt.net/solo_status.php?status=263483634307198977", new[] { "263483634307198977" })]
         public void ThirdPartyStatusUrlRegexTest(string url, string[] expected)
         {
-            var results = Twitter.ThirdPartyStatusUrlRegex.Matches(url).Cast<Match>()
+            var results = TwitterLegacy.ThirdPartyStatusUrlRegex.Matches(url).Cast<Match>()
                 .Select(x => x.Groups["StatusId"].Value).ToArray();
 
             Assert.Equal(expected, results);
@@ -113,14 +110,14 @@ namespace OpenTween
             Assert.Equal(20, usertl);
 
             // Timeline,Reply
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, false, false));
-            Assert.Equal(reply, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Reply, false, false));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, false, false));
+            Assert.Equal(reply, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Reply, false, false));
 
             // その他はTimelineと同値になる
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, false));
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, false, false));
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, false));
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, false));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, false));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, false, false));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, false));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, false));
 
             SettingManagerTest.Common = oldInstance;
         }
@@ -143,58 +140,58 @@ namespace OpenTween
             SettingManager.Instance.Common.UseAdditionalCount = true;
 
             // Timeline
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, false, false));
-            Assert.Equal(100, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, true, false)); // 100 件が上限
-            Assert.Equal(startup, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, false, true));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, false, false));
+            Assert.Equal(100, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, true, false)); // 100 件が上限
+            Assert.Equal(startup, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, false, true));
 
             // Reply
-            Assert.Equal(reply, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Reply, false, false));
-            Assert.Equal(more, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Reply, true, false));
-            Assert.Equal(reply, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Reply, false, true));  // Replyの値が使われる
+            Assert.Equal(reply, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Reply, false, false));
+            Assert.Equal(more, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Reply, true, false));
+            Assert.Equal(reply, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Reply, false, true));  // Replyの値が使われる
 
             // Favorites
-            Assert.Equal(favorite, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, false));
-            Assert.Equal(favorite, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, true, false));
-            Assert.Equal(favorite, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, true));
+            Assert.Equal(favorite, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, false));
+            Assert.Equal(favorite, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, true, false));
+            Assert.Equal(favorite, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, true));
 
             SettingManager.Instance.Common.FavoritesCountApi = 0;
 
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, false));
-            Assert.Equal(more, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, true, false));
-            Assert.Equal(startup, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, true));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, false));
+            Assert.Equal(more, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, true, false));
+            Assert.Equal(startup, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, false, true));
 
             // List
-            Assert.Equal(list, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, false, false));
-            Assert.Equal(list, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, true, false));
-            Assert.Equal(list, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, false, true));
+            Assert.Equal(list, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, false, false));
+            Assert.Equal(list, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, true, false));
+            Assert.Equal(list, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, false, true));
 
             SettingManager.Instance.Common.ListCountApi = 0;
 
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, false, false));
-            Assert.Equal(more, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, true, false));
-            Assert.Equal(startup, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, false, true));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, false, false));
+            Assert.Equal(more, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, true, false));
+            Assert.Equal(startup, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, false, true));
 
             // PublicSearch
-            Assert.Equal(search, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, false));
-            Assert.Equal(search, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, true, false));
-            Assert.Equal(search, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, true));
+            Assert.Equal(search, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, false));
+            Assert.Equal(search, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, true, false));
+            Assert.Equal(search, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, true));
 
             SettingManager.Instance.Common.SearchCountApi = 0;
 
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, false));
-            Assert.Equal(search, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, true, false));  // MoreCountApiの値がPublicSearchの最大値に制限される
-            Assert.Equal(startup, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, true));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, false));
+            Assert.Equal(search, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, true, false));  // MoreCountApiの値がPublicSearchの最大値に制限される
+            Assert.Equal(startup, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, false, true));
 
             // UserTimeline
-            Assert.Equal(usertl, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, false));
-            Assert.Equal(usertl, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, true, false));
-            Assert.Equal(usertl, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, true));
+            Assert.Equal(usertl, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, false));
+            Assert.Equal(usertl, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, true, false));
+            Assert.Equal(usertl, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, true));
 
             SettingManager.Instance.Common.UserTimelineCountApi = 0;
 
-            Assert.Equal(timeline, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, false));
-            Assert.Equal(more, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, true, false));
-            Assert.Equal(startup, Twitter.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, true));
+            Assert.Equal(timeline, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, false));
+            Assert.Equal(more, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, true, false));
+            Assert.Equal(startup, TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.UserTimeline, false, true));
 
             SettingManagerTest.Common = oldInstance;
         }
@@ -203,7 +200,7 @@ namespace OpenTween
         public void GetTextLengthRemain_Test()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             Assert.Equal(280, twitter.GetTextLengthRemain(""));
             Assert.Equal(272, twitter.GetTextLengthRemain("hogehoge"));
@@ -213,7 +210,7 @@ namespace OpenTween
         public void GetTextLengthRemain_DirectMessageTest()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             // 2015年8月から DM の文字数上限が 10,000 文字に変更された
             // https://twittercommunity.com/t/41348
@@ -234,7 +231,7 @@ namespace OpenTween
         public void GetTextLengthRemain_UrlTest()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             // t.co に短縮される分の文字数を考慮
             twitter.TextConfiguration.TransformedURLLength = 20;
@@ -251,7 +248,7 @@ namespace OpenTween
         public void GetTextLengthRemain_UrlWithoutSchemeTest()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             // t.co に短縮される分の文字数を考慮
             twitter.TextConfiguration.TransformedURLLength = 20;
@@ -269,7 +266,7 @@ namespace OpenTween
         public void GetTextLengthRemain_SurrogatePairTest()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             Assert.Equal(278, twitter.GetTextLengthRemain("🍣"));
             Assert.Equal(267, twitter.GetTextLengthRemain("🔥🐔🔥 焼き鳥"));
@@ -279,7 +276,7 @@ namespace OpenTween
         public void GetTextLengthRemain_EmojiTest()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             // 絵文字の文字数カウントの仕様変更に対するテストケース
             // https://twittercommunity.com/t/114607
@@ -299,7 +296,7 @@ namespace OpenTween
         public void GetTextLengthRemain_BrokenSurrogateTest()
         {
             using var twitterApi = new TwitterApi();
-            using var twitter = new Twitter(twitterApi);
+            using var twitter = new TwitterLegacy(twitterApi);
 
             // 投稿欄に IME から絵文字を入力すると HighSurrogate のみ入力された状態で TextChanged イベントが呼ばれることがある
             Assert.Equal(278, twitter.GetTextLengthRemain("\ud83d"));
@@ -313,11 +310,11 @@ namespace OpenTween
         [InlineData("https://pbs.twimg.com/profile_images/00000/foo_normal.jpg", "original", "https://pbs.twimg.com/profile_images/00000/foo.jpg")]
         [InlineData("https://pbs.twimg.com/profile_images/00000/foo_normal_bar_normal.jpg", "original", "https://pbs.twimg.com/profile_images/00000/foo_normal_bar.jpg")]
         public void CreateProfileImageUrl_Test(string normalUrl, string size, string expected)
-            => Assert.Equal(expected, Twitter.CreateProfileImageUrl(normalUrl, size));
+            => Assert.Equal(expected, TwitterLegacy.CreateProfileImageUrl(normalUrl, size));
 
         [Fact]
         public void CreateProfileImageUrl_InvalidSizeTest()
-            => Assert.Throws<ArgumentException>(() => Twitter.CreateProfileImageUrl("https://pbs.twimg.com/profile_images/00000/foo_normal.jpg", "INVALID"));
+            => Assert.Throws<ArgumentException>(() => TwitterLegacy.CreateProfileImageUrl("https://pbs.twimg.com/profile_images/00000/foo_normal.jpg", "INVALID"));
 
         [Theory]
         [InlineData(24, "mini")]
@@ -327,6 +324,6 @@ namespace OpenTween
         [InlineData(73, "bigger")]
         [InlineData(74, "original")]
         public void DecideProfileImageSize_Test(int sizePx, string expected)
-            => Assert.Equal(expected, Twitter.DecideProfileImageSize(sizePx));
+            => Assert.Equal(expected, TwitterLegacy.DecideProfileImageSize(sizePx));
     }
 }

--- a/OpenTween.Tests/SocialProtocol/Twitter/TwitterPostFactoryTest.cs
+++ b/OpenTween.Tests/SocialProtocol/Twitter/TwitterPostFactoryTest.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using OpenTween.Api.DataModel;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween.Models

--- a/OpenTween.Tests/TimelineListViewCacheTest.cs
+++ b/OpenTween.Tests/TimelineListViewCacheTest.cs
@@ -22,6 +22,7 @@
 using System;
 using OpenTween.Models;
 using OpenTween.OpenTweenCustomControl;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween

--- a/OpenTween.Tests/TimelineListViewStateTest.cs
+++ b/OpenTween.Tests/TimelineListViewStateTest.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Windows.Forms;
 using OpenTween.Models;
 using OpenTween.OpenTweenCustomControl;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween

--- a/OpenTween.Tests/TweenMainTest.cs
+++ b/OpenTween.Tests/TweenMainTest.cs
@@ -20,9 +20,7 @@
 // Boston, MA 02110-1301, USA.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -33,9 +31,9 @@ using OpenTween.Models;
 using OpenTween.OpenTweenCustomControl;
 using OpenTween.Setting;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 using OpenTween.Thumbnail;
 using Xunit;
-using Xunit.Extensions;
 
 namespace OpenTween
 {

--- a/OpenTween.Tests/TweetDetailsViewTest.cs
+++ b/OpenTween.Tests/TweetDetailsViewTest.cs
@@ -19,13 +19,9 @@
 // the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 // Boston, MA 02110-1301, USA.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 using Xunit;
 
 namespace OpenTween

--- a/OpenTween.Tests/TweetThumbnailTest.cs
+++ b/OpenTween.Tests/TweetThumbnailTest.cs
@@ -20,14 +20,12 @@
 // Boston, MA 02110-1301, USA.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 using OpenTween.Thumbnail;
 using OpenTween.Thumbnail.Services;
 using Xunit;

--- a/OpenTween/Api/DataModel/TwitterPageable.cs
+++ b/OpenTween/Api/DataModel/TwitterPageable.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.DataModel
 {

--- a/OpenTween/Api/GraphQL/CreateRetweetRequest.cs
+++ b/OpenTween/Api/GraphQL/CreateRetweetRequest.cs
@@ -25,7 +25,7 @@ using System;
 using System.Threading.Tasks;
 using System.Xml.XPath;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/CreateTweetRequest.cs
+++ b/OpenTween/Api/GraphQL/CreateTweetRequest.cs
@@ -29,7 +29,6 @@ using System.Threading.Tasks;
 using System.Xml.XPath;
 using OpenTween.Api.DataModel;
 using OpenTween.Connection;
-using OpenTween.Models;
 using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL

--- a/OpenTween/Api/GraphQL/DeleteRetweetRequest.cs
+++ b/OpenTween/Api/GraphQL/DeleteRetweetRequest.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/DeleteTweetRequest.cs
+++ b/OpenTween/Api/GraphQL/DeleteTweetRequest.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/FavoriteTweetRequest.cs
+++ b/OpenTween/Api/GraphQL/FavoriteTweetRequest.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/LikesRequest.cs
+++ b/OpenTween/Api/GraphQL/LikesRequest.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/TweetDetailRequest.cs
+++ b/OpenTween/Api/GraphQL/TweetDetailRequest.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/UnfavoriteTweetRequest.cs
+++ b/OpenTween/Api/GraphQL/UnfavoriteTweetRequest.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/GraphQL/UserTweetsAndRepliesRequest.cs
+++ b/OpenTween/Api/GraphQL/UserTweetsAndRepliesRequest.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.GraphQL
 {

--- a/OpenTween/Api/TwitterApi.cs
+++ b/OpenTween/Api/TwitterApi.cs
@@ -31,7 +31,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTween.Api.DataModel;
 using OpenTween.Connection;
-using OpenTween.Models;
 using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api

--- a/OpenTween/Api/TwitterV2/GetTimelineRequest.cs
+++ b/OpenTween/Api/TwitterV2/GetTimelineRequest.cs
@@ -28,7 +28,7 @@ using System.Text;
 using System.Threading.Tasks;
 using OpenTween.Api.DataModel;
 using OpenTween.Connection;
-using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Api.TwitterV2
 {

--- a/OpenTween/ImageCache.cs
+++ b/OpenTween/ImageCache.cs
@@ -32,6 +32,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using OpenTween.Connection;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {
@@ -145,7 +146,7 @@ namespace OpenTween
 
             foreach (var candidateSize in sizes.Skip(minimumIndex))
             {
-                var imageUrl = Twitter.CreateProfileImageUrl(normalUrl, candidateSize);
+                var imageUrl = TwitterLegacy.CreateProfileImageUrl(normalUrl, candidateSize);
                 var image = this.TryGetFromCache(imageUrl);
                 if (image != null)
                     return image;

--- a/OpenTween/ListElement.cs
+++ b/OpenTween/ListElement.cs
@@ -48,7 +48,7 @@ namespace OpenTween
         public string Username = "";
         public string Nickname = "";
 
-        protected Twitter tw = null!;
+        protected TwitterLegacy tw = null!;
 
         private List<UserInfo> members = new();
 
@@ -59,7 +59,7 @@ namespace OpenTween
         {
         }
 
-        public ListElement(TwitterList listElementData, Twitter tw)
+        public ListElement(TwitterList listElementData, TwitterLegacy tw)
         {
             this.Description = listElementData.Description;
             this.Id = listElementData.Id;

--- a/OpenTween/ListElement.cs
+++ b/OpenTween/ListElement.cs
@@ -31,6 +31,7 @@ using System.Threading.Tasks;
 using System.Xml.Serialization;
 using OpenTween.Api.DataModel;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {

--- a/OpenTween/ListManage.cs
+++ b/OpenTween/ListManage.cs
@@ -37,14 +37,15 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using OpenTween.Connection;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {
     public partial class ListManage : OTBaseForm
     {
-        private readonly Twitter tw;
+        private readonly TwitterLegacy tw;
 
-        public ListManage(Twitter tw)
+        public ListManage(TwitterLegacy tw)
         {
             this.InitializeComponent();
 
@@ -349,8 +350,8 @@ namespace OpenTween
 
             await this.UserIcon.SetImageFromTask(async () =>
             {
-                var sizeName = Twitter.DecideProfileImageSize(this.UserIcon.Width);
-                var uri = Twitter.CreateProfileImageUrl(imageUri.AbsoluteUri, sizeName);
+                var sizeName = TwitterLegacy.DecideProfileImageSize(this.UserIcon.Width);
+                var uri = TwitterLegacy.CreateProfileImageUrl(imageUri.AbsoluteUri, sizeName);
 
                 using var imageStream = await Networking.Http.GetStreamAsync(uri);
                 var image = await MemoryImage.CopyFromStreamAsync(imageStream);
@@ -421,7 +422,7 @@ namespace OpenTween
         {
             public bool IsCreated { get; private set; } = false;
 
-            public NewListElement(Twitter tw)
+            public NewListElement(TwitterLegacy tw)
                 => this.tw = tw;
 
             public override async Task Refresh()

--- a/OpenTween/MediaUploadServices/Mobypicture.cs
+++ b/OpenTween/MediaUploadServices/Mobypicture.cs
@@ -28,6 +28,7 @@ using System.Text;
 using System.Threading.Tasks;
 using OpenTween.Api;
 using OpenTween.Api.DataModel;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.MediaUploadServices
 {
@@ -72,7 +73,7 @@ namespace OpenTween.MediaUploadServices
 
         private TwitterConfiguration twitterConfig;
 
-        public Mobypicture(Twitter twitter, TwitterConfiguration twitterConfig)
+        public Mobypicture(TwitterLegacy twitter, TwitterConfiguration twitterConfig)
             : this(new MobypictureApi(twitter.Api), twitterConfig)
         {
         }

--- a/OpenTween/MediaUploadServices/TwitterPhoto.cs
+++ b/OpenTween/MediaUploadServices/TwitterPhoto.cs
@@ -44,10 +44,10 @@ namespace OpenTween.MediaUploadServices
     {
         private readonly string[] pictureExt = { ".jpg", ".jpeg", ".gif", ".png" };
 
-        private readonly Twitter tw;
+        private readonly TwitterLegacy tw;
         private TwitterConfiguration twitterConfig;
 
-        public TwitterPhoto(Twitter twitter, TwitterConfiguration twitterConfig)
+        public TwitterPhoto(TwitterLegacy twitter, TwitterConfiguration twitterConfig)
         {
             this.tw = twitter;
             this.twitterConfig = twitterConfig;
@@ -92,7 +92,7 @@ namespace OpenTween.MediaUploadServices
 
             TwitterMediaId[] mediaIds;
 
-            if (Twitter.DMSendTextRegex.IsMatch(postParams.Text))
+            if (TwitterLegacy.DMSendTextRegex.IsMatch(postParams.Text))
                 mediaIds = new[] { await this.UploadMediaForDM(mediaItems).ConfigureAwait(false) };
             else
                 mediaIds = await this.UploadMediaForTweet(mediaItems).ConfigureAwait(false);

--- a/OpenTween/Models/FavoritesTabModel.cs
+++ b/OpenTween/Models/FavoritesTabModel.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Models
 {
@@ -53,7 +54,7 @@ namespace OpenTween.Models
             progress.Report(Properties.Resources.GetTimelineWorker_RunWorkerCompletedText19);
 
             var firstLoad = !this.IsFirstLoadCompleted;
-            var count = Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, backward, firstLoad);
+            var count = TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Favorites, backward, firstLoad);
             var cursor = backward ? this.CursorBottom : this.CursorTop;
 
             var response = await account.Client.GetFavoritesTimeline(count, cursor, firstLoad)

--- a/OpenTween/Models/HomeSpecifiedAccountTabModel.cs
+++ b/OpenTween/Models/HomeSpecifiedAccountTabModel.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Models
 {
@@ -48,7 +49,7 @@ namespace OpenTween.Models
             progress.Report("Home refreshing...");
 
             var firstLoad = !this.IsFirstLoadCompleted;
-            var count = Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, backward, firstLoad);
+            var count = TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, backward, firstLoad);
             var cursor = backward ? this.CursorBottom : this.CursorTop;
 
             var response = await account.Client.GetHomeTimeline(count, cursor, firstLoad)

--- a/OpenTween/Models/HomeTabModel.cs
+++ b/OpenTween/Models/HomeTabModel.cs
@@ -72,7 +72,7 @@ namespace OpenTween.Models
             progress.Report(string.Format(Properties.Resources.GetTimelineWorker_RunWorkerCompletedText5, backward ? -1 : 1));
 
             var firstLoad = !this.IsFirstLoadCompleted;
-            var count = Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, backward, firstLoad);
+            var count = TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Timeline, backward, firstLoad);
             var cursor = backward ? this.CursorBottom : this.CursorTop;
 
             var response = await account.Client.GetHomeTimeline(count, cursor, firstLoad)

--- a/OpenTween/Models/ListTimelineTabModel.cs
+++ b/OpenTween/Models/ListTimelineTabModel.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Models
 {
@@ -59,7 +60,7 @@ namespace OpenTween.Models
             progress.Report("List refreshing...");
 
             var firstLoad = !this.IsFirstLoadCompleted;
-            var count = Twitter.GetApiResultCount(MyCommon.WORKERTYPE.List, backward, firstLoad);
+            var count = TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.List, backward, firstLoad);
             var cursor = backward ? this.CursorBottom : this.CursorTop;
 
             var response = await account.Client.GetListTimeline(this.ListInfo.Id, count, cursor, firstLoad)

--- a/OpenTween/Models/MentionsTabModel.cs
+++ b/OpenTween/Models/MentionsTabModel.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Models
 {
@@ -53,7 +54,7 @@ namespace OpenTween.Models
             progress.Report(string.Format(Properties.Resources.GetTimelineWorker_RunWorkerCompletedText4, backward ? -1 : 1));
 
             var firstLoad = !this.IsFirstLoadCompleted;
-            var count = Twitter.GetApiResultCount(MyCommon.WORKERTYPE.Reply, backward, firstLoad);
+            var count = TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.Reply, backward, firstLoad);
             var cursor = backward ? this.CursorBottom : this.CursorTop;
 
             var response = await account.Client.GetMentionsTimeline(count, cursor, firstLoad)

--- a/OpenTween/Models/PublicSearchTabModel.cs
+++ b/OpenTween/Models/PublicSearchTabModel.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Threading.Tasks;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Models
 {
@@ -74,7 +75,7 @@ namespace OpenTween.Models
             progress.Report("Search refreshing...");
 
             var firstLoad = !this.IsFirstLoadCompleted;
-            var count = Twitter.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, backward, firstLoad);
+            var count = TwitterLegacy.GetApiResultCount(MyCommon.WORKERTYPE.PublicSearch, backward, firstLoad);
             var cursor = backward ? this.CursorBottom : this.CursorTop;
 
             var response = await account.Client.GetSearchTimeline(this.SearchWords, this.SearchLang, count, cursor, firstLoad)

--- a/OpenTween/Models/TabInformations.cs
+++ b/OpenTween/Models/TabInformations.cs
@@ -37,6 +37,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using OpenTween.Setting;
 using OpenTween.SocialProtocol;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Models
 {

--- a/OpenTween/MyCommon.cs
+++ b/OpenTween/MyCommon.cs
@@ -51,7 +51,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using System.Windows.Forms;
-using OpenTween.Models;
 using OpenTween.Setting;
 using OpenTween.SocialProtocol.Twitter;
 

--- a/OpenTween/MyLists.cs
+++ b/OpenTween/MyLists.cs
@@ -38,12 +38,13 @@ using System.Windows.Forms;
 using OpenTween.Api;
 using OpenTween.Api.DataModel;
 using OpenTween.Connection;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {
     public partial class MyLists : OTBaseForm
     {
-        private readonly Twitter twitter = null!;
+        private readonly TwitterLegacy twitter = null!;
         private readonly string contextScreenName = null!;
 
         /// <summary>自分が所有しているリスト</summary>
@@ -55,7 +56,7 @@ namespace OpenTween
         public MyLists()
             => this.InitializeComponent();
 
-        public MyLists(string screenName, Twitter twitter)
+        public MyLists(string screenName, TwitterLegacy twitter)
         {
             this.InitializeComponent();
 

--- a/OpenTween/SendErrorReportForm.cs
+++ b/OpenTween/SendErrorReportForm.cs
@@ -35,6 +35,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using OpenTween.Api.DataModel;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {
@@ -133,7 +134,7 @@ namespace OpenTween
 
         private string encodedReportForDM = "";
 
-        private readonly Twitter? tw;
+        private readonly TwitterLegacy? tw;
         private readonly string originalReportText;
 
         public ErrorReport(string reportText)
@@ -141,7 +142,7 @@ namespace OpenTween
         {
         }
 
-        public ErrorReport(Twitter? tw, string reportText)
+        public ErrorReport(TwitterLegacy? tw, string reportText)
         {
             this.tw = tw;
             this.originalReportText = reportText;

--- a/OpenTween/Setting/Panel/GetCountPanel.cs
+++ b/OpenTween/Setting/Panel/GetCountPanel.cs
@@ -34,6 +34,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.Setting.Panel
 {
@@ -95,7 +96,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (!Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.Timeline, cnt))
+            if (!TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.Timeline, cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;
@@ -117,7 +118,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (!Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.Reply, cnt))
+            if (!TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.Reply, cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;
@@ -139,7 +140,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (cnt != 0 && !Twitter.VerifyMoreApiResultCount(cnt))
+            if (cnt != 0 && !TwitterLegacy.VerifyMoreApiResultCount(cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;
@@ -177,7 +178,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (cnt != 0 && !Twitter.VerifyFirstApiResultCount(cnt))
+            if (cnt != 0 && !TwitterLegacy.VerifyFirstApiResultCount(cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;
@@ -199,7 +200,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (cnt != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.PublicSearch, cnt))
+            if (cnt != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.PublicSearch, cnt))
             {
                 MessageBox.Show(Properties.Resources.TextSearchCountApi_Validating1);
                 e.Cancel = true;
@@ -221,7 +222,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (cnt != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.Favorites, cnt))
+            if (cnt != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.Favorites, cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;
@@ -243,7 +244,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (cnt != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.UserTimeline, cnt))
+            if (cnt != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.UserTimeline, cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;
@@ -265,7 +266,7 @@ namespace OpenTween.Setting.Panel
                 return;
             }
 
-            if (cnt != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.List, cnt))
+            if (cnt != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.List, cnt))
             {
                 MessageBox.Show(Properties.Resources.TextCountApi_Validating1);
                 e.Cancel = true;

--- a/OpenTween/Setting/SettingCommon.cs
+++ b/OpenTween/Setting/SettingCommon.cs
@@ -32,6 +32,7 @@ using System.ComponentModel;
 using System.Windows.Forms;
 using System.Xml.Serialization;
 using OpenTween.Connection;
+using OpenTween.SocialProtocol.Twitter;
 using OpenTween.Thumbnail;
 
 namespace OpenTween
@@ -298,28 +299,28 @@ namespace OpenTween
             if (this.ListsPeriod < 0)
                 this.ListsPeriod = 15;
 
-            if (!Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.Timeline, this.CountApi))
+            if (!TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.Timeline, this.CountApi))
                 this.CountApi = 60;
 
-            if (!Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.Reply, this.CountApiReply))
+            if (!TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.Reply, this.CountApiReply))
                 this.CountApiReply = 40;
 
-            if (this.MoreCountApi != 0 && !Twitter.VerifyMoreApiResultCount(this.MoreCountApi))
+            if (this.MoreCountApi != 0 && !TwitterLegacy.VerifyMoreApiResultCount(this.MoreCountApi))
                 this.MoreCountApi = 200;
 
-            if (this.FirstCountApi != 0 && !Twitter.VerifyFirstApiResultCount(this.FirstCountApi))
+            if (this.FirstCountApi != 0 && !TwitterLegacy.VerifyFirstApiResultCount(this.FirstCountApi))
                 this.FirstCountApi = 100;
 
-            if (this.FavoritesCountApi != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.Favorites, this.FavoritesCountApi))
+            if (this.FavoritesCountApi != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.Favorites, this.FavoritesCountApi))
                 this.FavoritesCountApi = 40;
 
-            if (this.ListCountApi != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.List, this.ListCountApi))
+            if (this.ListCountApi != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.List, this.ListCountApi))
                 this.ListCountApi = 100;
 
-            if (this.SearchCountApi != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.PublicSearch, this.SearchCountApi))
+            if (this.SearchCountApi != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.PublicSearch, this.SearchCountApi))
                 this.SearchCountApi = 100;
 
-            if (this.UserTimelineCountApi != 0 && !Twitter.VerifyApiResultCount(MyCommon.WORKERTYPE.UserTimeline, this.UserTimelineCountApi))
+            if (this.UserTimelineCountApi != 0 && !TwitterLegacy.VerifyApiResultCount(MyCommon.WORKERTYPE.UserTimeline, this.UserTimelineCountApi))
                 this.UserTimelineCountApi = 20;
 
             // 廃止サービスが選択されていた場合ux.nuへ読み替え

--- a/OpenTween/SocialProtocol/InvalidAccount.cs
+++ b/OpenTween/SocialProtocol/InvalidAccount.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using OpenTween.Api;
 using OpenTween.Connection;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween.SocialProtocol
 {

--- a/OpenTween/SocialProtocol/Misskey/MisskeyPostFactory.cs
+++ b/OpenTween/SocialProtocol/Misskey/MisskeyPostFactory.cs
@@ -28,6 +28,7 @@ using OpenTween.Api.DataModel;
 using OpenTween.Api.Misskey;
 using OpenTween.Models;
 using OpenTween.Setting;
+using OpenTween.SocialProtocol.Twitter;
 using OpenTween.Thumbnail;
 
 namespace OpenTween.SocialProtocol.Misskey

--- a/OpenTween/SocialProtocol/Misskey/MisskeyPostFactory.cs
+++ b/OpenTween/SocialProtocol/Misskey/MisskeyPostFactory.cs
@@ -144,7 +144,7 @@ namespace OpenTween.SocialProtocol.Misskey
         {
             foreach (var url in urls)
             {
-                var match = OpenTween.Twitter.StatusUrlRegex.Match(url.ExpandedUrl);
+                var match = TwitterLegacy.StatusUrlRegex.Match(url.ExpandedUrl);
                 if (match.Success)
                     yield return new TwitterStatusId(match.Groups["StatusId"].Value);
             }

--- a/OpenTween/SocialProtocol/Twitter/CreateTweetFormatter.cs
+++ b/OpenTween/SocialProtocol/Twitter/CreateTweetFormatter.cs
@@ -134,7 +134,7 @@ namespace OpenTween.SocialProtocol.Twitter
                 return createParams;
 
             var tweetText = createParams.Text;
-            var match = OpenTween.Twitter.AttachmentUrlRegex.Match(tweetText);
+            var match = TwitterLegacy.AttachmentUrlRegex.Match(tweetText);
             if (!match.Success)
                 return createParams;
 

--- a/OpenTween/SocialProtocol/Twitter/RelatedTweetsFetcher.cs
+++ b/OpenTween/SocialProtocol/Twitter/RelatedTweetsFetcher.cs
@@ -110,8 +110,8 @@ namespace OpenTween.SocialProtocol.Twitter
 
             // MRTとかに対応のためツイート内にあるツイートを指すURLを取り込む
             var text = targetPost.Text;
-            var ma = OpenTween.Twitter.StatusUrlRegex.Matches(text).Cast<Match>()
-                .Concat(OpenTween.Twitter.ThirdPartyStatusUrlRegex.Matches(text).Cast<Match>());
+            var ma = TwitterLegacy.StatusUrlRegex.Matches(text).Cast<Match>()
+                .Concat(TwitterLegacy.ThirdPartyStatusUrlRegex.Matches(text).Cast<Match>());
             foreach (var match in ma)
             {
                 var statusId = new TwitterStatusId(match.Groups["StatusId"].Value);

--- a/OpenTween/SocialProtocol/Twitter/TwitterAccount.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterAccount.cs
@@ -29,7 +29,7 @@ namespace OpenTween.SocialProtocol.Twitter
 {
     public class TwitterAccount : ISocialAccount
     {
-        private readonly OpenTween.Twitter twLegacy = new(new());
+        private readonly TwitterLegacy twLegacy = new(new());
         private TwitterApiConnection apiConnection = new();
 
         public string AccountType
@@ -46,7 +46,7 @@ namespace OpenTween.SocialProtocol.Twitter
         ISocialAccountState ISocialAccount.AccountState
             => this.AccountState;
 
-        public OpenTween.Twitter Legacy
+        public TwitterLegacy Legacy
             => this.twLegacy;
 
         public PersonId UserId

--- a/OpenTween/SocialProtocol/Twitter/TwitterDirectMessageId.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterDirectMessageId.cs
@@ -1,5 +1,5 @@
 ﻿// OpenTween - Client of Twitter
-// Copyright (c) 2024 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// Copyright (c) 2023 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
 // All rights reserved.
 //
 // This file is part of OpenTween.
@@ -22,16 +22,17 @@
 #nullable enable
 
 using System;
+using OpenTween.Models;
 
-namespace OpenTween.Models
+namespace OpenTween.SocialProtocol.Twitter
 {
-    public class TwitterUserId : PersonId
+    public class TwitterDirectMessageId : PostId
     {
-        public override string IdType => "twitter_user";
+        public override string IdType => "twitter_dm";
 
         public override string Id { get; }
 
-        public TwitterUserId(string id)
+        public TwitterDirectMessageId(string id)
             => this.Id = id ?? throw new ArgumentNullException(nameof(id));
     }
 }

--- a/OpenTween/SocialProtocol/Twitter/TwitterLegacy.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterLegacy.cs
@@ -29,31 +29,19 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using OpenTween.Api;
 using OpenTween.Api.DataModel;
 using OpenTween.Api.GraphQL;
-using OpenTween.Api.TwitterV2;
 using OpenTween.Connection;
 using OpenTween.Models;
 using OpenTween.Setting;
-using OpenTween.SocialProtocol.Twitter;
 
-namespace OpenTween
+namespace OpenTween.SocialProtocol.Twitter
 {
-    public class Twitter : IDisposable
+    public class TwitterLegacy : IDisposable
     {
         #region Regexp from twitter-text-js
 
@@ -181,7 +169,7 @@ namespace OpenTween
 
         private string? previousStatusId = null;
 
-        public Twitter(TwitterApi api)
+        public TwitterLegacy(TwitterApi api)
         {
             this.postFactory = new(TabInformations.GetInstance(), SettingManager.Instance.Common);
             this.urlExpander = new(ShortUrl.Instance);
@@ -210,7 +198,7 @@ namespace OpenTween
         {
             this.CheckAccountState();
 
-            if (Twitter.DMSendTextRegex.IsMatch(param.Text))
+            if (DMSendTextRegex.IsMatch(param.Text))
             {
                 var mediaId = param.MediaIds?.FirstOrDefault();
 
@@ -317,7 +305,7 @@ namespace OpenTween
                     .ConfigureAwait(false);
             }
 
-            succeeded:
+        succeeded:
             return mediaId;
         }
 
@@ -325,7 +313,7 @@ namespace OpenTween
         {
             this.CheckAccountState();
 
-            var mc = Twitter.DMSendTextRegex.Match(postStr);
+            var mc = DMSendTextRegex.Match(postStr);
 
             var body = mc.Groups["body"].Value;
             var recipientName = mc.Groups["id"].Value;
@@ -824,7 +812,7 @@ namespace OpenTween
 
         public int GetTextLengthRemain(string postText)
         {
-            var matchDm = Twitter.DMSendTextRegex.Match(postText);
+            var matchDm = DMSendTextRegex.Match(postText);
             if (matchDm.Success)
                 return this.GetTextLengthRemainDM(matchDm.Groups["body"].Value);
 

--- a/OpenTween/SocialProtocol/Twitter/TwitterPostFactory.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterPostFactory.cs
@@ -401,7 +401,7 @@ namespace OpenTween.SocialProtocol.Twitter
                 {
                     if (quotedStatus != null)
                     {
-                        var matchStatusUrl = OpenTween.Twitter.StatusUrlRegex.Match(entity.ExpandedUrl);
+                        var matchStatusUrl = TwitterLegacy.StatusUrlRegex.Match(entity.ExpandedUrl);
                         if (matchStatusUrl.Success && matchStatusUrl.Groups["StatusId"].Value == quotedStatus.IdStr)
                         {
                             var quotedText = CreateAccessibleText(quotedStatus.FullText, quotedStatus.MergedEntities, quotedStatus: null, quotedStatusLink: null);
@@ -552,7 +552,7 @@ namespace OpenTween.SocialProtocol.Twitter
         {
             foreach (var url in urls)
             {
-                var match = OpenTween.Twitter.StatusUrlRegex.Match(url);
+                var match = TwitterLegacy.StatusUrlRegex.Match(url);
                 if (match.Success)
                     yield return new(match.Groups["StatusId"].Value);
             }

--- a/OpenTween/SocialProtocol/Twitter/TwitterPostFactory.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterPostFactory.cs
@@ -23,14 +23,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using OpenTween.Api.DataModel;
-using OpenTween.Setting;
+using OpenTween.Models;
 
-namespace OpenTween.Models
+namespace OpenTween.SocialProtocol.Twitter
 {
     public class TwitterPostFactory
     {
@@ -402,7 +401,7 @@ namespace OpenTween.Models
                 {
                     if (quotedStatus != null)
                     {
-                        var matchStatusUrl = Twitter.StatusUrlRegex.Match(entity.ExpandedUrl);
+                        var matchStatusUrl = OpenTween.Twitter.StatusUrlRegex.Match(entity.ExpandedUrl);
                         if (matchStatusUrl.Success && matchStatusUrl.Groups["StatusId"].Value == quotedStatus.IdStr)
                         {
                             var quotedText = CreateAccessibleText(quotedStatus.FullText, quotedStatus.MergedEntities, quotedStatus: null, quotedStatusLink: null);
@@ -553,7 +552,7 @@ namespace OpenTween.Models
         {
             foreach (var url in urls)
             {
-                var match = Twitter.StatusUrlRegex.Match(url);
+                var match = OpenTween.Twitter.StatusUrlRegex.Match(url);
                 if (match.Success)
                     yield return new(match.Groups["StatusId"].Value);
             }

--- a/OpenTween/SocialProtocol/Twitter/TwitterStatusId.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterStatusId.cs
@@ -22,16 +22,26 @@
 #nullable enable
 
 using System;
+using OpenTween.Models;
 
-namespace OpenTween.Models
+namespace OpenTween.SocialProtocol.Twitter
 {
-    public class TwitterDirectMessageId : PostId
+    public class TwitterStatusId : PostId
     {
-        public override string IdType => "twitter_dm";
+        public override string IdType => "twitter_status";
 
         public override string Id { get; }
 
-        public TwitterDirectMessageId(string id)
+        public TwitterStatusId(string id)
             => this.Id = id ?? throw new ArgumentNullException(nameof(id));
+
+        public TwitterStatusId(long id)
+            => this.Id = id.ToString();
+    }
+
+    public static class TwitterStatusIdExtension
+    {
+        public static TwitterStatusId ToTwitterStatusId(this PostId postId)
+            => postId is TwitterStatusId statusId ? statusId : throw new InvalidOperationException("Cannot convert to twitter status_id.");
     }
 }

--- a/OpenTween/SocialProtocol/Twitter/TwitterUserId.cs
+++ b/OpenTween/SocialProtocol/Twitter/TwitterUserId.cs
@@ -1,5 +1,5 @@
 ﻿// OpenTween - Client of Twitter
-// Copyright (c) 2023 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
+// Copyright (c) 2024 kim_upsilon (@kim_upsilon) <https://upsilo.net/~upsilon/>
 // All rights reserved.
 //
 // This file is part of OpenTween.
@@ -22,25 +22,17 @@
 #nullable enable
 
 using System;
+using OpenTween.Models;
 
-namespace OpenTween.Models
+namespace OpenTween.SocialProtocol.Twitter
 {
-    public class TwitterStatusId : PostId
+    public class TwitterUserId : PersonId
     {
-        public override string IdType => "twitter_status";
+        public override string IdType => "twitter_user";
 
         public override string Id { get; }
 
-        public TwitterStatusId(string id)
+        public TwitterUserId(string id)
             => this.Id = id ?? throw new ArgumentNullException(nameof(id));
-
-        public TwitterStatusId(long id)
-            => this.Id = id.ToString();
-    }
-
-    public static class TwitterStatusIdExtension
-    {
-        public static TwitterStatusId ToTwitterStatusId(this PostId postId)
-            => postId is TwitterStatusId statusId ? statusId : throw new InvalidOperationException("Cannot convert to twitter status_id.");
     }
 }

--- a/OpenTween/TimelineListViewDrawer.cs
+++ b/OpenTween/TimelineListViewDrawer.cs
@@ -33,6 +33,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using OpenTween.Models;
 using OpenTween.OpenTweenCustomControl;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {
@@ -165,7 +166,7 @@ namespace OpenTween
             if (MyCommon.IsNullOrEmpty(normalImageUrl))
                 return;
 
-            var sizeName = Twitter.DecideProfileImageSize(scaledIconSize.Width);
+            var sizeName = TwitterLegacy.DecideProfileImageSize(scaledIconSize.Width);
             var cachedImage = this.iconCache.TryGetLargerOrSameSizeFromCache(normalImageUrl, sizeName);
 
             if (cachedImage != null)
@@ -209,7 +210,7 @@ namespace OpenTween
         {
             try
             {
-                var imageUrl = Twitter.CreateProfileImageUrl(normalImageUrl, sizeName);
+                var imageUrl = TwitterLegacy.CreateProfileImageUrl(normalImageUrl, sizeName);
                 await this.iconCache.DownloadImageAsync(imageUrl);
 
                 return true;

--- a/OpenTween/TimelineListViewState.cs
+++ b/OpenTween/TimelineListViewState.cs
@@ -27,7 +27,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;

--- a/OpenTween/Tween.cs
+++ b/OpenTween/Tween.cs
@@ -3322,7 +3322,7 @@ namespace OpenTween
                 // 参照: https://support.twitter.com/articles/14020
 
                 if (Regex.IsMatch(statusText, @"^[+\-\[\]\s\\.,*/(){}^~|='&%$#""<>?]*(d|dm|m)([+\-\[\]\s\\.,*/(){}^~|='&%$#""<>?]+|$)", RegexOptions.IgnoreCase)
-                    && !Twitter.DMSendTextRegex.IsMatch(statusText))
+                    && !TwitterLegacy.DMSendTextRegex.IsMatch(statusText))
                 {
                     // U+200B (ZERO WIDTH SPACE) を先頭に加えて回避
                     statusText = '\u200b' + statusText;
@@ -5536,7 +5536,7 @@ namespace OpenTween
             if (ret != DialogResult.OK)
                 return;
 
-            var match = Twitter.StatusUrlRegex.Match(inputText);
+            var match = TwitterLegacy.StatusUrlRegex.Match(inputText);
             if (!match.Success)
             {
                 ShowFormatErrorDialog(this);
@@ -6850,7 +6850,7 @@ namespace OpenTween
         {
             MatchCollection m;
             // ハッシュタグの保存
-            m = Regex.Matches(statusText, Twitter.Hashtag, RegexOptions.IgnoreCase);
+            m = Regex.Matches(statusText, TwitterLegacy.Hashtag, RegexOptions.IgnoreCase);
             var hstr = "";
             foreach (Match hm in m)
             {
@@ -9220,7 +9220,7 @@ namespace OpenTween
         }
 
         private async void TwitterApiStatusToolStripMenuItem_Click(object sender, EventArgs e)
-            => await MyCommon.OpenInBrowserAsync(this, Twitter.ServiceAvailabilityStatusUrl);
+            => await MyCommon.OpenInBrowserAsync(this, TwitterLegacy.ServiceAvailabilityStatusUrl);
 
         private void PostButton_KeyDown(object sender, KeyEventArgs e)
         {

--- a/OpenTween/TweetDetailsView.cs
+++ b/OpenTween/TweetDetailsView.cs
@@ -278,7 +278,7 @@ namespace OpenTween
 
             this.ClearUserPicture();
 
-            var imageSize = Twitter.DecideProfileImageSize(this.UserPicture.Width);
+            var imageSize = TwitterLegacy.DecideProfileImageSize(this.UserPicture.Width);
             if (!force)
             {
                 var cachedImage = this.IconCache.TryGetLargerOrSameSizeFromCache(normalImageUrl, imageSize);
@@ -298,7 +298,7 @@ namespace OpenTween
             await this.UserPicture.SetImageFromTask(
                 async () =>
                 {
-                    var imageUrl = Twitter.CreateProfileImageUrl(normalImageUrl, imageSize);
+                    var imageUrl = TwitterLegacy.CreateProfileImageUrl(normalImageUrl, imageSize);
                     var image = await this.IconCache.DownloadImageAsync(imageUrl, force)
                         .ConfigureAwait(false);
 
@@ -470,7 +470,7 @@ namespace OpenTween
 
         private string? GetUserId()
         {
-            var m = Twitter.StatusUrlRegex.Match(this.postBrowserStatusText);
+            var m = TwitterLegacy.StatusUrlRegex.Match(this.postBrowserStatusText);
             if (m.Success && this.Owner.IsTwitterId(m.Result("${ScreenName}")))
                 return m.Result("${ScreenName}");
             else
@@ -751,7 +751,7 @@ namespace OpenTween
             if (MyCommon.IsNullOrEmpty(imageNormalUrl))
                 return;
 
-            var imageOriginalUrl = Twitter.CreateProfileImageUrl(imageNormalUrl, "original");
+            var imageOriginalUrl = TwitterLegacy.CreateProfileImageUrl(imageNormalUrl, "original");
             await MyCommon.OpenInBrowserAsync(this, imageOriginalUrl);
         }
 

--- a/OpenTween/TweetExtractor.cs
+++ b/OpenTween/TweetExtractor.cs
@@ -29,6 +29,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using OpenTween.Api.DataModel;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {
@@ -47,7 +48,7 @@ namespace OpenTween
         /// </summary>
         public static IEnumerable<TwitterEntityUrl> ExtractUrlEntities(string text)
         {
-            var urlMatches = Regex.Matches(text, Twitter.RgUrl, RegexOptions.IgnoreCase).Cast<Match>();
+            var urlMatches = Regex.Matches(text, TwitterLegacy.RgUrl, RegexOptions.IgnoreCase).Cast<Match>();
             foreach (var m in urlMatches)
             {
                 var before = m.Groups["before"].Value;
@@ -59,15 +60,15 @@ namespace OpenTween
                 var validUrl = false;
                 if (protocol.Length == 0)
                 {
-                    if (Regex.IsMatch(before, Twitter.UrlInvalidWithoutProtocolPrecedingChars))
+                    if (Regex.IsMatch(before, TwitterLegacy.UrlInvalidWithoutProtocolPrecedingChars))
                         continue;
 
                     var last_url_invalid_match = false;
-                    var domainMatches = Regex.Matches(domain, Twitter.UrlValidAsciiDomain, RegexOptions.IgnoreCase).Cast<Match>();
+                    var domainMatches = Regex.Matches(domain, TwitterLegacy.UrlValidAsciiDomain, RegexOptions.IgnoreCase).Cast<Match>();
                     foreach (var mm in domainMatches)
                     {
                         var lasturl = mm.Value;
-                        last_url_invalid_match = Regex.IsMatch(lasturl, Twitter.UrlInvalidShortDomain, RegexOptions.IgnoreCase);
+                        last_url_invalid_match = Regex.IsMatch(lasturl, TwitterLegacy.UrlInvalidShortDomain, RegexOptions.IgnoreCase);
                         if (!last_url_invalid_match)
                         {
                             validUrl = true;
@@ -140,7 +141,7 @@ namespace OpenTween
         /// </summary>
         public static IEnumerable<TwitterEntityHashtag> ExtractHashtagEntities(string text)
         {
-            var matches = Regex.Matches(text, Twitter.Hashtag);
+            var matches = Regex.Matches(text, TwitterLegacy.Hashtag);
             foreach (var match in matches.Cast<Match>())
             {
                 var groupHashtagSharp = match.Groups[2];

--- a/OpenTween/UserInfo.cs
+++ b/OpenTween/UserInfo.cs
@@ -30,6 +30,7 @@ using System;
 using System.Net;
 using OpenTween.Api.DataModel;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {

--- a/OpenTween/UserInfoDialog.cs
+++ b/OpenTween/UserInfoDialog.cs
@@ -48,10 +48,10 @@ namespace OpenTween
         private CancellationTokenSource? cancellationTokenSource = null;
 
         private readonly TweenMain mainForm;
-        private readonly Twitter twitter;
+        private readonly TwitterLegacy twitter;
         private readonly DetailsHtmlBuilder detailsHtmlBuilder;
 
-        public UserInfoDialog(TweenMain mainForm, Twitter twitter, DetailsHtmlBuilder detailsHtmlBuilder)
+        public UserInfoDialog(TweenMain mainForm, TwitterLegacy twitter, DetailsHtmlBuilder detailsHtmlBuilder)
         {
             this.mainForm = mainForm;
             this.twitter = twitter;
@@ -207,8 +207,8 @@ namespace OpenTween
 
             await this.UserPicture.SetImageFromTask(async () =>
             {
-                var sizeName = Twitter.DecideProfileImageSize(this.UserPicture.Width);
-                var uri = Twitter.CreateProfileImageUrl(imageUri, sizeName);
+                var sizeName = TwitterLegacy.DecideProfileImageSize(this.UserPicture.Width);
+                var uri = TwitterLegacy.CreateProfileImageUrl(imageUri, sizeName);
 
                 using var imageStream = await Networking.Http.GetStreamAsync(uri)
                     .ConfigureAwait(false);
@@ -468,7 +468,7 @@ namespace OpenTween
         private async void UserPicture_Click(object sender, EventArgs e)
         {
             var imageUrl = this.displayUser.ProfileImageUrlHttps;
-            imageUrl = Twitter.CreateProfileImageUrl(imageUrl, "original");
+            imageUrl = TwitterLegacy.CreateProfileImageUrl(imageUrl, "original");
 
             await MyCommon.OpenInBrowserAsync(this, imageUrl);
         }

--- a/OpenTween/UserInfoDialog.cs
+++ b/OpenTween/UserInfoDialog.cs
@@ -27,24 +27,18 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using System.Windows.Forms;
-using OpenTween.Api;
 using OpenTween.Api.DataModel;
 using OpenTween.Connection;
 using OpenTween.Models;
+using OpenTween.SocialProtocol.Twitter;
 
 namespace OpenTween
 {


### PR DESCRIPTION
- TwitterDirectMessageId
    - 旧: `OpenTween.Models.TwitterDirectMessageId`
    - 新: `OpenTween.SocialProtocol.Twitter.TwitterDirectMessageId`
- TwitterStatusId
    - 旧: `OpenTween.Models.TwitterStatusId`
    - 新: `OpenTween.SocialProtocol.Twitter.TwitterStatusId`
- TwitterPostFactory
    - 旧: `OpenTween.Models.TwitterPostFactory`
    - 新: `OpenTween.SocialProtocol.Twitter.TwitterPostFactory`
- TwitterUserId
    - 旧: `OpenTween.Models.TwitterUserId`
    - 新: `OpenTween.SocialProtocol.Twitter.TwitterUserId`
- Twitter
    - 旧: `OpenTween.Twitter`
    - 新: `OpenTween.SocialProtocol.Twitter.TwitterLegacy`
